### PR TITLE
[FLIN-3127] Adds seat selection components

### DIFF
--- a/src/components/Amenity.tsx
+++ b/src/components/Amenity.tsx
@@ -1,0 +1,31 @@
+import classNames from "classnames";
+import * as React from "react";
+import { SeatMapCabinRowSectionElementAmenity } from "src/types/SeatMap";
+import { useViewportWidth } from "@lib/useViewPortWidth";
+import { Icon, IconName } from "./Icon";
+import { isMobileOrTablet } from "@lib/isMobileOrTablet";
+
+const amenitiesWithoutWrapper = ["bassinet", "exit_row"];
+export interface AmenityProps {
+  /**
+   * The type of the amenity
+   */
+  type: SeatMapCabinRowSectionElementAmenity;
+}
+
+/**
+ * An amenity on the seat map.
+ */
+export const Amenity: React.FC<AmenityProps> = ({ type }) => {
+  const width = useViewportWidth();
+  return (
+    <div
+      className={classNames("map-element map-element--amenity", {
+        "map-element--wrapped": !amenitiesWithoutWrapper.includes(type),
+      })}
+      aria-label={type.toString()}
+    >
+      <Icon name={type as IconName} size={isMobileOrTablet(width) ? 16 : 24} />
+    </div>
+  );
+};

--- a/src/components/DeckSelect.tsx
+++ b/src/components/DeckSelect.tsx
@@ -1,0 +1,27 @@
+import { Tabs } from "@components/Tabs";
+import * as React from "react";
+
+export interface DeckSelectProps {
+  /**
+   * The currently selected deck number
+   */
+  value: number;
+  /**
+   * What to do when the user selects a deck
+   */
+  setValue: (value: number) => void;
+}
+
+/**
+ * The deck selection component for the seat map.
+ */
+export const DeckSelect: React.FC<DeckSelectProps> = ({ value, setValue }) => {
+  const options = ["Lower deck", "Upper deck"];
+  return (
+    <Tabs
+      options={options}
+      value={options[value]}
+      onChange={(item) => setValue(options.indexOf(item))}
+    />
+  );
+};

--- a/src/components/DuffelCheckout.tsx
+++ b/src/components/DuffelCheckout.tsx
@@ -2,7 +2,7 @@ import { compileCreateOrderPayload } from "@lib/compileCreateOrderPayload";
 import { isMockOfferId } from "@lib/isMockOfferId";
 import { isPayloadComplete } from "@lib/isPayloadComplete";
 import { retrieveOffer } from "@lib/retrieveOffer";
-import { retrieveSeatMap } from "@lib/retrieveSeatMap";
+import { retrieveSeatMaps } from "@lib/retrieveSeatMaps";
 import * as React from "react";
 import { Offer } from "src//types/Offer";
 import {
@@ -92,7 +92,7 @@ export const DuffelCheckout: React.FC<DuffelCheckoutProps> = ({
     }
   };
 
-  const [seatMap, setSeatMap] = React.useState<SeatMap>();
+  const [seatMaps, setSeatMaps] = React.useState<SeatMap[]>();
   const [isSeatMapLoading, setIsSeatMapLoading] = React.useState(true);
 
   const [passengers, setPassengers] =
@@ -118,10 +118,10 @@ export const DuffelCheckout: React.FC<DuffelCheckoutProps> = ({
       setIsOfferLoading
     );
 
-    retrieveSeatMap(
+    retrieveSeatMaps(
       offer_id,
       client_key,
-      setSeatMap,
+      setSeatMaps,
       setError,
       setIsSeatMapLoading
     );
@@ -174,7 +174,7 @@ export const DuffelCheckout: React.FC<DuffelCheckoutProps> = ({
                 baggageSelectedServices,
                 offer,
                 error,
-                seatMap,
+                seatMaps,
               }}
             />
           )}
@@ -194,6 +194,7 @@ export const DuffelCheckout: React.FC<DuffelCheckoutProps> = ({
           {!error && selectedFeatures.has("seats") && (
             <SeatSelectionCard
               isLoading={isOfferLoading || isSeatMapLoading}
+              seatMaps={seatMaps}
               offer={offer}
               passengers={passengers}
               selectedServices={seatSelectedServices}

--- a/src/components/Inspect.tsx
+++ b/src/components/Inspect.tsx
@@ -10,7 +10,7 @@ export const Inspect: React.FC<InspectProps> = ({
     baggageSelectedServices,
     offer,
     error,
-    seatMap,
+    seatMaps,
   },
 }) => (
   <pre
@@ -34,8 +34,8 @@ export const Inspect: React.FC<InspectProps> = ({
       {`${offer ? "✓" : "x"} offer: ${
         JSON.stringify(offer) || (error ? "Failed" : "Loading...")
       }\n`}
-      {`${seatMap ? "✓" : "x"} seatMap: ${
-        JSON.stringify(seatMap) || (error ? "Failed" : "Loading...")
+      {`${seatMaps ? "✓" : "x"} seatMaps: ${
+        JSON.stringify(seatMaps) || (error ? "Failed" : "Loading...")
       }\n`}
       {`${
         baggageSelectedServices ? "✓" : "x"

--- a/src/components/Legend.tsx
+++ b/src/components/Legend.tsx
@@ -1,0 +1,60 @@
+import * as React from "react";
+import { Icon, IconName } from "@components/Icon";
+import { SeatMapCabinRowSectionElementAmenity } from "src/types/SeatMap";
+
+export interface LegendProps {
+  /**
+   * The set of additional symbols to display
+   */
+  symbols: Set<SeatMapCabinRowSectionElementAmenity>;
+}
+
+/**
+ * The legend for the seat map.
+ */
+export const Legend: React.FC<LegendProps> = ({ symbols }) => (
+  <div className="seat-map__legend">
+    <span className="seat-map__legend-item">
+      <span
+        className="seat-map__legend-seat seat-map__legend-seat--fee-payable"
+        aria-label="Additional cost for seat"
+      >
+        <Icon
+          name="seat_paid_indicator"
+          className="seat-map__legend-seat--fee-payable-indicator"
+          size={12}
+        />
+      </span>
+      Additional Cost
+    </span>
+    <span className="seat-map__legend-item">
+      <span
+        className="seat-map__legend-seat seat-map__legend-seat--included"
+        aria-label="Included seat"
+      />
+      Included
+    </span>
+    <span className="seat-map__legend-item">
+      <span
+        className="seat-map__legend-seat seat-map__legend-seat--selected"
+        aria-label="Selected seat"
+      />
+      Selected
+    </span>
+    <span className="seat-map__legend-item">
+      <span className="seat-map__legend-seat" aria-label="Unavailable seat">
+        <Icon name="close" size={14} />
+      </span>
+      Unavailable
+    </span>
+    {[...symbols].map((symbol) => (
+      <span
+        key={symbol}
+        className="seat-map__legend-item seat-map__legend-item--symbol"
+      >
+        <Icon name={symbol as IconName} size={20} />
+        {symbol.split("_")[0]}
+      </span>
+    ))}
+  </div>
+);

--- a/src/components/LoadingState.tsx
+++ b/src/components/LoadingState.tsx
@@ -1,0 +1,49 @@
+import * as React from "react";
+import { Icon } from "./Icon";
+
+const LOADING_MESSAGE = "Loading seat map";
+
+export interface LoadingStateProps {
+  origin: string;
+  destination: string;
+  duration: string;
+  done: () => void;
+}
+
+export const LoadingState: React.FC<LoadingStateProps> = ({
+  origin,
+  destination,
+  duration,
+  done,
+}) => {
+  const [loaded, setLoaded] = React.useState(false);
+  const loadingIndicator = React.useRef<HTMLElement>(null);
+
+  React.useEffect(() => {
+    if (loaded) {
+      done && done();
+    }
+  });
+
+  return !loaded ? (
+    <div className="loading-state__container">
+      <span className="loading-state__message">{LOADING_MESSAGE}</span>
+      <div className="loading-state__progress-indicator">
+        <span
+          className="loading-state__progress-indicator--status"
+          ref={loadingIndicator}
+          onAnimationEnd={() => setLoaded(true)}
+          data-testid="loading-state__progress-indicator--status"
+        />
+      </div>
+      <div className="loading-state__segment">
+        <span className="loading-state__segment--origin">{origin}</span>
+        <Icon name="arrow_forward" size={20} />
+        <span className="loading-state__segment--destination">
+          {destination}
+        </span>
+      </div>
+      <span className="loading-state__duration">{duration}</span>
+    </div>
+  ) : null;
+};

--- a/src/components/Modal.tsx
+++ b/src/components/Modal.tsx
@@ -1,10 +1,19 @@
 import * as React from "react";
 import { Button } from "./Button";
 
-export const Modal: React.FC<{
+interface ModalProps {
   children: React.ReactNode;
   onClose: () => void;
-}> = ({ children, onClose }) => {
+  modalContentStyle?: React.CSSProperties;
+  modalOverlayStyle?: React.CSSProperties;
+}
+
+export const Modal: React.FC<ModalProps> = ({
+  children,
+  onClose,
+  modalContentStyle,
+  modalOverlayStyle,
+}) => {
   React.useEffect(() => {
     document.body.style.overflow = "hidden";
     return () => {
@@ -13,8 +22,12 @@ export const Modal: React.FC<{
   }, []);
 
   return (
-    <div className="modal">
-      <div role="presentation" className="modal--content">
+    <div className="modal" style={modalOverlayStyle}>
+      <div
+        role="presentation"
+        className="modal--content"
+        style={modalContentStyle}
+      >
         {children}
         <Button
           intent="INVISIBLE"

--- a/src/components/PassengerSelect.tsx
+++ b/src/components/PassengerSelect.tsx
@@ -1,0 +1,42 @@
+import * as React from "react";
+import { PassengerSelectionSegment } from "./SelectionSegment";
+import { usePassengersContext } from "@lib/usePassengersContext";
+
+export interface Passenger {
+  id: string;
+  name?: string | null;
+}
+
+export interface PassengerSelectionProps {
+  renderPassengerSelectionDetails: (
+    passengerId: string,
+    segmentId: string
+  ) => React.ReactNode;
+}
+
+/**
+ * The passenger selection component for seat selection and additional baggage
+ */
+export const PassengerSelection: React.FC<PassengerSelectionProps> = ({
+  renderPassengerSelectionDetails,
+}) => {
+  const passengersContext = usePassengersContext();
+  if (!passengersContext) {
+    throw new Error(
+      "PassengerSelection can only be used within PassengersProvider"
+    );
+  }
+  return (
+    <div className="passenger-selection">
+      <ul className="passenger-selection__segments">
+        {passengersContext.segments.map((segment) => (
+          <PassengerSelectionSegment
+            segment={segment}
+            key={segment.id}
+            renderPassengerSelectionDetails={renderPassengerSelectionDetails}
+          />
+        ))}
+      </ul>
+    </div>
+  );
+};

--- a/src/components/PassengersLayout.tsx
+++ b/src/components/PassengersLayout.tsx
@@ -1,0 +1,102 @@
+import { isMobileOrTablet } from "@lib/isMobileOrTablet";
+import { usePassengersContext } from "@lib/usePassengersContext";
+import { useViewportWidth } from "@lib/useViewPortWidth";
+import * as React from "react";
+import { PassengerSelection } from "./PassengerSelect";
+import { Summary } from "./Summary";
+
+export interface PassengersLayoutProps {
+  renderPassengerSelectionDetails: (
+    passengerId: string,
+    segmentId: string
+  ) => React.ReactNode;
+  mobileOnlyContent?: React.ReactNode | null;
+  summaryTitle: string;
+  formattedTotalAmount: string;
+  onSubmit: () => void;
+}
+
+const getNextButtonText = (
+  width: number,
+  hasNextPassenger: boolean,
+  isLastPassengerInSegment: boolean
+) => {
+  if (!hasNextPassenger) {
+    return "Continue";
+  }
+
+  if (isMobileOrTablet(width)) {
+    return "Next";
+  }
+
+  return isLastPassengerInSegment ? "Next flight" : "Next passenger";
+};
+
+export const PassengersLayout: React.FC<
+  React.PropsWithChildren<PassengersLayoutProps>
+> = ({
+  summaryTitle,
+  formattedTotalAmount,
+  renderPassengerSelectionDetails,
+  mobileOnlyContent,
+  onSubmit,
+  children,
+}) => {
+  const width = useViewportWidth();
+  const passengersContext = usePassengersContext();
+  if (!passengersContext) {
+    throw new Error(
+      "PassengerSelection can only be used within PassengersProvider"
+    );
+  }
+
+  const {
+    dispatch,
+    hasPreviousPassenger,
+    hasNextPassenger,
+    isLastPassengerInSegment,
+  } = passengersContext;
+
+  return (
+    <div className="duffel-components">
+      <section className="layout">
+        <div className="layout__container">
+          {!isMobileOrTablet(width) && (
+            <aside className="layout__aside">
+              <PassengerSelection
+                renderPassengerSelectionDetails={
+                  renderPassengerSelectionDetails
+                }
+              />
+            </aside>
+          )}
+          <div className="layout__main-content">{children}</div>
+        </div>
+        {mobileOnlyContent && isMobileOrTablet(width)
+          ? mobileOnlyContent
+          : null}
+        <div className="layout__confirmation">
+          <Summary
+            title={summaryTitle}
+            formattedAmount={formattedTotalAmount}
+            onClick={() => {
+              if (!hasNextPassenger) {
+                onSubmit();
+                return;
+              }
+              dispatch({ type: "selectNextPassenger" });
+            }}
+            onBackClick={() => dispatch({ type: "selectPreviousPassenger" })}
+            disableBackButton={hasPreviousPassenger}
+            iconAfter={hasNextPassenger ? "arrow_right" : undefined}
+            primaryButtonCopy={getNextButtonText(
+              width,
+              hasNextPassenger,
+              isLastPassengerInSegment
+            )}
+          />
+        </div>
+      </section>
+    </div>
+  );
+};

--- a/src/components/Row.tsx
+++ b/src/components/Row.tsx
@@ -1,0 +1,96 @@
+import classNames from "classnames";
+import * as React from "react";
+import { Amenity } from "./Amenity";
+import { Seat } from "./Seat";
+import {
+  SeatMapCabinRow,
+  SeatMapCabinRowSectionElement,
+} from "src/types/SeatMap";
+import { Icon } from "./Icon";
+import { getRowNumber } from "@lib/get-row-number";
+export interface RowProps {
+  /**
+   * The row contents.
+   */
+  row: SeatMapCabinRow;
+  /**
+   * Does the row sit above wings?
+   */
+  hasWings: boolean;
+}
+
+const elementComponentMap = (
+  element: SeatMapCabinRowSectionElement,
+  elementIndex: number,
+  sectionIndex: number
+) => (
+  <>
+    {element.type === "seat" ? (
+      <Seat key={elementIndex} seat={element} />
+    ) : element.type === "empty" ? (
+      <div key={elementIndex} className="map-element map-element--empty" />
+    ) : element.type === "exit_row" ? (
+      <div
+        key={elementIndex}
+        className={classNames("map-element map-element--exit", {
+          "map-element--exit--right": sectionIndex > 0,
+        })}
+      >
+        {sectionIndex === 0 ? (
+          <Icon name="exit_row" />
+        ) : (
+          <Icon name="exit_row_right" />
+        )}
+      </div>
+    ) : (
+      <Amenity key={elementIndex} type={element.type} />
+    )}
+  </>
+);
+
+/**
+ * The row component for the seat map.
+ */
+export const Row: React.FC<RowProps> = ({ row, hasWings }) => {
+  const rowNumber = getRowNumber(row);
+  const rowSections = row.sections;
+
+  return (
+    <>
+      {Object.values(rowSections).map((section, sectionIndex) => {
+        const rowLength = Object.keys(row.sections).length;
+        const isOneSectionRow = rowLength === 1;
+
+        return (
+          <React.Fragment key={sectionIndex}>
+            <div
+              className={classNames("map-section", {
+                "map-section--left": sectionIndex === 0,
+                "map-section--right": !isOneSectionRow
+                  ? sectionIndex === rowLength - 1
+                  : false,
+                "map-section--wing": hasWings,
+              })}
+              data-testid={`row-section-${sectionIndex}`}
+            >
+              {section.elements.length > 0
+                ? section.elements.map((element, elementIndex) => (
+                    <React.Fragment key={elementIndex}>
+                      {elementComponentMap(element, elementIndex, sectionIndex)}
+                    </React.Fragment>
+                  ))
+                : elementComponentMap({ type: "empty" }, -1, sectionIndex)}
+            </div>
+            {(sectionIndex < rowLength - 1 ||
+              (isOneSectionRow && sectionIndex < rowLength)) && (
+              <span className="map-section__aisle">{rowNumber}</span>
+            )}
+            {isOneSectionRow &&
+              sectionIndex === row.sections.length - 1 &&
+              elementComponentMap({ type: "empty" }, -1, sectionIndex)}
+          </React.Fragment>
+        );
+      })}
+    </>
+  );
+};

--- a/src/components/Seat.tsx
+++ b/src/components/Seat.tsx
@@ -1,0 +1,189 @@
+import classNames from "classnames";
+import * as React from "react";
+import { SeatInfo } from "./SeatInfo";
+import { SeatMapCabinRowSectionElementSeat } from "src/types/SeatMap";
+import {
+  ExtendedSeatInfo,
+  SeatSelectionPassenger,
+  useSeatSelectionContext,
+} from "@lib/useSeatSelectionContext";
+import { useViewportWidth } from "@lib/useViewPortWidth";
+import { usePassengersContext } from "@lib/usePassengersContext";
+import { getServiceInformation } from "@lib/get-service-information";
+import { moneyStringFormatter } from "@lib/formatConvertedCurrency";
+import { isMobileOrTablet } from "@lib/isMobileOrTablet";
+import { Icon } from "./Icon";
+
+export interface SeatProps {
+  /**
+   * The seat information.
+   */
+  seat: SeatMapCabinRowSectionElementSeat;
+}
+
+const getPassengerInitials = (
+  passengers: SeatSelectionPassenger[],
+  selectedBy: string | undefined
+) => {
+  if (!selectedBy) return false;
+  let passengerInitials = "";
+  passengers.forEach((passenger, index) => {
+    if (passenger.name) {
+      const rgx = new RegExp(/(\p{L}{1})\p{L}+/, "gu");
+
+      const initials = [...passenger.name.matchAll(rgx)] || [];
+
+      if (passenger.id === selectedBy) {
+        return (passengerInitials = (
+          (initials.shift()?.[1] || "") + (initials.pop()?.[1] || "")
+        ).toUpperCase());
+      }
+    }
+    if (passenger.id === selectedBy)
+      return (passengerInitials = `P${index + 1}`);
+  });
+  return passengerInitials;
+};
+
+/**
+ * A seat on the seat map.
+ */
+export const Seat: React.FC<SeatProps> = ({ seat }) => {
+  const width = useViewportWidth();
+  const [isPopoverOpen, setIsPopoverOpen] = React.useState(false);
+
+  const passengerContext = usePassengersContext();
+  const {
+    seatSelection,
+    currentSeat,
+    setCurrentSeat,
+    onSelectSeat,
+    extendedSeatInfo,
+    setExtendedSeatInfo,
+  } = useSeatSelectionContext();
+
+  if (!passengerContext) {
+    throw new Error("Seat has to be used under PassengersProvider");
+  }
+
+  const { passengers, selectedPassenger, selectedSegment } = passengerContext;
+  const { service, isAvailable, selectedBy } = getServiceInformation(
+    seat,
+    selectedPassenger.id,
+    seatSelection[selectedSegment.id]
+  );
+  const passenger = getPassengerInitials(passengers, selectedBy);
+  const price = `${
+    service &&
+    moneyStringFormatter(service.total_currency)(+service.total_amount)
+  }`;
+  const isFeePayable =
+    service?.total_amount && parseInt(service?.total_amount) !== 0;
+  const selectedByOther = selectedBy && selectedBy !== selectedPassenger.id;
+
+  const updateExtendedSeatInfo = (seat: ExtendedSeatInfo) => {
+    if (seat !== null) {
+      const {
+        segment,
+        seat: { designator },
+      } = seat;
+
+      const seatInfo = extendedSeatInfo
+        .map((previousSeats) => previousSeats)
+        .find(
+          (previousSeat) =>
+            previousSeat.segment === segment &&
+            previousSeat.seat.designator === designator
+        );
+
+      if (!seatInfo) {
+        service &&
+          setExtendedSeatInfo([...extendedSeatInfo, { ...seat, service }]);
+      } else {
+        setExtendedSeatInfo(
+          extendedSeatInfo.splice(
+            extendedSeatInfo.findIndex(
+              (previousSeat) =>
+                previousSeat.segment !== segment &&
+                previousSeat.seat.designator !== designator
+            )
+          )
+        );
+      }
+    }
+  };
+  return (
+    <>
+      {selectedBy || isAvailable ? (
+        <button
+          id={seat.designator}
+          type="button"
+          className={classNames("map-element", "map-element__seat", {
+            "map-element--available": isAvailable && !selectedBy,
+            "map-element--selected": selectedBy,
+            "map-element--actionable":
+              isAvailable || selectedBy == selectedPassenger.id,
+          })}
+          onClick={(e) => {
+            service &&
+              updateExtendedSeatInfo({
+                segment: selectedSegment.id,
+                seat,
+                service,
+              });
+
+            if (isMobileOrTablet(width) && !selectedByOther) {
+              // We need all the ? here since we actually get `seat=false` as prop somehow and we haven't got time to look into that yet.
+              // Also we ultimately should use `seat.id` to compare but we don't have the capacity to update the types + mocks
+              // to be up-to-date yet, so we will need to use the designator for now.
+              currentSeat?.seat?.designator === seat?.designator
+                ? setCurrentSeat({ seat: null, service: undefined })
+                : setCurrentSeat({ seat, service });
+            }
+
+            if (service && !selectedByOther) {
+              onSelectSeat(
+                selectedBy === selectedPassenger.id
+                  ? null
+                  : { designator: seat.designator, service }
+              );
+              const target = e.target as any;
+              target.blur();
+            }
+          }}
+          onMouseEnter={() =>
+            !isMobileOrTablet(width) && setIsPopoverOpen(true)
+          }
+          onMouseLeave={() =>
+            !isMobileOrTablet(width) && setIsPopoverOpen(false)
+          }
+          aria-label={`${seat.designator} ${seat.name || "Seat"} ${price}`}
+        >
+          {isFeePayable && (
+            <Icon
+              name="seat_paid_indicator"
+              className="map-element--fee-payable"
+              size={isMobileOrTablet(width) ? 16 : 24}
+            />
+          )}
+          {selectedBy
+            ? passenger
+            : seat.designator.charAt(seat.designator.length - 1)}
+          {isPopoverOpen &&
+            !selectedByOther &&
+            service &&
+            !isMobileOrTablet(width) && (
+              <SeatInfo seat={seat} service={service} />
+            )}
+        </button>
+      ) : (
+        <span
+          className="map-element map-element__seat"
+          aria-label={`${seat.designator} ${seat.name || "Seat"} Unavailable`}
+        >
+          <Icon name="close" size={isMobileOrTablet(width) ? 14 : 16} />
+        </span>
+      )}
+    </>
+  );
+};

--- a/src/components/SeatInfo.tsx
+++ b/src/components/SeatInfo.tsx
@@ -1,0 +1,41 @@
+import * as React from "react";
+import {
+  SeatMapCabinRowSectionAvailableService,
+  SeatMapCabinRowSectionElementSeat,
+} from "src/types/SeatMap";
+import { moneyStringFormatter } from "@lib/formatConvertedCurrency";
+
+export interface SeatInfoProps {
+  /**
+   * The seat information.
+   */
+  seat: SeatMapCabinRowSectionElementSeat | null;
+  /**
+   * The service information.
+   */
+  service: SeatMapCabinRowSectionAvailableService | undefined;
+}
+
+/**
+ * Contents of the seat info panel with seat information
+ */
+export const SeatInfo: React.FC<SeatInfoProps> = ({ seat, service }) => {
+  const price = service
+    ? moneyStringFormatter(service.total_currency)(+service.total_amount)
+    : "";
+
+  return (
+    <div className="seat-info">
+      <div className="seat-info__details">
+        <strong>{seat?.designator}</strong>
+        <span>{seat?.name || "Seat"} </span>
+        <strong>{price}</strong>
+      </div>
+      {seat?.disclosures.map((disclosure, index) => (
+        <div key={index} className="seat-info__disclosure">
+          {disclosure}
+        </div>
+      ))}
+    </div>
+  );
+};

--- a/src/components/SeatMap.tsx
+++ b/src/components/SeatMap.tsx
@@ -1,0 +1,92 @@
+import classNames from "classnames";
+import * as React from "react";
+import { DeckSelect } from "./DeckSelect";
+import { Legend } from "./Legend";
+import { Row } from "./Row";
+import { getCabins } from "@lib/getCabins";
+import { getSymbols } from "@lib/getSymbols";
+import { NonIdealState } from "@components/NonIdealState";
+import { usePassengersContext } from "@lib/usePassengersContext";
+import { useSeatSelectionContext } from "@lib/useSeatSelectionContext";
+
+/**
+ * The seat map component.
+ */
+export const SeatMap: React.FC = () => {
+  const { seatMaps } = useSeatSelectionContext();
+  const passengerContext = usePassengersContext();
+  const [selectedDeck, setSelectedDeck] = React.useState(0);
+
+  if (!passengerContext) {
+    throw new Error("SeatMap must be used under PassengersProvider");
+  }
+
+  const { cabins, hasMultipleDecks, anyHasWings } = getCabins(
+    selectedDeck,
+    passengerContext.selectedSegment.id,
+    seatMaps
+  );
+  if (!cabins || !cabins.length) {
+    return (
+      <NonIdealState>
+        <p style={{ marginBlock: "0" }} className="p1--semibold">
+          Seat selection unavailable
+        </p>
+        <p
+          className="p1--regular"
+          style={{
+            color: "var(--GREY-600)",
+            marginBlock: "12px",
+            textAlign: "center",
+          }}
+        >
+          Unfortunately seat selection is not available for this flight. A seat
+          will be allocated by the airline.
+        </p>
+      </NonIdealState>
+    );
+  }
+
+  const symbols = getSymbols(cabins);
+
+  return (
+    <div
+      data-testid="seat-map"
+      className={classNames("seat-map", {
+        "seat-map--wings": anyHasWings,
+      })}
+    >
+      {hasMultipleDecks && (
+        <DeckSelect
+          value={selectedDeck}
+          setValue={(value) => {
+            setSelectedDeck(value);
+          }}
+        />
+      )}
+      <div className="seat-map__legend-container">
+        <Legend symbols={symbols} />
+      </div>
+      {cabins.map((cabin, idx) => (
+        <div
+          key={`cabin-${idx}`}
+          className="seat-map__map-container"
+          style={{ "--CABIN-AISLES": cabin.aisles } as React.CSSProperties}
+        >
+          {cabin.rows.map((row, rowIndex) => (
+            <Row
+              key={rowIndex}
+              row={row}
+              hasWings={
+                cabin.wings
+                  ? cabin.wings.first_row_index <= rowIndex &&
+                    cabin.wings.last_row_index >= rowIndex
+                  : false
+              }
+            />
+          ))}
+        </div>
+      ))}
+    </div>
+  );
+};

--- a/src/components/SeatSelect.tsx
+++ b/src/components/SeatSelect.tsx
@@ -1,0 +1,298 @@
+import { ErrorBoundary } from "@components/ErrorBoundary";
+import { PassengersLayout } from "@components/PassengersLayout";
+import { convertDurationToString } from "@lib/convert-duration-to-string";
+import { moneyStringFormatter } from "@lib/formatConvertedCurrency";
+import { getSeatServices } from "@lib/getSeatServices";
+import { isElementVisible } from "@lib/isElementVisible";
+import {
+  PassengersProvider,
+  usePassengersContext,
+} from "@lib/usePassengersContext";
+import {
+  CurrentSeat,
+  ExtendedSeatInfo,
+  SeatSelectionContext,
+  SeatSelectionContextInterface,
+  Size,
+} from "@lib/useSeatSelectionContext";
+import * as React from "react";
+import {
+  CreateOrderPayload,
+  CreateOrderPayloadServices,
+} from "src/types/CreateOrderPayload";
+import { Offer } from "src/types/Offer";
+import {
+  SeatMap,
+  SeatMapCabinRowSectionAvailableService,
+} from "src/types/SeatMap";
+import { LoadingState } from "./LoadingState";
+import { SeatInfo } from "./SeatInfo";
+import { SeatMap as SeatMapComponent } from "./SeatMap";
+
+export interface SeatSelectionProps {
+  offer: Offer;
+  seatMaps: SeatMap[];
+  passengers: CreateOrderPayload["passengers"];
+  selectedServices: CreateOrderPayloadServices;
+  onClose: (selectedServices: CreateOrderPayloadServices) => void;
+}
+
+export const SeatSelection: React.FC<SeatSelectionProps> = (props) => (
+  <ErrorBoundary>
+    <PassengersProvider
+      passengers={props.passengers}
+      segments={props.offer.slices
+        .map((slice) => slice.segments)
+        .flat()
+        .filter((segment) => {
+          const segmentIds = props.seatMaps.map(
+            (seatMap) => seatMap.segment_id
+          );
+          return segmentIds.includes(segment.id);
+        })}
+    >
+      <SeatSelect {...props} />
+    </PassengersProvider>
+  </ErrorBoundary>
+);
+
+const SeatSelect: React.FC<Omit<SeatSelectionProps, "passengers">> = ({
+  seatMaps,
+  offer,
+  // selectedServices,
+  onClose,
+}) => {
+  const passengersContext = usePassengersContext();
+
+  const [seatSelection, setSeatSelection] =
+    React.useState<SeatSelectionContextInterface>({});
+  const [size, setSize] = React.useState<Size>("default");
+  const [currentSeatSelected, setCurrentSeatSelected] =
+    React.useState<CurrentSeat>({ seat: null, service: undefined });
+  const [isLoading, setIsLoading] = React.useState<boolean>(true);
+  const [extendedSeatInfo, setExtendedSeatInfo] = React.useState<
+    ExtendedSeatInfo[]
+  >([]);
+
+  React.useMemo(() => {
+    if (!passengersContext?.segments) {
+      return;
+    }
+
+    if (Object.keys(seatSelection).length <= 0) {
+      const initialiseData = new Map(
+        passengersContext?.segments.map((segment) => {
+          const passengerId = new Map(
+            segment.passengers.map((passenger) => [
+              passenger.passenger_id,
+              null,
+            ])
+          );
+          return [
+            segment.id,
+            Object.fromEntries(
+              new Map(
+                [...passengerId.entries()].sort((a, b) =>
+                  a[0].localeCompare(b[0])
+                )
+              )
+            ),
+          ];
+        })
+      );
+      const data = Object.fromEntries(initialiseData);
+      if (data) {
+        setSeatSelection(data);
+      }
+    }
+  }, [passengersContext?.segments, seatSelection]);
+
+  React.useEffect(() => {
+    const handleResize = () => {
+      if (window.innerWidth < 1024 && size !== "small") {
+        setSize("small");
+      } else if (window.innerWidth >= 1024 && size !== "default") {
+        setSize("default");
+      }
+    };
+
+    window.addEventListener("resize", handleResize);
+    return () => window.removeEventListener("resize", handleResize);
+  }, [size]);
+
+  // show loading state if the segment changes
+  React.useEffect(() => {
+    setIsLoading(true);
+  }, [passengersContext?.selectedSegment]);
+
+  // whenever the selected passenger or selected segment changes, ensure that the selected
+  // seat is scrolled into view and the mobile view is shown properly
+  React.useEffect(() => {
+    if (!passengersContext) {
+      return;
+    }
+
+    const { selectedSegment, selectedPassenger } = passengersContext;
+
+    const seat =
+      seatSelection[selectedSegment.id] &&
+      seatSelection[selectedSegment.id][selectedPassenger.id];
+
+    if (seat && seat.designator !== null) {
+      const selectedSeat = document.getElementById(seat.designator);
+      if (selectedSeat && !isElementVisible(selectedSeat))
+        selectedSeat?.scrollIntoView({ behavior: "smooth", block: "center" });
+
+      const seatInfo = extendedSeatInfo.find(
+        (seatInfo) =>
+          seatInfo.segment === selectedSegment.id &&
+          seatInfo.seat.designator === seat.designator
+      );
+
+      if (seatInfo) {
+        setCurrentSeatSelected({
+          seat: seatInfo.seat,
+          service: seatInfo.service,
+        });
+      }
+    }
+  }, [passengersContext, extendedSeatInfo, seatSelection]);
+
+  if (
+    !passengersContext ||
+    !passengersContext.passengers.length ||
+    !passengersContext.segments.length
+  ) {
+    return null;
+  }
+
+  const { selectedSegment, selectedPassenger, segments } = passengersContext;
+
+  const selectSeatForSelectedPassenger = (
+    seatId: {
+      designator: string;
+      service: SeatMapCabinRowSectionAvailableService;
+    } | null
+  ) => {
+    const newSelectedSeatIds = Object.assign({}, seatSelection, {
+      [selectedSegment.id]: Object.assign(
+        {},
+        seatSelection[selectedSegment.id],
+        {
+          [selectedPassenger.id]: { ...seatId },
+        }
+      ),
+    });
+    setSeatSelection(newSelectedSeatIds);
+  };
+
+  const renderMobileSeatInfo = () => {
+    const { seat, service } = currentSeatSelected;
+    return seat !== null &&
+      seatSelection[selectedSegment.id] &&
+      seatSelection[selectedSegment.id][selectedPassenger.id] !== null ? (
+      <div className="seat-selection__mobile-seat-info">
+        <SeatInfo seat={seat} service={service} />
+      </div>
+    ) : null;
+  };
+
+  const renderLoadingState = () => {
+    const origin = selectedSegment.origin.iata_code || "";
+    const destination = selectedSegment.destination.iata_code || "";
+    const duration =
+      (selectedSegment.duration &&
+        convertDurationToString(selectedSegment.duration)) ||
+      "";
+
+    return (
+      <LoadingState
+        origin={origin}
+        destination={destination}
+        duration={duration}
+        done={() => setIsLoading(false)}
+      />
+    );
+  };
+
+  const renderPassengerSelectionDetails = (
+    passengerId: string,
+    segmentId: string
+  ) => {
+    const seat =
+      seatSelection[segmentId] && seatSelection[segmentId][passengerId];
+
+    return seat && seat.service ? (
+      <span className="passenger-selection-passenger__action">
+        <span className="passenger-selection-passenger__seat-designator">
+          {seat.designator}
+        </span>
+        <span className="passenger-selection-passenger__seat-price">
+          {moneyStringFormatter(seat.service.total_currency)(
+            +seat.service.total_amount
+          )}
+        </span>
+      </span>
+    ) : (
+      <span className="passenger-selection-passenger__action">Unselected</span>
+    );
+  };
+
+  const renderSeatMap = (isLoading: boolean): React.ReactNode =>
+    isLoading ? (
+      renderLoadingState()
+    ) : (
+      <ErrorBoundary>
+        <SeatMapComponent />
+      </ErrorBoundary>
+    );
+
+  // these values are used to render summary text
+  const services = getSeatServices(seatSelection);
+  const numberOfSeats = segments.reduce(
+    (total, segment) => total + segment.passengers.length,
+    0
+  );
+
+  const numberOfServices = services && services.length;
+  const currency = offer.total_currency;
+  const formattedAmount =
+    numberOfServices > 0
+      ? moneyStringFormatter(services[0].total_currency)(
+          services.reduce((total, service) => total + +service.total_amount, 0)
+        )
+      : offer
+      ? moneyStringFormatter(currency)(0)
+      : "0";
+
+  return (
+    <SeatSelectionContext.Provider
+      value={{
+        offer,
+        seatMaps,
+        seatSelection,
+        size,
+        onSelectSeat: selectSeatForSelectedPassenger,
+        currentSeat: currentSeatSelected,
+        setCurrentSeat: setCurrentSeatSelected,
+        setIsLoading,
+        extendedSeatInfo,
+        setExtendedSeatInfo,
+        currency,
+      }}
+    >
+      <PassengersLayout
+        renderPassengerSelectionDetails={renderPassengerSelectionDetails}
+        mobileOnlyContent={renderMobileSeatInfo()}
+        summaryTitle={`${numberOfServices} of ${numberOfSeats} seat${
+          numberOfSeats > 1 ? "s" : ""
+        } selected`}
+        formattedTotalAmount={formattedAmount}
+        // TODO: close with selected service instead
+        onSubmit={() => onClose(seatSelection as any)}
+      >
+        {renderSeatMap(isLoading)}
+      </PassengersLayout>
+    </SeatSelectionContext.Provider>
+  );
+};

--- a/src/components/SeatSelectionCard.tsx
+++ b/src/components/SeatSelectionCard.tsx
@@ -1,7 +1,6 @@
 import { moneyStringFormatter } from "@lib/formatConvertedCurrency";
 import { getTotalAmountForServices } from "@lib/getTotalAmountForServices";
 import { getTotalQuantity } from "@lib/getTotalQuantity";
-import { hasService } from "@lib/hasService";
 import { withPlural } from "@lib/withPlural";
 import React from "react";
 import {
@@ -9,6 +8,7 @@ import {
   CreateOrderPayloadServices,
 } from "src/types/CreateOrderPayload";
 import { Offer } from "src/types/Offer";
+import { SeatMap } from "src/types/SeatMap";
 import { AnimatedLoaderEllipsis } from "./AnimatedLoaderEllipsis";
 import { Card } from "./Card";
 import { SeatSelectionModal } from "./SeatSelectionModal";
@@ -17,6 +17,7 @@ import { Stamp } from "./Stamp";
 export interface SeatSelectionCardProps {
   isLoading: boolean;
   offer?: Offer;
+  seatMaps?: SeatMap[];
   passengers: CreateOrderPayload["passengers"];
   selectedServices: CreateOrderPayloadServices;
   setSelectedServices: (selectedServices: CreateOrderPayloadServices) => void;
@@ -25,13 +26,14 @@ export interface SeatSelectionCardProps {
 export const SeatSelectionCard: React.FC<SeatSelectionCardProps> = ({
   isLoading,
   offer,
+  seatMaps,
   passengers,
   selectedServices,
   setSelectedServices,
 }) => {
   const [isOpen, setIsOpen] = React.useState(false);
 
-  const containsSeatService = hasService(offer, "seats");
+  const containsSeatService = Array.isArray(seatMaps) && seatMaps.length > 0;
   const totalQuantity = getTotalQuantity(selectedServices);
   const areSeatsAdded = totalQuantity > 0;
 
@@ -73,8 +75,9 @@ export const SeatSelectionCard: React.FC<SeatSelectionCardProps> = ({
         )}
       </Card>
 
-      {isOpen && offer && (
+      {isOpen && offer && seatMaps && (
         <SeatSelectionModal
+          seatMaps={seatMaps}
           offer={offer}
           passengers={passengers}
           onClose={(newSelectedServices) => {

--- a/src/components/SeatSelectionModal.tsx
+++ b/src/components/SeatSelectionModal.tsx
@@ -1,17 +1,17 @@
-import { getPassengerMapById } from "@lib/getPassengerMapById";
-import { getSegmentList } from "@lib/getSegmentList";
-import { getServicePriceMapById } from "@lib/getServicePriceMapById";
-import React, { useState } from "react";
+import React from "react";
 import {
   CreateOrderPayload,
   CreateOrderPayloadServices,
 } from "src/types/CreateOrderPayload";
 import { Offer } from "src/types/Offer";
+import { SeatMap } from "src/types/SeatMap";
 import { Modal } from "./Modal";
+import { SeatSelection } from "./SeatSelect";
 
 export interface SeatSelectionModalProps {
   offer: Offer;
   passengers: CreateOrderPayload["passengers"];
+  seatMaps: SeatMap[];
   selectedServices: CreateOrderPayloadServices;
   onClose: (selectedServices: CreateOrderPayloadServices) => void;
 }
@@ -21,27 +21,38 @@ export const SeatSelectionModal: React.FC<SeatSelectionModalProps> = ({
   passengers,
   onClose,
   selectedServices,
+  seatMaps,
 }) => {
-  const [currentSegmentIndex] = useState(0);
+  // const [currentSegmentIndex] = useState(0);
 
-  const [selectedServicesState] = React.useState(selectedServices);
+  // const [selectedServicesState] = React.useState(selectedServices);
 
-  const segments = getSegmentList(offer);
-  const currentSegment = segments[currentSegmentIndex];
+  // const segments = getSegmentList(offer);
+  // const currentSegment = segments[currentSegmentIndex];
 
-  const passengerMapById = getPassengerMapById(passengers);
-  const servicePricesMap = getServicePriceMapById(offer.available_services);
+  // const passengerMapById = getPassengerMapById(passengers);
+  // const servicePricesMap = getServicePriceMapById(offer.available_services);
 
   return (
-    <Modal onClose={() => onClose(selectedServicesState)}>
-      <h2>modal content coming soon</h2>
-      <pre>
-        {JSON.stringify(
-          { currentSegment, passengerMapById, servicePricesMap },
-          null,
-          2
-        )}
-      </pre>
+    // TODO: should we return the partial selection in this case on close?
+    <Modal
+      onClose={() => onClose([])}
+      modalOverlayStyle={{
+        padding: 0,
+        alignItems: "flex-end",
+      }}
+      modalContentStyle={{
+        maxWidth: "100%",
+        height: "calc(100vh - 40px)",
+      }}
+    >
+      <SeatSelection
+        offer={offer}
+        passengers={passengers}
+        seatMaps={seatMaps}
+        selectedServices={selectedServices}
+        onClose={onClose}
+      />
     </Modal>
   );
 };

--- a/src/components/SelectionSegment.tsx
+++ b/src/components/SelectionSegment.tsx
@@ -1,0 +1,57 @@
+import { Segment } from "@components/Segment";
+import classNames from "classnames";
+import * as React from "react";
+import { OfferSliceSegment } from "src/types/Offer";
+import { usePassengersContext } from "@lib/usePassengersContext";
+
+export interface PassengerSelectionSegmentProps {
+  segment: OfferSliceSegment;
+  renderPassengerSelectionDetails: (
+    passengerId: string,
+    segmentId: string
+  ) => React.ReactNode;
+}
+
+export const PassengerSelectionSegment: React.FC<
+  PassengerSelectionSegmentProps
+> = ({ segment, renderPassengerSelectionDetails }) => {
+  const passengersContext = usePassengersContext();
+  if (!passengersContext) {
+    throw new Error(
+      "PassengerSelectionSegment can only be used within PassengersProvider"
+    );
+  }
+  const { passengers, dispatch, selectedSegment, selectedPassenger } =
+    passengersContext;
+
+  return (
+    <li key={segment.id} className="passenger-selection-segment">
+      {Object.keys(segment).length > 0 && <Segment segment={segment} />}
+      {passengers.map((passenger, passengerIndex) => (
+        <button
+          data-testid={`passenger-${passenger.id}`}
+          type="button"
+          key={passenger.id}
+          onClick={() =>
+            dispatch({
+              type: "selectPassenger",
+              passengerId: passenger.id,
+              segmentId: segment.id,
+            })
+          }
+          className={classNames("passenger-selection-passenger", {
+            "passenger-selection-passenger--selected":
+              selectedSegment.id === segment.id &&
+              selectedPassenger.id === passenger.id,
+          })}
+        >
+          <span className="passenger-selection-passenger__identifier">
+            {passenger.name || `Passenger ${passengerIndex + 1}`}
+          </span>
+
+          {renderPassengerSelectionDetails(passenger.id, segment.id)}
+        </button>
+      ))}
+    </li>
+  );
+};

--- a/src/components/Summary.tsx
+++ b/src/components/Summary.tsx
@@ -1,8 +1,8 @@
 import * as React from "react";
-import { usePassengersContext } from "@lib/usePassengersContext";
+import { Segment } from "@components/Segment";
 import { IconName } from "@components/Icon";
 import { Button } from "@components/Button";
-import { Segment } from "@components/Segment";
+import { usePassengersContext } from "@lib/usePassengersContext";
 
 export interface SummaryProps {
   title: string;

--- a/src/components/Tabs.tsx
+++ b/src/components/Tabs.tsx
@@ -1,0 +1,41 @@
+import classNames from "classnames";
+
+export interface TabsProps<T_Options extends string> {
+  /**
+   * The currently selected tab option
+   */
+  value: T_Options;
+
+  /**
+   * Callback for when a new tab option is selected
+   */
+  onChange: (value: T_Options) => void;
+
+  /**
+   * The options you want to render on the tabs
+   */
+  options: T_Options[];
+}
+
+export function Tabs<T extends string>({
+  value,
+  onChange,
+  options,
+}: TabsProps<T>) {
+  return (
+    <div className="seat-map__tab-select">
+      {options.map((option) => (
+        <button
+          key={option}
+          type="button"
+          className={classNames("seat-map__tab-select-option", {
+            "seat-map__tab-select-option--selected": option === value,
+          })}
+          onClick={() => value !== option && onChange(option)}
+        >
+          {option}
+        </button>
+      ))}
+    </div>
+  );
+}

--- a/src/lib/convert-duration-to-string.ts
+++ b/src/lib/convert-duration-to-string.ts
@@ -1,0 +1,18 @@
+const iso8601DurationRegex = /P(?:([.,\d]+)D)?T(?:([.,\d]+)H)?(?:([.,\d]+)M)?/i;
+
+export const convertDurationToString = (duration: string): string => {
+  const matches = duration.match(iso8601DurationRegex);
+  if (!matches) return duration;
+
+  const daysString = matches[1] && matches[1] !== "0" ? `${matches[1]}d` : "";
+  const hoursString =
+    matches[2] && matches[2] !== "0"
+      ? `${matches[2].toString().padStart(2, "0")}h`
+      : "";
+  const minutesString =
+    matches[3] && matches[3] !== "0"
+      ? `${matches[3].toString().padStart(2, "0")}m`
+      : "";
+
+  return `${daysString} ${hoursString} ${minutesString}`.trim();
+};

--- a/src/lib/fetchFromMocks.ts
+++ b/src/lib/fetchFromMocks.ts
@@ -4,5 +4,5 @@ import { SeatMap } from "src/types/SeatMap";
 export const fetchFromMockOffers = (offerId: string): Promise<Offer> =>
   import(`/mocks/offers/${offerId}.js`).then(({ offer }) => offer);
 
-export const fetchFromMockSeatMaps = (offerId: string): Promise<SeatMap> =>
-  import(`/mocks/seat-maps/${offerId}.js`).then(({ seatMap }) => seatMap);
+export const fetchFromMockSeatMaps = (offerId: string): Promise<SeatMap[]> =>
+  import(`/mocks/seat-maps/${offerId}.js`).then(({ seatMaps }) => seatMaps);

--- a/src/lib/get-row-number.ts
+++ b/src/lib/get-row-number.ts
@@ -1,0 +1,16 @@
+import {
+  SeatMapCabinRow,
+  SeatMapCabinRowSectionElementSeat,
+} from "src/types/SeatMap";
+
+export const getRowNumber = (row: SeatMapCabinRow): string | null => {
+  const seats = Object.values(row.sections)
+    .map((section) => section.elements)
+    .reduce((acc, val) => acc.concat(val), [])
+    .filter(
+      (element) => element.type === "seat"
+    ) as SeatMapCabinRowSectionElementSeat[];
+  return seats.length > 0
+    ? seats[0].designator.substring(0, seats[0].designator.length - 1)
+    : null;
+};

--- a/src/lib/get-service-information.ts
+++ b/src/lib/get-service-information.ts
@@ -1,0 +1,26 @@
+import { SeatMapCabinRowSectionElementSeat } from "src/types/SeatMap";
+import { SeatSelectionForSegment } from "./useSeatSelectionContext";
+
+export const getServiceInformation = (
+  forSeat: SeatMapCabinRowSectionElementSeat,
+  forPassengerId: string,
+  selectedServices: SeatSelectionForSegment
+) => {
+  const service = forSeat.available_services?.find(
+    (service) => service.passenger_id === forPassengerId
+  );
+
+  const alreadySelectedService = forSeat.available_services?.find(
+    (availableService) =>
+      selectedServices
+        ? selectedServices[availableService.passenger_id]?.service?.id ===
+          availableService.id
+        : false
+  );
+  const isAvailable = (service && !alreadySelectedService) || false;
+  return {
+    service,
+    isAvailable,
+    selectedBy: alreadySelectedService?.passenger_id,
+  };
+};

--- a/src/lib/getCabins.ts
+++ b/src/lib/getCabins.ts
@@ -1,0 +1,23 @@
+import { SeatMap } from "src/types/SeatMap";
+
+export const getCabins = (
+  forDeck: number,
+  forSegmentId: string,
+  segments: SeatMap[]
+) => {
+  const seatmap = segments.find(
+    (segment) => segment.segment_id === forSegmentId
+  );
+
+  if (!seatmap?.cabins || seatmap?.cabins.length === 0) return { cabins: null };
+
+  const cabinsForDeck = seatmap?.cabins.filter(
+    (cabin) => cabin.deck === forDeck
+  );
+
+  return {
+    cabins: cabinsForDeck,
+    hasMultipleDecks: cabinsForDeck.length !== seatmap.cabins.length,
+    anyHasWings: seatmap.cabins.some((cabin) => cabin.wings),
+  };
+};

--- a/src/lib/getNextItemInArray.ts
+++ b/src/lib/getNextItemInArray.ts
@@ -1,0 +1,5 @@
+export const getNextItemInArray = (items: string[], currentItem: string) => {
+  const currentIndex = items.indexOf(currentItem);
+  const nextIndex = (currentIndex + 1) % items.length;
+  return nextIndex;
+};

--- a/src/lib/getSeatServices.ts
+++ b/src/lib/getSeatServices.ts
@@ -1,0 +1,14 @@
+import { SeatMapCabinRowSectionAvailableService } from "src/types/SeatMap";
+import { SeatSelectionContextInterface } from "./useSeatSelectionContext";
+
+export const getSeatServices = (
+  forSeatSelection: SeatSelectionContextInterface
+) => {
+  const services = Object.values(forSeatSelection)
+    .map((segment) => Object.values(segment))
+    .map((seats) => seats.map((seat) => seat?.service || null))
+    .flat();
+  return services.filter(
+    (service) => service !== null
+  ) as SeatMapCabinRowSectionAvailableService[];
+};

--- a/src/lib/getSeatsPerSegment.ts
+++ b/src/lib/getSeatsPerSegment.ts
@@ -1,0 +1,36 @@
+import { OfferSliceSegment } from "src/types/Offer";
+import { SeatSelectionContextInterface } from "./useSeatSelectionContext";
+
+export type SeatPerSegmentsProps = Record<string, string[]>;
+
+export const getSeatsPerSegment = (
+  currentSelectedSegment: OfferSliceSegment,
+  seatSelection: SeatSelectionContextInterface
+): SeatPerSegmentsProps => {
+  const seatsPerSegment = Object.keys(seatSelection).reduce(
+    (memo: SeatPerSegmentsProps, segment) => {
+      const currentPassenger = currentSelectedSegment.passengers;
+      if (currentPassenger) {
+        if (currentPassenger.length > 0) {
+          const passengers: string[] = [];
+          currentPassenger.forEach((passenger) => {
+            passengers.push(passenger.passenger_id);
+          });
+          memo = {
+            ...memo,
+            [segment]: passengers.sort((a, b) => a.localeCompare(b)),
+          };
+        } else {
+          // eslint-disable-next-line @typescript-eslint/no-unused-vars
+          const { [segment]: _, ...rest } = memo;
+          return rest;
+        }
+      }
+
+      return memo;
+    },
+    {}
+  );
+
+  return seatsPerSegment;
+};

--- a/src/lib/getSymbols.ts
+++ b/src/lib/getSymbols.ts
@@ -1,0 +1,22 @@
+import {
+  SeatMapCabin,
+  SeatMapCabinRowSectionElementAmenity,
+} from "src/types/SeatMap";
+
+export const getSymbols = (
+  cabins: SeatMapCabin[]
+): Set<SeatMapCabinRowSectionElementAmenity> => {
+  const results: Set<SeatMapCabinRowSectionElementAmenity> = new Set();
+  for (const cabin of cabins) {
+    for (const row of cabin.rows) {
+      for (const section of row.sections) {
+        for (const element of section.elements) {
+          if (element.type !== "seat" && element.type !== "empty") {
+            results.add(element.type);
+          }
+        }
+      }
+    }
+  }
+  return results;
+};

--- a/src/lib/isElementVisible.ts
+++ b/src/lib/isElementVisible.ts
@@ -1,0 +1,8 @@
+export const isElementVisible = (element: HTMLElement) => {
+  const rect = element.getBoundingClientRect();
+  const viewHeight = Math.max(
+    document.documentElement.clientHeight,
+    window.innerHeight
+  );
+  return !(rect.bottom < 0 || rect.top - viewHeight >= 0);
+};

--- a/src/lib/isMobileOrTablet.ts
+++ b/src/lib/isMobileOrTablet.ts
@@ -1,0 +1,3 @@
+export const isMobileOrTablet = (viewport: number) => {
+  return viewport < 768;
+};

--- a/src/lib/mocks/saved/seat-maps/off_mock_1A_RT_LHR_JFK.js
+++ b/src/lib/mocks/saved/seat-maps/off_mock_1A_RT_LHR_JFK.js
@@ -1,3 +1,8308 @@
-export const seatMap = {
-  id: "seat_map_id_here",
-};
+export const seatMaps = [
+  {
+    slice_id: "pre_00001",
+    segment_id: "seg_00001",
+    id: "sea_0000AUXto7iMMDpNAyhpBc",
+    cabins: [
+      {
+        wings: null,
+        rows: [
+          {
+            sections: [
+              {
+                id: "sec_0000AUXto7iMMDpNAyhpBf",
+                elements: [
+                  {
+                    type: "seat",
+                    seat_characteristics: null,
+                    name: "Main Cabin Extra",
+                    id: "ele_0000AUXto7iMMDpNAyhpBg",
+                    disclosures: [],
+                    designator: "17A",
+                    available_services: [
+                      {
+                        total_currency: "GBP",
+                        total_amount: "126.66",
+                        passenger_id: "pas_0000AUXtjPGOFpXaMEJ1KZ",
+                        id: "ase_0000AUXto7bclGRKq5YRge",
+                      },
+                    ],
+                  },
+                  {
+                    type: "empty",
+                    seat_characteristics: null,
+                    name: null,
+                    id: "ele_0000AUXto7iMMDpNAyhpBh",
+                    disclosures: null,
+                    designator: null,
+                    available_services: [],
+                  },
+                  {
+                    type: "seat",
+                    seat_characteristics: null,
+                    name: "Main Cabin Extra",
+                    id: "ele_0000AUXto7iMMDpNAyhpBi",
+                    disclosures: [],
+                    designator: "17C",
+                    available_services: [
+                      {
+                        total_currency: "GBP",
+                        total_amount: "126.66",
+                        passenger_id: "pas_0000AUXtjPGOFpXaMEJ1KZ",
+                        id: "ase_0000AUXto7bclGRKq5YRgg",
+                      },
+                    ],
+                  },
+                ],
+              },
+              {
+                id: "sec_0000AUXto7iMMDpNAyhpBj",
+                elements: [
+                  {
+                    type: "seat",
+                    seat_characteristics: null,
+                    name: "Main Cabin Extra",
+                    id: "ele_0000AUXto7iiKu6xC4s6jo",
+                    disclosures: [],
+                    designator: "17D",
+                    available_services: [
+                      {
+                        total_currency: "GBP",
+                        total_amount: "126.66",
+                        passenger_id: "pas_0000AUXtjPGOFpXaMEJ1KZ",
+                        id: "ase_0000AUXto7bclGRKq5YRgi",
+                      },
+                    ],
+                  },
+                  {
+                    type: "seat",
+                    seat_characteristics: null,
+                    name: "Main Cabin Extra",
+                    id: "ele_0000AUXto7iiKu6xC4s6jp",
+                    disclosures: [],
+                    designator: "17E",
+                    available_services: [
+                      {
+                        total_currency: "GBP",
+                        total_amount: "126.66",
+                        passenger_id: "pas_0000AUXtjPGOFpXaMEJ1KZ",
+                        id: "ase_0000AUXto7bclGRKq5YRgk",
+                      },
+                    ],
+                  },
+                  {
+                    type: "seat",
+                    seat_characteristics: null,
+                    name: "Main Cabin Extra",
+                    id: "ele_0000AUXto7iiKu6xC4s6jq",
+                    disclosures: [],
+                    designator: "17G",
+                    available_services: [
+                      {
+                        total_currency: "GBP",
+                        total_amount: "126.66",
+                        passenger_id: "pas_0000AUXtjPGOFpXaMEJ1KZ",
+                        id: "ase_0000AUXto7bclGRKq5YRgm",
+                      },
+                    ],
+                  },
+                  {
+                    type: "seat",
+                    seat_characteristics: null,
+                    name: "Main Cabin Extra",
+                    id: "ele_0000AUXto7iiKu6xC4s6jr",
+                    disclosures: [],
+                    designator: "17H",
+                    available_services: [
+                      {
+                        total_currency: "GBP",
+                        total_amount: "126.66",
+                        passenger_id: "pas_0000AUXtjPGOFpXaMEJ1KZ",
+                        id: "ase_0000AUXto7bclGRKq5YRgn",
+                      },
+                    ],
+                  },
+                ],
+              },
+              {
+                id: "sec_0000AUXto7iiKu6xC4s6js",
+                elements: [
+                  {
+                    type: "seat",
+                    seat_characteristics: null,
+                    name: "Main Cabin Extra",
+                    id: "ele_0000AUXto7iiKu6xC4s6jt",
+                    disclosures: [],
+                    designator: "17J",
+                    available_services: [],
+                  },
+                  {
+                    type: "empty",
+                    seat_characteristics: null,
+                    name: null,
+                    id: "ele_0000AUXto7iiKu6xC4s6ju",
+                    disclosures: null,
+                    designator: null,
+                    available_services: [],
+                  },
+                  {
+                    type: "seat",
+                    seat_characteristics: null,
+                    name: "Main Cabin Extra",
+                    id: "ele_0000AUXto7iiKu6xC4s6jv",
+                    disclosures: [],
+                    designator: "17L",
+                    available_services: [],
+                  },
+                ],
+              },
+            ],
+            id: "row_0000AUXto7iMMDpNAyhpBe",
+          },
+          {
+            sections: [
+              {
+                id: "sec_0000AUXto7iiKu6xC4s6jz",
+                elements: [
+                  {
+                    type: "seat",
+                    seat_characteristics: null,
+                    name: "Main Cabin Extra",
+                    id: "ele_0000AUXto7iiKu6xC4s6k0",
+                    disclosures: [],
+                    designator: "18A",
+                    available_services: [
+                      {
+                        total_currency: "GBP",
+                        total_amount: "163.50",
+                        passenger_id: "pas_0000AUXtjPGOFpXaMEJ1KZ",
+                        id: "ase_0000AUXto7byjwiurBijEv",
+                      },
+                    ],
+                  },
+                  {
+                    type: "seat",
+                    seat_characteristics: null,
+                    name: "Main Cabin Extra",
+                    id: "ele_0000AUXto7iiKu6xC4s6k2",
+                    disclosures: [],
+                    designator: "18B",
+                    available_services: [
+                      {
+                        total_currency: "GBP",
+                        total_amount: "142.78",
+                        passenger_id: "pas_0000AUXtjPGOFpXaMEJ1KZ",
+                        id: "ase_0000AUXto7byjwiurBijEx",
+                      },
+                    ],
+                  },
+                  {
+                    type: "seat",
+                    seat_characteristics: null,
+                    name: "Main Cabin Extra",
+                    id: "ele_0000AUXto7iiKu6xC4s6k3",
+                    disclosures: [],
+                    designator: "18C",
+                    available_services: [
+                      {
+                        total_currency: "GBP",
+                        total_amount: "163.50",
+                        passenger_id: "pas_0000AUXtjPGOFpXaMEJ1KZ",
+                        id: "ase_0000AUXto7byjwiurBijEz",
+                      },
+                    ],
+                  },
+                ],
+              },
+              {
+                id: "sec_0000AUXto7iiKu6xC4s6k4",
+                elements: [
+                  {
+                    type: "seat",
+                    seat_characteristics: null,
+                    name: "Main Cabin Extra",
+                    id: "ele_0000AUXto7iiKu6xC4s6k5",
+                    disclosures: [],
+                    designator: "18D",
+                    available_services: [
+                      {
+                        total_currency: "GBP",
+                        total_amount: "163.50",
+                        passenger_id: "pas_0000AUXtjPGOFpXaMEJ1KZ",
+                        id: "ase_0000AUXto7byjwiurBijF0",
+                      },
+                    ],
+                  },
+                  {
+                    type: "seat",
+                    seat_characteristics: null,
+                    name: "Main Cabin Extra",
+                    id: "ele_0000AUXto7iiKu6xC4s6k6",
+                    disclosures: [],
+                    designator: "18E",
+                    available_services: [
+                      {
+                        total_currency: "GBP",
+                        total_amount: "142.78",
+                        passenger_id: "pas_0000AUXtjPGOFpXaMEJ1KZ",
+                        id: "ase_0000AUXto7byjwiurBijF1",
+                      },
+                    ],
+                  },
+                  {
+                    type: "seat",
+                    seat_characteristics: null,
+                    name: "Main Cabin Extra",
+                    id: "ele_0000AUXto7iiKu6xC4s6k7",
+                    disclosures: [],
+                    designator: "18G",
+                    available_services: [
+                      {
+                        total_currency: "GBP",
+                        total_amount: "142.78",
+                        passenger_id: "pas_0000AUXtjPGOFpXaMEJ1KZ",
+                        id: "ase_0000AUXto7byjwiurBijF2",
+                      },
+                    ],
+                  },
+                  {
+                    type: "seat",
+                    seat_characteristics: null,
+                    name: "Main Cabin Extra",
+                    id: "ele_0000AUXto7iiKu6xC4s6k8",
+                    disclosures: [],
+                    designator: "18H",
+                    available_services: [
+                      {
+                        total_currency: "GBP",
+                        total_amount: "163.50",
+                        passenger_id: "pas_0000AUXtjPGOFpXaMEJ1KZ",
+                        id: "ase_0000AUXto7byjwiurBijF3",
+                      },
+                    ],
+                  },
+                ],
+              },
+              {
+                id: "sec_0000AUXto7iiKu6xC4s6k9",
+                elements: [
+                  {
+                    type: "seat",
+                    seat_characteristics: null,
+                    name: "Main Cabin Extra",
+                    id: "ele_0000AUXto7iiKu6xC4s6kA",
+                    disclosures: [],
+                    designator: "18J",
+                    available_services: [
+                      {
+                        total_currency: "GBP",
+                        total_amount: "163.50",
+                        passenger_id: "pas_0000AUXtjPGOFpXaMEJ1KZ",
+                        id: "ase_0000AUXto7byjwiurBijF4",
+                      },
+                    ],
+                  },
+                  {
+                    type: "seat",
+                    seat_characteristics: null,
+                    name: "Main Cabin Extra",
+                    id: "ele_0000AUXto7iiKu6xC4s6kB",
+                    disclosures: [],
+                    designator: "18K",
+                    available_services: [
+                      {
+                        total_currency: "GBP",
+                        total_amount: "142.78",
+                        passenger_id: "pas_0000AUXtjPGOFpXaMEJ1KZ",
+                        id: "ase_0000AUXto7byjwiurBijF5",
+                      },
+                    ],
+                  },
+                  {
+                    type: "seat",
+                    seat_characteristics: null,
+                    name: "Main Cabin Extra",
+                    id: "ele_0000AUXto7iiKu6xC4s6kC",
+                    disclosures: [],
+                    designator: "18L",
+                    available_services: [
+                      {
+                        total_currency: "GBP",
+                        total_amount: "163.50",
+                        passenger_id: "pas_0000AUXtjPGOFpXaMEJ1KZ",
+                        id: "ase_0000AUXto7byjwiurBijF7",
+                      },
+                    ],
+                  },
+                ],
+              },
+            ],
+            id: "row_0000AUXto7iiKu6xC4s6jw",
+          },
+          {
+            sections: [
+              {
+                id: "sec_0000AUXto7iiKu6xC4s6kE",
+                elements: [
+                  {
+                    type: "seat",
+                    seat_characteristics: null,
+                    name: "Main Cabin Extra",
+                    id: "ele_0000AUXto7iiKu6xC4s6kF",
+                    disclosures: [],
+                    designator: "19A",
+                    available_services: [
+                      {
+                        total_currency: "GBP",
+                        total_amount: "163.50",
+                        passenger_id: "pas_0000AUXtjPGOFpXaMEJ1KZ",
+                        id: "ase_0000AUXto7byjwiurBijF8",
+                      },
+                    ],
+                  },
+                  {
+                    type: "seat",
+                    seat_characteristics: null,
+                    name: "Main Cabin Extra",
+                    id: "ele_0000AUXto7iiKu6xC4s6kG",
+                    disclosures: [],
+                    designator: "19B",
+                    available_services: [
+                      {
+                        total_currency: "GBP",
+                        total_amount: "142.78",
+                        passenger_id: "pas_0000AUXtjPGOFpXaMEJ1KZ",
+                        id: "ase_0000AUXto7byjwiurBijF9",
+                      },
+                    ],
+                  },
+                  {
+                    type: "seat",
+                    seat_characteristics: null,
+                    name: "Main Cabin Extra",
+                    id: "ele_0000AUXto7iiKu6xC4s6kH",
+                    disclosures: [],
+                    designator: "19C",
+                    available_services: [
+                      {
+                        total_currency: "GBP",
+                        total_amount: "163.50",
+                        passenger_id: "pas_0000AUXtjPGOFpXaMEJ1KZ",
+                        id: "ase_0000AUXto7byjwiurBijFA",
+                      },
+                    ],
+                  },
+                ],
+              },
+              {
+                id: "sec_0000AUXto7iiKu6xC4s6kI",
+                elements: [
+                  {
+                    type: "seat",
+                    seat_characteristics: null,
+                    name: "Main Cabin Extra",
+                    id: "ele_0000AUXto7iiKu6xC4s6kJ",
+                    disclosures: [],
+                    designator: "19D",
+                    available_services: [
+                      {
+                        total_currency: "GBP",
+                        total_amount: "163.50",
+                        passenger_id: "pas_0000AUXtjPGOFpXaMEJ1KZ",
+                        id: "ase_0000AUXto7byjwiurBijFB",
+                      },
+                    ],
+                  },
+                  {
+                    type: "seat",
+                    seat_characteristics: null,
+                    name: "Main Cabin Extra",
+                    id: "ele_0000AUXto7iiKu6xC4s6kK",
+                    disclosures: [],
+                    designator: "19E",
+                    available_services: [
+                      {
+                        total_currency: "GBP",
+                        total_amount: "142.78",
+                        passenger_id: "pas_0000AUXtjPGOFpXaMEJ1KZ",
+                        id: "ase_0000AUXto7byjwiurBijFC",
+                      },
+                    ],
+                  },
+                  {
+                    type: "seat",
+                    seat_characteristics: null,
+                    name: "Main Cabin Extra",
+                    id: "ele_0000AUXto7j4JaOXDB2OI4",
+                    disclosures: [],
+                    designator: "19G",
+                    available_services: [
+                      {
+                        total_currency: "GBP",
+                        total_amount: "142.78",
+                        passenger_id: "pas_0000AUXtjPGOFpXaMEJ1KZ",
+                        id: "ase_0000AUXto7byjwiurBijFD",
+                      },
+                    ],
+                  },
+                  {
+                    type: "seat",
+                    seat_characteristics: null,
+                    name: "Main Cabin Extra",
+                    id: "ele_0000AUXto7j4JaOXDB2OI5",
+                    disclosures: [],
+                    designator: "19H",
+                    available_services: [
+                      {
+                        total_currency: "GBP",
+                        total_amount: "163.50",
+                        passenger_id: "pas_0000AUXtjPGOFpXaMEJ1KZ",
+                        id: "ase_0000AUXto7byjwiurBijFE",
+                      },
+                    ],
+                  },
+                ],
+              },
+              {
+                id: "sec_0000AUXto7j4JaOXDB2OI6",
+                elements: [
+                  {
+                    type: "seat",
+                    seat_characteristics: null,
+                    name: "Main Cabin Extra",
+                    id: "ele_0000AUXto7j4JaOXDB2OI7",
+                    disclosures: [],
+                    designator: "19J",
+                    available_services: [
+                      {
+                        total_currency: "GBP",
+                        total_amount: "163.50",
+                        passenger_id: "pas_0000AUXtjPGOFpXaMEJ1KZ",
+                        id: "ase_0000AUXto7cKid0UsHt0nA",
+                      },
+                    ],
+                  },
+                  {
+                    type: "seat",
+                    seat_characteristics: null,
+                    name: "Main Cabin Extra",
+                    id: "ele_0000AUXto7j4JaOXDB2OI8",
+                    disclosures: [],
+                    designator: "19K",
+                    available_services: [
+                      {
+                        total_currency: "GBP",
+                        total_amount: "142.78",
+                        passenger_id: "pas_0000AUXtjPGOFpXaMEJ1KZ",
+                        id: "ase_0000AUXto7cKid0UsHt0nB",
+                      },
+                    ],
+                  },
+                  {
+                    type: "seat",
+                    seat_characteristics: null,
+                    name: "Main Cabin Extra",
+                    id: "ele_0000AUXto7j4JaOXDB2OI9",
+                    disclosures: [],
+                    designator: "19L",
+                    available_services: [
+                      {
+                        total_currency: "GBP",
+                        total_amount: "163.50",
+                        passenger_id: "pas_0000AUXtjPGOFpXaMEJ1KZ",
+                        id: "ase_0000AUXto7cKid0UsHt0nC",
+                      },
+                    ],
+                  },
+                ],
+              },
+            ],
+            id: "row_0000AUXto7iiKu6xC4s6kD",
+          },
+          {
+            sections: [
+              {
+                id: "sec_0000AUXto7j4JaOXDB2OIB",
+                elements: [
+                  {
+                    type: "seat",
+                    seat_characteristics: null,
+                    name: "Preferred Seats",
+                    id: "ele_0000AUXto7j4JaOXDB2OIC",
+                    disclosures: [],
+                    designator: "20A",
+                    available_services: [
+                      {
+                        total_currency: "GBP",
+                        total_amount: "92.11",
+                        passenger_id: "pas_0000AUXtjPGOFpXaMEJ1KZ",
+                        id: "ase_0000AUXto7cKid0UsHt0nD",
+                      },
+                    ],
+                  },
+                  {
+                    type: "seat",
+                    seat_characteristics: null,
+                    name: "Preferred Seats",
+                    id: "ele_0000AUXto7j4JaOXDB2OIE",
+                    disclosures: [],
+                    designator: "20B",
+                    available_services: [
+                      {
+                        total_currency: "GBP",
+                        total_amount: "84.43",
+                        passenger_id: "pas_0000AUXtjPGOFpXaMEJ1KZ",
+                        id: "ase_0000AUXto7cKid0UsHt0nE",
+                      },
+                    ],
+                  },
+                  {
+                    type: "seat",
+                    seat_characteristics: null,
+                    name: "Preferred Seats",
+                    id: "ele_0000AUXto7j4JaOXDB2OIF",
+                    disclosures: [],
+                    designator: "20C",
+                    available_services: [],
+                  },
+                ],
+              },
+              {
+                id: "sec_0000AUXto7j4JaOXDB2OIG",
+                elements: [
+                  {
+                    type: "seat",
+                    seat_characteristics: null,
+                    name: "Main Cabin Extra",
+                    id: "ele_0000AUXto7j4JaOXDB2OIH",
+                    disclosures: [],
+                    designator: "20D",
+                    available_services: [
+                      {
+                        total_currency: "GBP",
+                        total_amount: "120.90",
+                        passenger_id: "pas_0000AUXtjPGOFpXaMEJ1KZ",
+                        id: "ase_0000AUXto7cKid0UsHt0nF",
+                      },
+                    ],
+                  },
+                  {
+                    type: "seat",
+                    seat_characteristics: null,
+                    name: "Main Cabin Extra",
+                    id: "ele_0000AUXto7j4JaOXDB2OIJ",
+                    disclosures: [],
+                    designator: "20E",
+                    available_services: [
+                      {
+                        total_currency: "GBP",
+                        total_amount: "109.38",
+                        passenger_id: "pas_0000AUXtjPGOFpXaMEJ1KZ",
+                        id: "ase_0000AUXto7cKid0UsHt0nG",
+                      },
+                    ],
+                  },
+                  {
+                    type: "seat",
+                    seat_characteristics: null,
+                    name: "Main Cabin Extra",
+                    id: "ele_0000AUXto7j4JaOXDB2OIK",
+                    disclosures: [],
+                    designator: "20G",
+                    available_services: [
+                      {
+                        total_currency: "GBP",
+                        total_amount: "109.38",
+                        passenger_id: "pas_0000AUXtjPGOFpXaMEJ1KZ",
+                        id: "ase_0000AUXto7cKid0UsHt0nH",
+                      },
+                    ],
+                  },
+                  {
+                    type: "seat",
+                    seat_characteristics: null,
+                    name: "Main Cabin Extra",
+                    id: "ele_0000AUXto7j4JaOXDB2OIL",
+                    disclosures: [],
+                    designator: "20H",
+                    available_services: [
+                      {
+                        total_currency: "GBP",
+                        total_amount: "120.90",
+                        passenger_id: "pas_0000AUXtjPGOFpXaMEJ1KZ",
+                        id: "ase_0000AUXto7cKid0UsHt0nJ",
+                      },
+                    ],
+                  },
+                ],
+              },
+              {
+                id: "sec_0000AUXto7j4JaOXDB2OIM",
+                elements: [
+                  {
+                    type: "seat",
+                    seat_characteristics: null,
+                    name: "Preferred Seats",
+                    id: "ele_0000AUXto7j4JaOXDB2OIO",
+                    disclosures: [],
+                    designator: "20J",
+                    available_services: [],
+                  },
+                  {
+                    type: "seat",
+                    seat_characteristics: null,
+                    name: "Standard Seats",
+                    id: "ele_0000AUXto7j4JaOXDB2OIT",
+                    disclosures: [],
+                    designator: "20K",
+                    available_services: [
+                      {
+                        total_currency: "GBP",
+                        total_amount: "8.87",
+                        passenger_id: "pas_0000AUXtjPGOFpXaMEJ1KZ",
+                        id: "ase_0000AUXto7cKid0UsHt0nK",
+                      },
+                    ],
+                  },
+                  {
+                    type: "seat",
+                    seat_characteristics: null,
+                    name: "Preferred Seats",
+                    id: "ele_0000AUXto7j4JaOXDB2OIW",
+                    disclosures: [],
+                    designator: "20L",
+                    available_services: [
+                      {
+                        total_currency: "GBP",
+                        total_amount: "92.11",
+                        passenger_id: "pas_0000AUXtjPGOFpXaMEJ1KZ",
+                        id: "ase_0000AUXto7cKid0UsHt0nL",
+                      },
+                    ],
+                  },
+                ],
+              },
+            ],
+            id: "row_0000AUXto7j4JaOXDB2OIA",
+          },
+          {
+            sections: [
+              {
+                id: "sec_0000AUXto7j4JaOXDB2OIa",
+                elements: [
+                  {
+                    type: "seat",
+                    seat_characteristics: null,
+                    name: "Preferred Seats",
+                    id: "ele_0000AUXto7j4JaOXDB2OIb",
+                    disclosures: [],
+                    designator: "21A",
+                    available_services: [
+                      {
+                        total_currency: "GBP",
+                        total_amount: "92.11",
+                        passenger_id: "pas_0000AUXtjPGOFpXaMEJ1KZ",
+                        id: "ase_0000AUXto7cKid0UsHt0nM",
+                      },
+                    ],
+                  },
+                  {
+                    type: "seat",
+                    seat_characteristics: null,
+                    name: "Standard Seats",
+                    id: "ele_0000AUXto7j4JaOXDB2OIc",
+                    disclosures: [],
+                    designator: "21B",
+                    available_services: [
+                      {
+                        total_currency: "GBP",
+                        total_amount: "8.87",
+                        passenger_id: "pas_0000AUXtjPGOFpXaMEJ1KZ",
+                        id: "ase_0000AUXto7cKid0UsHt0nN",
+                      },
+                    ],
+                  },
+                  {
+                    type: "seat",
+                    seat_characteristics: null,
+                    name: "Preferred Seats",
+                    id: "ele_0000AUXto7j4JaOXDB2OId",
+                    disclosures: [],
+                    designator: "21C",
+                    available_services: [],
+                  },
+                ],
+              },
+              {
+                id: "sec_0000AUXto7jQIGg7EHCfqK",
+                elements: [
+                  {
+                    type: "seat",
+                    seat_characteristics: null,
+                    name: "Preferred Seats",
+                    id: "ele_0000AUXto7jQIGg7EHCfqL",
+                    disclosures: [],
+                    designator: "21D",
+                    available_services: [],
+                  },
+                  {
+                    type: "seat",
+                    seat_characteristics: null,
+                    name: "Preferred Seats",
+                    id: "ele_0000AUXto7jQIGg7EHCfqM",
+                    disclosures: [],
+                    designator: "21E",
+                    available_services: [
+                      {
+                        total_currency: "GBP",
+                        total_amount: "84.43",
+                        passenger_id: "pas_0000AUXtjPGOFpXaMEJ1KZ",
+                        id: "ase_0000AUXto7cKid0UsHt0nO",
+                      },
+                    ],
+                  },
+                  {
+                    type: "seat",
+                    seat_characteristics: null,
+                    name: "Preferred Seats",
+                    id: "ele_0000AUXto7jQIGg7EHCfqN",
+                    disclosures: [],
+                    designator: "21G",
+                    available_services: [
+                      {
+                        total_currency: "GBP",
+                        total_amount: "84.43",
+                        passenger_id: "pas_0000AUXtjPGOFpXaMEJ1KZ",
+                        id: "ase_0000AUXto7cKid0UsHt0nP",
+                      },
+                    ],
+                  },
+                  {
+                    type: "seat",
+                    seat_characteristics: null,
+                    name: "Preferred Seats",
+                    id: "ele_0000AUXto7jQIGg7EHCfqO",
+                    disclosures: [],
+                    designator: "21H",
+                    available_services: [],
+                  },
+                ],
+              },
+              {
+                id: "sec_0000AUXto7jQIGg7EHCfqP",
+                elements: [
+                  {
+                    type: "seat",
+                    seat_characteristics: null,
+                    name: "Preferred Seats",
+                    id: "ele_0000AUXto7jQIGg7EHCfqQ",
+                    disclosures: [],
+                    designator: "21J",
+                    available_services: [],
+                  },
+                  {
+                    type: "seat",
+                    seat_characteristics: null,
+                    name: "Standard Seats",
+                    id: "ele_0000AUXto7jQIGg7EHCfqR",
+                    disclosures: [],
+                    designator: "21K",
+                    available_services: [
+                      {
+                        total_currency: "GBP",
+                        total_amount: "8.87",
+                        passenger_id: "pas_0000AUXtjPGOFpXaMEJ1KZ",
+                        id: "ase_0000AUXto7cKid0UsHt0nR",
+                      },
+                    ],
+                  },
+                  {
+                    type: "seat",
+                    seat_characteristics: null,
+                    name: "Preferred Seats",
+                    id: "ele_0000AUXto7jQIGg7EHCfqS",
+                    disclosures: [],
+                    designator: "21L",
+                    available_services: [
+                      {
+                        total_currency: "GBP",
+                        total_amount: "92.11",
+                        passenger_id: "pas_0000AUXtjPGOFpXaMEJ1KZ",
+                        id: "ase_0000AUXto7cKid0UsHt0nS",
+                      },
+                    ],
+                  },
+                ],
+              },
+            ],
+            id: "row_0000AUXto7j4JaOXDB2OIZ",
+          },
+          {
+            sections: [
+              {
+                id: "sec_0000AUXto7jQIGg7EHCfqU",
+                elements: [
+                  {
+                    type: "seat",
+                    seat_characteristics: null,
+                    name: "Preferred Seats",
+                    id: "ele_0000AUXto7jQIGg7EHCfqV",
+                    disclosures: [],
+                    designator: "22A",
+                    available_services: [
+                      {
+                        total_currency: "GBP",
+                        total_amount: "92.11",
+                        passenger_id: "pas_0000AUXtjPGOFpXaMEJ1KZ",
+                        id: "ase_0000AUXto7cKid0UsHt0nT",
+                      },
+                    ],
+                  },
+                  {
+                    type: "seat",
+                    seat_characteristics: null,
+                    name: "Standard Seats",
+                    id: "ele_0000AUXto7jQIGg7EHCfqW",
+                    disclosures: [],
+                    designator: "22B",
+                    available_services: [
+                      {
+                        total_currency: "GBP",
+                        total_amount: "8.87",
+                        passenger_id: "pas_0000AUXtjPGOFpXaMEJ1KZ",
+                        id: "ase_0000AUXto7cKid0UsHt0nU",
+                      },
+                    ],
+                  },
+                  {
+                    type: "seat",
+                    seat_characteristics: null,
+                    name: "Preferred Seats",
+                    id: "ele_0000AUXto7jQIGg7EHCfqX",
+                    disclosures: [],
+                    designator: "22C",
+                    available_services: [],
+                  },
+                ],
+              },
+              {
+                id: "sec_0000AUXto7jQIGg7EHCfqY",
+                elements: [
+                  {
+                    type: "seat",
+                    seat_characteristics: null,
+                    name: "Preferred Seats",
+                    id: "ele_0000AUXto7jQIGg7EHCfqZ",
+                    disclosures: [],
+                    designator: "22D",
+                    available_services: [
+                      {
+                        total_currency: "GBP",
+                        total_amount: "92.11",
+                        passenger_id: "pas_0000AUXtjPGOFpXaMEJ1KZ",
+                        id: "ase_0000AUXto7cKid0UsHt0nV",
+                      },
+                    ],
+                  },
+                  {
+                    type: "seat",
+                    seat_characteristics: null,
+                    name: "Preferred Seats",
+                    id: "ele_0000AUXto7jQIGg7EHCfqa",
+                    disclosures: [],
+                    designator: "22E",
+                    available_services: [
+                      {
+                        total_currency: "GBP",
+                        total_amount: "84.43",
+                        passenger_id: "pas_0000AUXtjPGOFpXaMEJ1KZ",
+                        id: "ase_0000AUXto7cKid0UsHt0nW",
+                      },
+                    ],
+                  },
+                  {
+                    type: "seat",
+                    seat_characteristics: null,
+                    name: "Preferred Seats",
+                    id: "ele_0000AUXto7jQIGg7EHCfqb",
+                    disclosures: [],
+                    designator: "22G",
+                    available_services: [
+                      {
+                        total_currency: "GBP",
+                        total_amount: "84.43",
+                        passenger_id: "pas_0000AUXtjPGOFpXaMEJ1KZ",
+                        id: "ase_0000AUXto7cKid0UsHt0nX",
+                      },
+                    ],
+                  },
+                  {
+                    type: "seat",
+                    seat_characteristics: null,
+                    name: "Preferred Seats",
+                    id: "ele_0000AUXto7jQIGg7EHCfqc",
+                    disclosures: [],
+                    designator: "22H",
+                    available_services: [
+                      {
+                        total_currency: "GBP",
+                        total_amount: "92.11",
+                        passenger_id: "pas_0000AUXtjPGOFpXaMEJ1KZ",
+                        id: "ase_0000AUXto7cKid0UsHt0nZ",
+                      },
+                    ],
+                  },
+                ],
+              },
+              {
+                id: "sec_0000AUXto7jQIGg7EHCfqd",
+                elements: [
+                  {
+                    type: "seat",
+                    seat_characteristics: null,
+                    name: "Preferred Seats",
+                    id: "ele_0000AUXto7jQIGg7EHCfqe",
+                    disclosures: [],
+                    designator: "22J",
+                    available_services: [],
+                  },
+                  {
+                    type: "seat",
+                    seat_characteristics: null,
+                    name: "Standard Seats",
+                    id: "ele_0000AUXto7jQIGg7EHCfqf",
+                    disclosures: [],
+                    designator: "22K",
+                    available_services: [
+                      {
+                        total_currency: "GBP",
+                        total_amount: "8.87",
+                        passenger_id: "pas_0000AUXtjPGOFpXaMEJ1KZ",
+                        id: "ase_0000AUXto7cKid0UsHt0nb",
+                      },
+                    ],
+                  },
+                  {
+                    type: "seat",
+                    seat_characteristics: null,
+                    name: "Preferred Seats",
+                    id: "ele_0000AUXto7jQIGg7EHCfqg",
+                    disclosures: [],
+                    designator: "22L",
+                    available_services: [
+                      {
+                        total_currency: "GBP",
+                        total_amount: "92.11",
+                        passenger_id: "pas_0000AUXtjPGOFpXaMEJ1KZ",
+                        id: "ase_0000AUXto7cKid0UsHt0nd",
+                      },
+                    ],
+                  },
+                ],
+              },
+            ],
+            id: "row_0000AUXto7jQIGg7EHCfqT",
+          },
+          {
+            sections: [
+              {
+                id: "sec_0000AUXto7jQIGg7EHCfqi",
+                elements: [
+                  {
+                    type: "seat",
+                    seat_characteristics: null,
+                    name: "Preferred Seats",
+                    id: "ele_0000AUXto7jQIGg7EHCfqj",
+                    disclosures: [],
+                    designator: "23A",
+                    available_services: [
+                      {
+                        total_currency: "GBP",
+                        total_amount: "92.11",
+                        passenger_id: "pas_0000AUXtjPGOFpXaMEJ1KZ",
+                        id: "ase_0000AUXto7cKid0UsHt0nf",
+                      },
+                    ],
+                  },
+                  {
+                    type: "seat",
+                    seat_characteristics: null,
+                    name: "Standard Seats",
+                    id: "ele_0000AUXto7jQIGg7EHCfqk",
+                    disclosures: [],
+                    designator: "23B",
+                    available_services: [
+                      {
+                        total_currency: "GBP",
+                        total_amount: "8.87",
+                        passenger_id: "pas_0000AUXtjPGOFpXaMEJ1KZ",
+                        id: "ase_0000AUXto7cKid0UsHt0ni",
+                      },
+                    ],
+                  },
+                  {
+                    type: "seat",
+                    seat_characteristics: null,
+                    name: "Preferred Seats",
+                    id: "ele_0000AUXto7jQIGg7EHCfql",
+                    disclosures: [],
+                    designator: "23C",
+                    available_services: [],
+                  },
+                ],
+              },
+              {
+                id: "sec_0000AUXto7jQIGg7EHCfqm",
+                elements: [
+                  {
+                    type: "seat",
+                    seat_characteristics: null,
+                    name: "Preferred Seats",
+                    id: "ele_0000AUXto7jQIGg7EHCfqn",
+                    disclosures: [],
+                    designator: "23D",
+                    available_services: [
+                      {
+                        total_currency: "GBP",
+                        total_amount: "92.11",
+                        passenger_id: "pas_0000AUXtjPGOFpXaMEJ1KZ",
+                        id: "ase_0000AUXto7cghJI4tO3ILR",
+                      },
+                    ],
+                  },
+                  {
+                    type: "seat",
+                    seat_characteristics: null,
+                    name: "Preferred Seats",
+                    id: "ele_0000AUXto7jQIGg7EHCfqo",
+                    disclosures: [],
+                    designator: "23E",
+                    available_services: [
+                      {
+                        total_currency: "GBP",
+                        total_amount: "84.43",
+                        passenger_id: "pas_0000AUXtjPGOFpXaMEJ1KZ",
+                        id: "ase_0000AUXto7cghJI4tO3ILT",
+                      },
+                    ],
+                  },
+                  {
+                    type: "seat",
+                    seat_characteristics: null,
+                    name: "Preferred Seats",
+                    id: "ele_0000AUXto7jQIGg7EHCfqp",
+                    disclosures: [],
+                    designator: "23G",
+                    available_services: [
+                      {
+                        total_currency: "GBP",
+                        total_amount: "84.43",
+                        passenger_id: "pas_0000AUXtjPGOFpXaMEJ1KZ",
+                        id: "ase_0000AUXto7cghJI4tO3ILV",
+                      },
+                    ],
+                  },
+                  {
+                    type: "seat",
+                    seat_characteristics: null,
+                    name: "Preferred Seats",
+                    id: "ele_0000AUXto7jQIGg7EHCfqr",
+                    disclosures: [],
+                    designator: "23H",
+                    available_services: [
+                      {
+                        total_currency: "GBP",
+                        total_amount: "92.11",
+                        passenger_id: "pas_0000AUXtjPGOFpXaMEJ1KZ",
+                        id: "ase_0000AUXto7cghJI4tO3ILW",
+                      },
+                    ],
+                  },
+                ],
+              },
+              {
+                id: "sec_0000AUXto7jmGwxhFNMxOa",
+                elements: [
+                  {
+                    type: "seat",
+                    seat_characteristics: null,
+                    name: "Preferred Seats",
+                    id: "ele_0000AUXto7jmGwxhFNMxOb",
+                    disclosures: [],
+                    designator: "23J",
+                    available_services: [],
+                  },
+                  {
+                    type: "seat",
+                    seat_characteristics: null,
+                    name: "Standard Seats",
+                    id: "ele_0000AUXto7jmGwxhFNMxOc",
+                    disclosures: [],
+                    designator: "23K",
+                    available_services: [
+                      {
+                        total_currency: "GBP",
+                        total_amount: "8.87",
+                        passenger_id: "pas_0000AUXtjPGOFpXaMEJ1KZ",
+                        id: "ase_0000AUXto7cghJI4tO3ILX",
+                      },
+                    ],
+                  },
+                  {
+                    type: "seat",
+                    seat_characteristics: null,
+                    name: "Preferred Seats",
+                    id: "ele_0000AUXto7jmGwxhFNMxOd",
+                    disclosures: [],
+                    designator: "23L",
+                    available_services: [
+                      {
+                        total_currency: "GBP",
+                        total_amount: "92.11",
+                        passenger_id: "pas_0000AUXtjPGOFpXaMEJ1KZ",
+                        id: "ase_0000AUXto7d2fzZeuUDZth",
+                      },
+                    ],
+                  },
+                ],
+              },
+            ],
+            id: "row_0000AUXto7jQIGg7EHCfqh",
+          },
+          {
+            sections: [
+              {
+                id: "sec_0000AUXto7jmGwxhFNMxOf",
+                elements: [
+                  {
+                    type: "seat",
+                    seat_characteristics: null,
+                    name: "Preferred Seats",
+                    id: "ele_0000AUXto7jmGwxhFNMxOg",
+                    disclosures: [],
+                    designator: "24A",
+                    available_services: [
+                      {
+                        total_currency: "GBP",
+                        total_amount: "92.11",
+                        passenger_id: "pas_0000AUXtjPGOFpXaMEJ1KZ",
+                        id: "ase_0000AUXto7dOefrEvaNrRw",
+                      },
+                    ],
+                  },
+                  {
+                    type: "seat",
+                    seat_characteristics: null,
+                    name: "Standard Seats",
+                    id: "ele_0000AUXto7jmGwxhFNMxOh",
+                    disclosures: [],
+                    designator: "24B",
+                    available_services: [
+                      {
+                        total_currency: "GBP",
+                        total_amount: "8.87",
+                        passenger_id: "pas_0000AUXtjPGOFpXaMEJ1KZ",
+                        id: "ase_0000AUXto7dOefrEvaNrS0",
+                      },
+                    ],
+                  },
+                  {
+                    type: "seat",
+                    seat_characteristics: null,
+                    name: "Standard Seats",
+                    id: "ele_0000AUXto7jmGwxhFNMxOi",
+                    disclosures: [],
+                    designator: "24C",
+                    available_services: [],
+                  },
+                ],
+              },
+              {
+                id: "sec_0000AUXto7jmGwxhFNMxOj",
+                elements: [
+                  {
+                    type: "seat",
+                    seat_characteristics: null,
+                    name: "Preferred Seats",
+                    id: "ele_0000AUXto7jmGwxhFNMxOk",
+                    disclosures: [],
+                    designator: "24D",
+                    available_services: [
+                      {
+                        total_currency: "GBP",
+                        total_amount: "92.11",
+                        passenger_id: "pas_0000AUXtjPGOFpXaMEJ1KZ",
+                        id: "ase_0000AUXto7dkdM8owgY90C",
+                      },
+                    ],
+                  },
+                  {
+                    type: "seat",
+                    seat_characteristics: null,
+                    name: "Standard Seats",
+                    id: "ele_0000AUXto7jmGwxhFNMxOl",
+                    disclosures: [],
+                    designator: "24E",
+                    available_services: [
+                      {
+                        total_currency: "GBP",
+                        total_amount: "8.87",
+                        passenger_id: "pas_0000AUXtjPGOFpXaMEJ1KZ",
+                        id: "ase_0000AUXto7dkdM8owgY90D",
+                      },
+                    ],
+                  },
+                  {
+                    type: "seat",
+                    seat_characteristics: null,
+                    name: "Standard Seats",
+                    id: "ele_0000AUXto7jmGwxhFNMxOm",
+                    disclosures: [],
+                    designator: "24G",
+                    available_services: [
+                      {
+                        total_currency: "GBP",
+                        total_amount: "8.87",
+                        passenger_id: "pas_0000AUXtjPGOFpXaMEJ1KZ",
+                        id: "ase_0000AUXto7dkdM8owgY90F",
+                      },
+                    ],
+                  },
+                  {
+                    type: "seat",
+                    seat_characteristics: null,
+                    name: "Preferred Seats",
+                    id: "ele_0000AUXto7jmGwxhFNMxOn",
+                    disclosures: [],
+                    designator: "24H",
+                    available_services: [
+                      {
+                        total_currency: "GBP",
+                        total_amount: "92.11",
+                        passenger_id: "pas_0000AUXtjPGOFpXaMEJ1KZ",
+                        id: "ase_0000AUXto7dkdM8owgY90H",
+                      },
+                    ],
+                  },
+                ],
+              },
+              {
+                id: "sec_0000AUXto7jmGwxhFNMxOo",
+                elements: [
+                  {
+                    type: "seat",
+                    seat_characteristics: null,
+                    name: "Standard Seats",
+                    id: "ele_0000AUXto7jmGwxhFNMxOp",
+                    disclosures: [],
+                    designator: "24J",
+                    available_services: [],
+                  },
+                  {
+                    type: "seat",
+                    seat_characteristics: null,
+                    name: "Standard Seats",
+                    id: "ele_0000AUXto7jmGwxhFNMxOq",
+                    disclosures: [],
+                    designator: "24K",
+                    available_services: [
+                      {
+                        total_currency: "GBP",
+                        total_amount: "8.87",
+                        passenger_id: "pas_0000AUXtjPGOFpXaMEJ1KZ",
+                        id: "ase_0000AUXto7dkdM8owgY90I",
+                      },
+                    ],
+                  },
+                  {
+                    type: "seat",
+                    seat_characteristics: null,
+                    name: "Standard Seats",
+                    id: "ele_0000AUXto7jmGwxhFNMxOr",
+                    disclosures: [],
+                    designator: "24L",
+                    available_services: [],
+                  },
+                ],
+              },
+            ],
+            id: "row_0000AUXto7jmGwxhFNMxOe",
+          },
+          {
+            sections: [
+              {
+                id: "sec_0000AUXto7jmGwxhFNMxOt",
+                elements: [],
+              },
+              {
+                id: "sec_0000AUXto7jmGwxhFNMxOu",
+                elements: [],
+              },
+              {
+                id: "sec_0000AUXto7jmGwxhFNMxOv",
+                elements: [
+                  {
+                    type: "lavatory",
+                    seat_characteristics: null,
+                    name: null,
+                    id: "ele_0000AUXto7jmGwxhFNMxOw",
+                    disclosures: null,
+                    designator: null,
+                    available_services: [],
+                  },
+                ],
+              },
+            ],
+            id: "row_0000AUXto7jmGwxhFNMxOs",
+          },
+          {
+            sections: [
+              {
+                id: "sec_0000AUXto7jmGwxhFNMxOz",
+                elements: [
+                  {
+                    type: "seat",
+                    seat_characteristics: null,
+                    name: "Preferred Seats",
+                    id: "ele_0000AUXto7jmGwxhFNMxP0",
+                    disclosures: [],
+                    designator: "25A",
+                    available_services: [
+                      {
+                        total_currency: "GBP",
+                        total_amount: "92.11",
+                        passenger_id: "pas_0000AUXtjPGOFpXaMEJ1KZ",
+                        id: "ase_0000AUXto7dkdM8owgY90J",
+                      },
+                    ],
+                  },
+                  {
+                    type: "empty",
+                    seat_characteristics: null,
+                    name: null,
+                    id: "ele_0000AUXto7jmGwxhFNMxP3",
+                    disclosures: null,
+                    designator: null,
+                    available_services: [],
+                  },
+                  {
+                    type: "seat",
+                    seat_characteristics: null,
+                    name: "Preferred Seats",
+                    id: "ele_0000AUXto7jmGwxhFNMxP4",
+                    disclosures: [],
+                    designator: "25C",
+                    available_services: [
+                      {
+                        total_currency: "GBP",
+                        total_amount: "92.11",
+                        passenger_id: "pas_0000AUXtjPGOFpXaMEJ1KZ",
+                        id: "ase_0000AUXto7dkdM8owgY90L",
+                      },
+                    ],
+                  },
+                ],
+              },
+              {
+                id: "sec_0000AUXto7k8FdFHGTXEwr",
+                elements: [
+                  {
+                    type: "empty",
+                    seat_characteristics: null,
+                    name: null,
+                    id: "ele_0000AUXto7k8FdFHGTXEws",
+                    disclosures: null,
+                    designator: null,
+                    available_services: [],
+                  },
+                  {
+                    type: "empty",
+                    seat_characteristics: null,
+                    name: null,
+                    id: "ele_0000AUXto7k8FdFHGTXEwt",
+                    disclosures: null,
+                    designator: null,
+                    available_services: [],
+                  },
+                  {
+                    type: "empty",
+                    seat_characteristics: null,
+                    name: null,
+                    id: "ele_0000AUXto7k8FdFHGTXEwu",
+                    disclosures: null,
+                    designator: null,
+                    available_services: [],
+                  },
+                  {
+                    type: "empty",
+                    seat_characteristics: null,
+                    name: null,
+                    id: "ele_0000AUXto7k8FdFHGTXEwv",
+                    disclosures: null,
+                    designator: null,
+                    available_services: [],
+                  },
+                ],
+              },
+              {
+                id: "sec_0000AUXto7k8FdFHGTXEww",
+                elements: [
+                  {
+                    type: "empty",
+                    seat_characteristics: null,
+                    name: null,
+                    id: "ele_0000AUXto7k8FdFHGTXEwx",
+                    disclosures: null,
+                    designator: null,
+                    available_services: [],
+                  },
+                  {
+                    type: "empty",
+                    seat_characteristics: null,
+                    name: null,
+                    id: "ele_0000AUXto7k8FdFHGTXEwy",
+                    disclosures: null,
+                    designator: null,
+                    available_services: [],
+                  },
+                  {
+                    type: "lavatory",
+                    seat_characteristics: null,
+                    name: null,
+                    id: "ele_0000AUXto7k8FdFHGTXEwz",
+                    disclosures: null,
+                    designator: null,
+                    available_services: [],
+                  },
+                ],
+              },
+            ],
+            id: "row_0000AUXto7jmGwxhFNMxOx",
+          },
+          {
+            sections: [
+              {
+                id: "sec_0000AUXto7k8FdFHGTXEx1",
+                elements: [
+                  {
+                    type: "lavatory",
+                    seat_characteristics: null,
+                    name: null,
+                    id: "ele_0000AUXto7k8FdFHGTXEx2",
+                    disclosures: null,
+                    designator: null,
+                    available_services: [],
+                  },
+                ],
+              },
+              {
+                id: "sec_0000AUXto7k8FdFHGTXEx3",
+                elements: [],
+              },
+              {
+                id: "sec_0000AUXto7k8FdFHGTXEx4",
+                elements: [],
+              },
+            ],
+            id: "row_0000AUXto7k8FdFHGTXEx0",
+          },
+          {
+            sections: [
+              {
+                id: "sec_0000AUXto7k8FdFHGTXEx6",
+                elements: [
+                  {
+                    type: "exit_row",
+                    seat_characteristics: null,
+                    name: null,
+                    id: "ele_0000AUXto7k8FdFHGTXEx7",
+                    disclosures: null,
+                    designator: null,
+                    available_services: [],
+                  },
+                ],
+              },
+              {
+                id: "sec_0000AUXto7k8FdFHGTXEx8",
+                elements: [],
+              },
+              {
+                id: "sec_0000AUXto7k8FdFHGTXEx9",
+                elements: [
+                  {
+                    type: "exit_row",
+                    seat_characteristics: null,
+                    name: null,
+                    id: "ele_0000AUXto7k8FdFHGTXExA",
+                    disclosures: null,
+                    designator: null,
+                    available_services: [],
+                  },
+                ],
+              },
+            ],
+            id: "row_0000AUXto7k8FdFHGTXEx5",
+          },
+          {
+            sections: [
+              {
+                id: "sec_0000AUXto7k8FdFHGTXExC",
+                elements: [
+                  {
+                    type: "seat",
+                    seat_characteristics: null,
+                    name: "Main Cabin Extra",
+                    id: "ele_0000AUXto7k8FdFHGTXExD",
+                    disclosures: [],
+                    designator: "26A",
+                    available_services: [
+                      {
+                        total_currency: "GBP",
+                        total_amount: "126.66",
+                        passenger_id: "pas_0000AUXtjPGOFpXaMEJ1KZ",
+                        id: "ase_0000AUXto7dkdM8owgY90M",
+                      },
+                    ],
+                  },
+                  {
+                    type: "seat",
+                    seat_characteristics: null,
+                    name: "Main Cabin Extra",
+                    id: "ele_0000AUXto7k8FdFHGTXExE",
+                    disclosures: [],
+                    designator: "26B",
+                    available_services: [
+                      {
+                        total_currency: "GBP",
+                        total_amount: "126.66",
+                        passenger_id: "pas_0000AUXtjPGOFpXaMEJ1KZ",
+                        id: "ase_0000AUXto7dkdM8owgY90N",
+                      },
+                    ],
+                  },
+                  {
+                    type: "seat",
+                    seat_characteristics: null,
+                    name: "Main Cabin Extra",
+                    id: "ele_0000AUXto7k8FdFHGTXExF",
+                    disclosures: [],
+                    designator: "26C",
+                    available_services: [
+                      {
+                        total_currency: "GBP",
+                        total_amount: "126.66",
+                        passenger_id: "pas_0000AUXtjPGOFpXaMEJ1KZ",
+                        id: "ase_0000AUXto7dkdM8owgY90O",
+                      },
+                    ],
+                  },
+                ],
+              },
+              {
+                id: "sec_0000AUXto7k8FdFHGTXExG",
+                elements: [
+                  {
+                    type: "seat",
+                    seat_characteristics: null,
+                    name: "Main Cabin Extra",
+                    id: "ele_0000AUXto7k8FdFHGTXExH",
+                    disclosures: [],
+                    designator: "26D",
+                    available_services: [
+                      {
+                        total_currency: "GBP",
+                        total_amount: "126.66",
+                        passenger_id: "pas_0000AUXtjPGOFpXaMEJ1KZ",
+                        id: "ase_0000AUXto7dkdM8owgY90P",
+                      },
+                    ],
+                  },
+                  {
+                    type: "seat",
+                    seat_characteristics: null,
+                    name: "Main Cabin Extra",
+                    id: "ele_0000AUXto7k8FdFHGTXExI",
+                    disclosures: [],
+                    designator: "26E",
+                    available_services: [
+                      {
+                        total_currency: "GBP",
+                        total_amount: "126.66",
+                        passenger_id: "pas_0000AUXtjPGOFpXaMEJ1KZ",
+                        id: "ase_0000AUXto7dkdM8owgY90Q",
+                      },
+                    ],
+                  },
+                  {
+                    type: "seat",
+                    seat_characteristics: null,
+                    name: "Main Cabin Extra",
+                    id: "ele_0000AUXto7k8FdFHGTXExJ",
+                    disclosures: [],
+                    designator: "26G",
+                    available_services: [
+                      {
+                        total_currency: "GBP",
+                        total_amount: "126.66",
+                        passenger_id: "pas_0000AUXtjPGOFpXaMEJ1KZ",
+                        id: "ase_0000AUXto7dkdM8owgY90R",
+                      },
+                    ],
+                  },
+                  {
+                    type: "seat",
+                    seat_characteristics: null,
+                    name: "Main Cabin Extra",
+                    id: "ele_0000AUXto7k8FdFHGTXExK",
+                    disclosures: [],
+                    designator: "26H",
+                    available_services: [
+                      {
+                        total_currency: "GBP",
+                        total_amount: "126.66",
+                        passenger_id: "pas_0000AUXtjPGOFpXaMEJ1KZ",
+                        id: "ase_0000AUXto7dkdM8owgY90S",
+                      },
+                    ],
+                  },
+                ],
+              },
+              {
+                id: "sec_0000AUXto7k8FdFHGTXExL",
+                elements: [
+                  {
+                    type: "seat",
+                    seat_characteristics: null,
+                    name: "Main Cabin Extra",
+                    id: "ele_0000AUXto7kUEJWrHZhWV6",
+                    disclosures: [],
+                    designator: "26J",
+                    available_services: [
+                      {
+                        total_currency: "GBP",
+                        total_amount: "126.66",
+                        passenger_id: "pas_0000AUXtjPGOFpXaMEJ1KZ",
+                        id: "ase_0000AUXto7dkdM8owgY90T",
+                      },
+                    ],
+                  },
+                  {
+                    type: "seat",
+                    seat_characteristics: null,
+                    name: "Main Cabin Extra",
+                    id: "ele_0000AUXto7kUEJWrHZhWV7",
+                    disclosures: [],
+                    designator: "26K",
+                    available_services: [
+                      {
+                        total_currency: "GBP",
+                        total_amount: "126.66",
+                        passenger_id: "pas_0000AUXtjPGOFpXaMEJ1KZ",
+                        id: "ase_0000AUXto7dkdM8owgY90U",
+                      },
+                    ],
+                  },
+                  {
+                    type: "seat",
+                    seat_characteristics: null,
+                    name: "Main Cabin Extra",
+                    id: "ele_0000AUXto7kUEJWrHZhWV8",
+                    disclosures: [],
+                    designator: "26L",
+                    available_services: [
+                      {
+                        total_currency: "GBP",
+                        total_amount: "126.66",
+                        passenger_id: "pas_0000AUXtjPGOFpXaMEJ1KZ",
+                        id: "ase_0000AUXto7dkdM8owgY90V",
+                      },
+                    ],
+                  },
+                ],
+              },
+            ],
+            id: "row_0000AUXto7k8FdFHGTXExB",
+          },
+          {
+            sections: [
+              {
+                id: "sec_0000AUXto7kUEJWrHZhWVB",
+                elements: [
+                  {
+                    type: "seat",
+                    seat_characteristics: null,
+                    name: "Main Cabin Extra",
+                    id: "ele_0000AUXto7kUEJWrHZhWVC",
+                    disclosures: [],
+                    designator: "27A",
+                    available_services: [
+                      {
+                        total_currency: "GBP",
+                        total_amount: "120.90",
+                        passenger_id: "pas_0000AUXtjPGOFpXaMEJ1KZ",
+                        id: "ase_0000AUXto7dkdM8owgY90W",
+                      },
+                    ],
+                  },
+                  {
+                    type: "seat",
+                    seat_characteristics: null,
+                    name: "Main Cabin Extra",
+                    id: "ele_0000AUXto7kUEJWrHZhWVD",
+                    disclosures: [],
+                    designator: "27B",
+                    available_services: [
+                      {
+                        total_currency: "GBP",
+                        total_amount: "109.38",
+                        passenger_id: "pas_0000AUXtjPGOFpXaMEJ1KZ",
+                        id: "ase_0000AUXto7dkdM8owgY90X",
+                      },
+                    ],
+                  },
+                  {
+                    type: "seat",
+                    seat_characteristics: null,
+                    name: "Main Cabin Extra",
+                    id: "ele_0000AUXto7kUEJWrHZhWVE",
+                    disclosures: [],
+                    designator: "27C",
+                    available_services: [
+                      {
+                        total_currency: "GBP",
+                        total_amount: "120.90",
+                        passenger_id: "pas_0000AUXtjPGOFpXaMEJ1KZ",
+                        id: "ase_0000AUXto7dkdM8owgY90Y",
+                      },
+                    ],
+                  },
+                ],
+              },
+              {
+                id: "sec_0000AUXto7kUEJWrHZhWVF",
+                elements: [
+                  {
+                    type: "seat",
+                    seat_characteristics: null,
+                    name: "Main Cabin Extra",
+                    id: "ele_0000AUXto7kUEJWrHZhWVG",
+                    disclosures: [],
+                    designator: "27D",
+                    available_services: [
+                      {
+                        total_currency: "GBP",
+                        total_amount: "120.90",
+                        passenger_id: "pas_0000AUXtjPGOFpXaMEJ1KZ",
+                        id: "ase_0000AUXto7dkdM8owgY90Z",
+                      },
+                    ],
+                  },
+                  {
+                    type: "seat",
+                    seat_characteristics: null,
+                    name: "Main Cabin Extra",
+                    id: "ele_0000AUXto7kUEJWrHZhWVH",
+                    disclosures: [],
+                    designator: "27E",
+                    available_services: [
+                      {
+                        total_currency: "GBP",
+                        total_amount: "109.38",
+                        passenger_id: "pas_0000AUXtjPGOFpXaMEJ1KZ",
+                        id: "ase_0000AUXto7dkdM8owgY90a",
+                      },
+                    ],
+                  },
+                  {
+                    type: "seat",
+                    seat_characteristics: null,
+                    name: "Main Cabin Extra",
+                    id: "ele_0000AUXto7kUEJWrHZhWVI",
+                    disclosures: [],
+                    designator: "27G",
+                    available_services: [
+                      {
+                        total_currency: "GBP",
+                        total_amount: "109.38",
+                        passenger_id: "pas_0000AUXtjPGOFpXaMEJ1KZ",
+                        id: "ase_0000AUXto7dkdM8owgY90b",
+                      },
+                    ],
+                  },
+                  {
+                    type: "seat",
+                    seat_characteristics: null,
+                    name: "Main Cabin Extra",
+                    id: "ele_0000AUXto7kUEJWrHZhWVJ",
+                    disclosures: [],
+                    designator: "27H",
+                    available_services: [
+                      {
+                        total_currency: "GBP",
+                        total_amount: "120.90",
+                        passenger_id: "pas_0000AUXtjPGOFpXaMEJ1KZ",
+                        id: "ase_0000AUXto7dkdM8owgY90c",
+                      },
+                    ],
+                  },
+                ],
+              },
+              {
+                id: "sec_0000AUXto7kUEJWrHZhWVK",
+                elements: [
+                  {
+                    type: "seat",
+                    seat_characteristics: null,
+                    name: "Main Cabin Extra",
+                    id: "ele_0000AUXto7kUEJWrHZhWVL",
+                    disclosures: [],
+                    designator: "27J",
+                    available_services: [
+                      {
+                        total_currency: "GBP",
+                        total_amount: "120.90",
+                        passenger_id: "pas_0000AUXtjPGOFpXaMEJ1KZ",
+                        id: "ase_0000AUXto7dkdM8owgY90d",
+                      },
+                    ],
+                  },
+                  {
+                    type: "seat",
+                    seat_characteristics: null,
+                    name: "Main Cabin Extra",
+                    id: "ele_0000AUXto7kUEJWrHZhWVM",
+                    disclosures: [],
+                    designator: "27K",
+                    available_services: [
+                      {
+                        total_currency: "GBP",
+                        total_amount: "109.38",
+                        passenger_id: "pas_0000AUXtjPGOFpXaMEJ1KZ",
+                        id: "ase_0000AUXto7dkdM8owgY90e",
+                      },
+                    ],
+                  },
+                  {
+                    type: "seat",
+                    seat_characteristics: null,
+                    name: "Main Cabin Extra",
+                    id: "ele_0000AUXto7kUEJWrHZhWVO",
+                    disclosures: [],
+                    designator: "27L",
+                    available_services: [
+                      {
+                        total_currency: "GBP",
+                        total_amount: "120.90",
+                        passenger_id: "pas_0000AUXtjPGOFpXaMEJ1KZ",
+                        id: "ase_0000AUXto7dkdM8owgY90f",
+                      },
+                    ],
+                  },
+                ],
+              },
+            ],
+            id: "row_0000AUXto7kUEJWrHZhWVA",
+          },
+          {
+            sections: [
+              {
+                id: "sec_0000AUXto7kUEJWrHZhWVQ",
+                elements: [
+                  {
+                    type: "seat",
+                    seat_characteristics: null,
+                    name: "Main Cabin Extra",
+                    id: "ele_0000AUXto7kUEJWrHZhWVR",
+                    disclosures: [],
+                    designator: "28A",
+                    available_services: [
+                      {
+                        total_currency: "GBP",
+                        total_amount: "120.90",
+                        passenger_id: "pas_0000AUXtjPGOFpXaMEJ1KZ",
+                        id: "ase_0000AUXto7dkdM8owgY90g",
+                      },
+                    ],
+                  },
+                  {
+                    type: "seat",
+                    seat_characteristics: null,
+                    name: "Main Cabin Extra",
+                    id: "ele_0000AUXto7kUEJWrHZhWVS",
+                    disclosures: [],
+                    designator: "28B",
+                    available_services: [
+                      {
+                        total_currency: "GBP",
+                        total_amount: "109.38",
+                        passenger_id: "pas_0000AUXtjPGOFpXaMEJ1KZ",
+                        id: "ase_0000AUXto7dkdM8owgY90h",
+                      },
+                    ],
+                  },
+                  {
+                    type: "seat",
+                    seat_characteristics: null,
+                    name: "Main Cabin Extra",
+                    id: "ele_0000AUXto7kUEJWrHZhWVT",
+                    disclosures: [],
+                    designator: "28C",
+                    available_services: [
+                      {
+                        total_currency: "GBP",
+                        total_amount: "120.90",
+                        passenger_id: "pas_0000AUXtjPGOFpXaMEJ1KZ",
+                        id: "ase_0000AUXto7dkdM8owgY90i",
+                      },
+                    ],
+                  },
+                ],
+              },
+              {
+                id: "sec_0000AUXto7kUEJWrHZhWVU",
+                elements: [
+                  {
+                    type: "seat",
+                    seat_characteristics: null,
+                    name: "Main Cabin Extra",
+                    id: "ele_0000AUXto7kUEJWrHZhWVV",
+                    disclosures: [],
+                    designator: "28D",
+                    available_services: [
+                      {
+                        total_currency: "GBP",
+                        total_amount: "120.90",
+                        passenger_id: "pas_0000AUXtjPGOFpXaMEJ1KZ",
+                        id: "ase_0000AUXto7e6c2QOxmiQYS",
+                      },
+                    ],
+                  },
+                  {
+                    type: "seat",
+                    seat_characteristics: null,
+                    name: "Main Cabin Extra",
+                    id: "ele_0000AUXto7kUEJWrHZhWVW",
+                    disclosures: [],
+                    designator: "28E",
+                    available_services: [
+                      {
+                        total_currency: "GBP",
+                        total_amount: "109.38",
+                        passenger_id: "pas_0000AUXtjPGOFpXaMEJ1KZ",
+                        id: "ase_0000AUXto7e6c2QOxmiQYT",
+                      },
+                    ],
+                  },
+                  {
+                    type: "seat",
+                    seat_characteristics: null,
+                    name: "Main Cabin Extra",
+                    id: "ele_0000AUXto7kUEJWrHZhWVX",
+                    disclosures: [],
+                    designator: "28G",
+                    available_services: [
+                      {
+                        total_currency: "GBP",
+                        total_amount: "109.38",
+                        passenger_id: "pas_0000AUXtjPGOFpXaMEJ1KZ",
+                        id: "ase_0000AUXto7e6c2QOxmiQYX",
+                      },
+                    ],
+                  },
+                  {
+                    type: "seat",
+                    seat_characteristics: null,
+                    name: "Main Cabin Extra",
+                    id: "ele_0000AUXto7kUEJWrHZhWVY",
+                    disclosures: [],
+                    designator: "28H",
+                    available_services: [
+                      {
+                        total_currency: "GBP",
+                        total_amount: "120.90",
+                        passenger_id: "pas_0000AUXtjPGOFpXaMEJ1KZ",
+                        id: "ase_0000AUXto7e6c2QOxmiQYY",
+                      },
+                    ],
+                  },
+                ],
+              },
+              {
+                id: "sec_0000AUXto7kUEJWrHZhWVZ",
+                elements: [
+                  {
+                    type: "seat",
+                    seat_characteristics: null,
+                    name: "Main Cabin Extra",
+                    id: "ele_0000AUXto7kUEJWrHZhWVa",
+                    disclosures: [],
+                    designator: "28J",
+                    available_services: [
+                      {
+                        total_currency: "GBP",
+                        total_amount: "120.90",
+                        passenger_id: "pas_0000AUXtjPGOFpXaMEJ1KZ",
+                        id: "ase_0000AUXto7e6c2QOxmiQYZ",
+                      },
+                    ],
+                  },
+                  {
+                    type: "seat",
+                    seat_characteristics: null,
+                    name: "Main Cabin Extra",
+                    id: "ele_0000AUXto7kqCzoRIfro3M",
+                    disclosures: [],
+                    designator: "28K",
+                    available_services: [
+                      {
+                        total_currency: "GBP",
+                        total_amount: "109.38",
+                        passenger_id: "pas_0000AUXtjPGOFpXaMEJ1KZ",
+                        id: "ase_0000AUXto7e6c2QOxmiQYa",
+                      },
+                    ],
+                  },
+                  {
+                    type: "seat",
+                    seat_characteristics: null,
+                    name: "Main Cabin Extra",
+                    id: "ele_0000AUXto7kqCzoRIfro3N",
+                    disclosures: [],
+                    designator: "28L",
+                    available_services: [
+                      {
+                        total_currency: "GBP",
+                        total_amount: "120.90",
+                        passenger_id: "pas_0000AUXtjPGOFpXaMEJ1KZ",
+                        id: "ase_0000AUXto7e6c2QOxmiQYb",
+                      },
+                    ],
+                  },
+                ],
+              },
+            ],
+            id: "row_0000AUXto7kUEJWrHZhWVP",
+          },
+          {
+            sections: [
+              {
+                id: "sec_0000AUXto7kqCzoRIfro3R",
+                elements: [
+                  {
+                    type: "seat",
+                    seat_characteristics: null,
+                    name: "Preferred Seats",
+                    id: "ele_0000AUXto7kqCzoRIfro3S",
+                    disclosures: [],
+                    designator: "29A",
+                    available_services: [
+                      {
+                        total_currency: "GBP",
+                        total_amount: "92.11",
+                        passenger_id: "pas_0000AUXtjPGOFpXaMEJ1KZ",
+                        id: "ase_0000AUXto7e6c2QOxmiQYc",
+                      },
+                    ],
+                  },
+                  {
+                    type: "seat",
+                    seat_characteristics: null,
+                    name: "Preferred Seats",
+                    id: "ele_0000AUXto7kqCzoRIfro3T",
+                    disclosures: [],
+                    designator: "29B",
+                    available_services: [
+                      {
+                        total_currency: "GBP",
+                        total_amount: "84.43",
+                        passenger_id: "pas_0000AUXtjPGOFpXaMEJ1KZ",
+                        id: "ase_0000AUXto7e6c2QOxmiQYd",
+                      },
+                    ],
+                  },
+                  {
+                    type: "seat",
+                    seat_characteristics: null,
+                    name: "Preferred Seats",
+                    id: "ele_0000AUXto7kqCzoRIfro3U",
+                    disclosures: [],
+                    designator: "29C",
+                    available_services: [
+                      {
+                        total_currency: "GBP",
+                        total_amount: "92.11",
+                        passenger_id: "pas_0000AUXtjPGOFpXaMEJ1KZ",
+                        id: "ase_0000AUXto7e6c2QOxmiQYe",
+                      },
+                    ],
+                  },
+                ],
+              },
+              {
+                id: "sec_0000AUXto7kqCzoRIfro3V",
+                elements: [
+                  {
+                    type: "seat",
+                    seat_characteristics: null,
+                    name: "Main Cabin Extra",
+                    id: "ele_0000AUXto7kqCzoRIfro3W",
+                    disclosures: [],
+                    designator: "29D",
+                    available_services: [
+                      {
+                        total_currency: "GBP",
+                        total_amount: "120.90",
+                        passenger_id: "pas_0000AUXtjPGOFpXaMEJ1KZ",
+                        id: "ase_0000AUXto7e6c2QOxmiQYf",
+                      },
+                    ],
+                  },
+                  {
+                    type: "seat",
+                    seat_characteristics: null,
+                    name: "Main Cabin Extra",
+                    id: "ele_0000AUXto7kqCzoRIfro3X",
+                    disclosures: [],
+                    designator: "29E",
+                    available_services: [
+                      {
+                        total_currency: "GBP",
+                        total_amount: "109.38",
+                        passenger_id: "pas_0000AUXtjPGOFpXaMEJ1KZ",
+                        id: "ase_0000AUXto7e6c2QOxmiQYg",
+                      },
+                    ],
+                  },
+                  {
+                    type: "seat",
+                    seat_characteristics: null,
+                    name: "Main Cabin Extra",
+                    id: "ele_0000AUXto7kqCzoRIfro3Y",
+                    disclosures: [],
+                    designator: "29G",
+                    available_services: [
+                      {
+                        total_currency: "GBP",
+                        total_amount: "109.38",
+                        passenger_id: "pas_0000AUXtjPGOFpXaMEJ1KZ",
+                        id: "ase_0000AUXto7e6c2QOxmiQYh",
+                      },
+                    ],
+                  },
+                  {
+                    type: "seat",
+                    seat_characteristics: null,
+                    name: "Main Cabin Extra",
+                    id: "ele_0000AUXto7kqCzoRIfro3Z",
+                    disclosures: [],
+                    designator: "29H",
+                    available_services: [
+                      {
+                        total_currency: "GBP",
+                        total_amount: "120.90",
+                        passenger_id: "pas_0000AUXtjPGOFpXaMEJ1KZ",
+                        id: "ase_0000AUXto7e6c2QOxmiQYi",
+                      },
+                    ],
+                  },
+                ],
+              },
+              {
+                id: "sec_0000AUXto7kqCzoRIfro3b",
+                elements: [
+                  {
+                    type: "seat",
+                    seat_characteristics: null,
+                    name: "Preferred Seats",
+                    id: "ele_0000AUXto7kqCzoRIfro3c",
+                    disclosures: [],
+                    designator: "29J",
+                    available_services: [
+                      {
+                        total_currency: "GBP",
+                        total_amount: "92.11",
+                        passenger_id: "pas_0000AUXtjPGOFpXaMEJ1KZ",
+                        id: "ase_0000AUXto7e6c2QOxmiQYj",
+                      },
+                    ],
+                  },
+                  {
+                    type: "seat",
+                    seat_characteristics: null,
+                    name: "Preferred Seats",
+                    id: "ele_0000AUXto7kqCzoRIfro3d",
+                    disclosures: [],
+                    designator: "29K",
+                    available_services: [
+                      {
+                        total_currency: "GBP",
+                        total_amount: "84.43",
+                        passenger_id: "pas_0000AUXtjPGOFpXaMEJ1KZ",
+                        id: "ase_0000AUXto7e6c2QOxmiQYk",
+                      },
+                    ],
+                  },
+                  {
+                    type: "seat",
+                    seat_characteristics: null,
+                    name: "Preferred Seats",
+                    id: "ele_0000AUXto7kqCzoRIfro3e",
+                    disclosures: [],
+                    designator: "29L",
+                    available_services: [
+                      {
+                        total_currency: "GBP",
+                        total_amount: "92.11",
+                        passenger_id: "pas_0000AUXtjPGOFpXaMEJ1KZ",
+                        id: "ase_0000AUXto7eSaihyyssi6j",
+                      },
+                    ],
+                  },
+                ],
+              },
+            ],
+            id: "row_0000AUXto7kqCzoRIfro3P",
+          },
+          {
+            sections: [
+              {
+                id: "sec_0000AUXto7kqCzoRIfro3g",
+                elements: [
+                  {
+                    type: "seat",
+                    seat_characteristics: null,
+                    name: "Standard Seats",
+                    id: "ele_0000AUXto7kqCzoRIfro3h",
+                    disclosures: [],
+                    designator: "30A",
+                    available_services: [],
+                  },
+                  {
+                    type: "seat",
+                    seat_characteristics: null,
+                    name: "Standard Seats",
+                    id: "ele_0000AUXto7kqCzoRIfro3i",
+                    disclosures: [],
+                    designator: "30B",
+                    available_services: [
+                      {
+                        total_currency: "GBP",
+                        total_amount: "8.87",
+                        passenger_id: "pas_0000AUXtjPGOFpXaMEJ1KZ",
+                        id: "ase_0000AUXto7eSaihyyssi6k",
+                      },
+                    ],
+                  },
+                  {
+                    type: "seat",
+                    seat_characteristics: null,
+                    name: "Standard Seats",
+                    id: "ele_0000AUXto7kqCzoRIfro3j",
+                    disclosures: [],
+                    designator: "30C",
+                    available_services: [
+                      {
+                        total_currency: "GBP",
+                        total_amount: "9.33",
+                        passenger_id: "pas_0000AUXtjPGOFpXaMEJ1KZ",
+                        id: "ase_0000AUXto7eSaihyyssi6l",
+                      },
+                    ],
+                  },
+                ],
+              },
+              {
+                id: "sec_0000AUXto7kqCzoRIfro3k",
+                elements: [
+                  {
+                    type: "seat",
+                    seat_characteristics: null,
+                    name: "Standard Seats",
+                    id: "ele_0000AUXto7kqCzoRIfro3l",
+                    disclosures: [],
+                    designator: "30D",
+                    available_services: [
+                      {
+                        total_currency: "GBP",
+                        total_amount: "9.33",
+                        passenger_id: "pas_0000AUXtjPGOFpXaMEJ1KZ",
+                        id: "ase_0000AUXto7eSaihyyssi6m",
+                      },
+                    ],
+                  },
+                  {
+                    type: "seat",
+                    seat_characteristics: null,
+                    name: "Standard Seats",
+                    id: "ele_0000AUXto7kqCzoRIfro3m",
+                    disclosures: [],
+                    designator: "30E",
+                    available_services: [
+                      {
+                        total_currency: "GBP",
+                        total_amount: "8.87",
+                        passenger_id: "pas_0000AUXtjPGOFpXaMEJ1KZ",
+                        id: "ase_0000AUXto7eSaihyyssi6o",
+                      },
+                    ],
+                  },
+                  {
+                    type: "seat",
+                    seat_characteristics: null,
+                    name: "Standard Seats",
+                    id: "ele_0000AUXto7kqCzoRIfro3n",
+                    disclosures: [],
+                    designator: "30G",
+                    available_services: [
+                      {
+                        total_currency: "GBP",
+                        total_amount: "8.87",
+                        passenger_id: "pas_0000AUXtjPGOFpXaMEJ1KZ",
+                        id: "ase_0000AUXto7eSaihyyssi6q",
+                      },
+                    ],
+                  },
+                  {
+                    type: "seat",
+                    seat_characteristics: null,
+                    name: "Standard Seats",
+                    id: "ele_0000AUXto7kqCzoRIfro3o",
+                    disclosures: [],
+                    designator: "30H",
+                    available_services: [
+                      {
+                        total_currency: "GBP",
+                        total_amount: "9.33",
+                        passenger_id: "pas_0000AUXtjPGOFpXaMEJ1KZ",
+                        id: "ase_0000AUXto7eSaihyyssi6s",
+                      },
+                    ],
+                  },
+                ],
+              },
+              {
+                id: "sec_0000AUXto7lCBg61Jm25bc",
+                elements: [
+                  {
+                    type: "seat",
+                    seat_characteristics: null,
+                    name: "Standard Seats",
+                    id: "ele_0000AUXto7lCBg61Jm25bd",
+                    disclosures: [],
+                    designator: "30J",
+                    available_services: [
+                      {
+                        total_currency: "GBP",
+                        total_amount: "9.33",
+                        passenger_id: "pas_0000AUXtjPGOFpXaMEJ1KZ",
+                        id: "ase_0000AUXto7eSaihyyssi6t",
+                      },
+                    ],
+                  },
+                  {
+                    type: "seat",
+                    seat_characteristics: null,
+                    name: "Standard Seats",
+                    id: "ele_0000AUXto7lCBg61Jm25be",
+                    disclosures: [],
+                    designator: "30K",
+                    available_services: [
+                      {
+                        total_currency: "GBP",
+                        total_amount: "8.87",
+                        passenger_id: "pas_0000AUXtjPGOFpXaMEJ1KZ",
+                        id: "ase_0000AUXto7eSaihyyssi6u",
+                      },
+                    ],
+                  },
+                  {
+                    type: "seat",
+                    seat_characteristics: null,
+                    name: "Standard Seats",
+                    id: "ele_0000AUXto7lCBg61Jm25bf",
+                    disclosures: [],
+                    designator: "30L",
+                    available_services: [
+                      {
+                        total_currency: "GBP",
+                        total_amount: "9.33",
+                        passenger_id: "pas_0000AUXtjPGOFpXaMEJ1KZ",
+                        id: "ase_0000AUXto7eSaihyyssi6v",
+                      },
+                    ],
+                  },
+                ],
+              },
+            ],
+            id: "row_0000AUXto7kqCzoRIfro3f",
+          },
+          {
+            sections: [
+              {
+                id: "sec_0000AUXto7lCBg61Jm25bh",
+                elements: [
+                  {
+                    type: "seat",
+                    seat_characteristics: null,
+                    name: "Standard Seats",
+                    id: "ele_0000AUXto7lCBg61Jm25bi",
+                    disclosures: [],
+                    designator: "31A",
+                    available_services: [
+                      {
+                        total_currency: "GBP",
+                        total_amount: "9.33",
+                        passenger_id: "pas_0000AUXtjPGOFpXaMEJ1KZ",
+                        id: "ase_0000AUXto7eSaihyyssi6w",
+                      },
+                    ],
+                  },
+                  {
+                    type: "seat",
+                    seat_characteristics: null,
+                    name: "Standard Seats",
+                    id: "ele_0000AUXto7lCBg61Jm25bj",
+                    disclosures: [],
+                    designator: "31B",
+                    available_services: [
+                      {
+                        total_currency: "GBP",
+                        total_amount: "8.87",
+                        passenger_id: "pas_0000AUXtjPGOFpXaMEJ1KZ",
+                        id: "ase_0000AUXto7eSaihyyssi6x",
+                      },
+                    ],
+                  },
+                  {
+                    type: "seat",
+                    seat_characteristics: null,
+                    name: "Standard Seats",
+                    id: "ele_0000AUXto7lCBg61Jm25bk",
+                    disclosures: [],
+                    designator: "31C",
+                    available_services: [
+                      {
+                        total_currency: "GBP",
+                        total_amount: "9.33",
+                        passenger_id: "pas_0000AUXtjPGOFpXaMEJ1KZ",
+                        id: "ase_0000AUXto7eSaihyyssi6y",
+                      },
+                    ],
+                  },
+                ],
+              },
+              {
+                id: "sec_0000AUXto7lCBg61Jm25bm",
+                elements: [
+                  {
+                    type: "seat",
+                    seat_characteristics: null,
+                    name: "Standard Seats",
+                    id: "ele_0000AUXto7lCBg61Jm25bp",
+                    disclosures: [],
+                    designator: "31D",
+                    available_services: [
+                      {
+                        total_currency: "GBP",
+                        total_amount: "9.33",
+                        passenger_id: "pas_0000AUXtjPGOFpXaMEJ1KZ",
+                        id: "ase_0000AUXto7eSaihyyssi71",
+                      },
+                    ],
+                  },
+                  {
+                    type: "seat",
+                    seat_characteristics: null,
+                    name: "Standard Seats",
+                    id: "ele_0000AUXto7lCBg61Jm25bq",
+                    disclosures: [],
+                    designator: "31E",
+                    available_services: [
+                      {
+                        total_currency: "GBP",
+                        total_amount: "8.87",
+                        passenger_id: "pas_0000AUXtjPGOFpXaMEJ1KZ",
+                        id: "ase_0000AUXto7eSaihyyssi72",
+                      },
+                    ],
+                  },
+                  {
+                    type: "seat",
+                    seat_characteristics: null,
+                    name: "Standard Seats",
+                    id: "ele_0000AUXto7lCBg61Jm25br",
+                    disclosures: [],
+                    designator: "31G",
+                    available_services: [
+                      {
+                        total_currency: "GBP",
+                        total_amount: "8.87",
+                        passenger_id: "pas_0000AUXtjPGOFpXaMEJ1KZ",
+                        id: "ase_0000AUXto7eSaihyyssi73",
+                      },
+                    ],
+                  },
+                  {
+                    type: "seat",
+                    seat_characteristics: null,
+                    name: "Standard Seats",
+                    id: "ele_0000AUXto7lCBg61Jm25bs",
+                    disclosures: [],
+                    designator: "31H",
+                    available_services: [
+                      {
+                        total_currency: "GBP",
+                        total_amount: "9.33",
+                        passenger_id: "pas_0000AUXtjPGOFpXaMEJ1KZ",
+                        id: "ase_0000AUXto7eSaihyyssi74",
+                      },
+                    ],
+                  },
+                ],
+              },
+              {
+                id: "sec_0000AUXto7lCBg61Jm25bt",
+                elements: [
+                  {
+                    type: "seat",
+                    seat_characteristics: null,
+                    name: "Standard Seats",
+                    id: "ele_0000AUXto7lCBg61Jm25bu",
+                    disclosures: [],
+                    designator: "31J",
+                    available_services: [
+                      {
+                        total_currency: "GBP",
+                        total_amount: "9.33",
+                        passenger_id: "pas_0000AUXtjPGOFpXaMEJ1KZ",
+                        id: "ase_0000AUXto7eSaihyyssi75",
+                      },
+                    ],
+                  },
+                  {
+                    type: "seat",
+                    seat_characteristics: null,
+                    name: "Standard Seats",
+                    id: "ele_0000AUXto7lCBg61Jm25bv",
+                    disclosures: [],
+                    designator: "31K",
+                    available_services: [
+                      {
+                        total_currency: "GBP",
+                        total_amount: "8.87",
+                        passenger_id: "pas_0000AUXtjPGOFpXaMEJ1KZ",
+                        id: "ase_0000AUXto7eSaihyyssi76",
+                      },
+                    ],
+                  },
+                  {
+                    type: "seat",
+                    seat_characteristics: null,
+                    name: "Standard Seats",
+                    id: "ele_0000AUXto7lCBg61Jm25bw",
+                    disclosures: [],
+                    designator: "31L",
+                    available_services: [
+                      {
+                        total_currency: "GBP",
+                        total_amount: "9.33",
+                        passenger_id: "pas_0000AUXtjPGOFpXaMEJ1KZ",
+                        id: "ase_0000AUXto7eSaihyyssi77",
+                      },
+                    ],
+                  },
+                ],
+              },
+            ],
+            id: "row_0000AUXto7lCBg61Jm25bg",
+          },
+          {
+            sections: [
+              {
+                id: "sec_0000AUXto7lCBg61Jm25bz",
+                elements: [
+                  {
+                    type: "seat",
+                    seat_characteristics: null,
+                    name: "Standard Seats",
+                    id: "ele_0000AUXto7lCBg61Jm25c0",
+                    disclosures: [],
+                    designator: "32A",
+                    available_services: [
+                      {
+                        total_currency: "GBP",
+                        total_amount: "9.33",
+                        passenger_id: "pas_0000AUXtjPGOFpXaMEJ1KZ",
+                        id: "ase_0000AUXto7eSaihyyssi78",
+                      },
+                    ],
+                  },
+                  {
+                    type: "seat",
+                    seat_characteristics: null,
+                    name: "Standard Seats",
+                    id: "ele_0000AUXto7lYAMNbKsCN9t",
+                    disclosures: [],
+                    designator: "32B",
+                    available_services: [
+                      {
+                        total_currency: "GBP",
+                        total_amount: "8.87",
+                        passenger_id: "pas_0000AUXtjPGOFpXaMEJ1KZ",
+                        id: "ase_0000AUXto7eSaihyyssi79",
+                      },
+                    ],
+                  },
+                  {
+                    type: "seat",
+                    seat_characteristics: null,
+                    name: "Standard Seats",
+                    id: "ele_0000AUXto7lYAMNbKsCN9w",
+                    disclosures: [],
+                    designator: "32C",
+                    available_services: [
+                      {
+                        total_currency: "GBP",
+                        total_amount: "9.33",
+                        passenger_id: "pas_0000AUXtjPGOFpXaMEJ1KZ",
+                        id: "ase_0000AUXto7eSaihyyssi7A",
+                      },
+                    ],
+                  },
+                ],
+              },
+              {
+                id: "sec_0000AUXto7lYAMNbKsCN9z",
+                elements: [
+                  {
+                    type: "seat",
+                    seat_characteristics: null,
+                    name: "Standard Seats",
+                    id: "ele_0000AUXto7lYAMNbKsCNA1",
+                    disclosures: [],
+                    designator: "32D",
+                    available_services: [
+                      {
+                        total_currency: "GBP",
+                        total_amount: "9.33",
+                        passenger_id: "pas_0000AUXtjPGOFpXaMEJ1KZ",
+                        id: "ase_0000AUXto7eSaihyyssi7B",
+                      },
+                    ],
+                  },
+                  {
+                    type: "seat",
+                    seat_characteristics: null,
+                    name: "Standard Seats",
+                    id: "ele_0000AUXto7lYAMNbKsCNA4",
+                    disclosures: [],
+                    designator: "32E",
+                    available_services: [
+                      {
+                        total_currency: "GBP",
+                        total_amount: "8.87",
+                        passenger_id: "pas_0000AUXtjPGOFpXaMEJ1KZ",
+                        id: "ase_0000AUXto7eSaihyyssi7C",
+                      },
+                    ],
+                  },
+                  {
+                    type: "seat",
+                    seat_characteristics: null,
+                    name: "Standard Seats",
+                    id: "ele_0000AUXto7lYAMNbKsCNA5",
+                    disclosures: [],
+                    designator: "32G",
+                    available_services: [
+                      {
+                        total_currency: "GBP",
+                        total_amount: "8.87",
+                        passenger_id: "pas_0000AUXtjPGOFpXaMEJ1KZ",
+                        id: "ase_0000AUXto7eoZOzYzz2zey",
+                      },
+                    ],
+                  },
+                  {
+                    type: "seat",
+                    seat_characteristics: null,
+                    name: "Standard Seats",
+                    id: "ele_0000AUXto7lu92fBLyMei8",
+                    disclosures: [],
+                    designator: "32H",
+                    available_services: [
+                      {
+                        total_currency: "GBP",
+                        total_amount: "9.33",
+                        passenger_id: "pas_0000AUXtjPGOFpXaMEJ1KZ",
+                        id: "ase_0000AUXto7eoZOzYzz2zez",
+                      },
+                    ],
+                  },
+                ],
+              },
+              {
+                id: "sec_0000AUXto7lu92fBLyMeiA",
+                elements: [
+                  {
+                    type: "seat",
+                    seat_characteristics: null,
+                    name: "Standard Seats",
+                    id: "ele_0000AUXto7lu92fBLyMeiB",
+                    disclosures: [],
+                    designator: "32J",
+                    available_services: [
+                      {
+                        total_currency: "GBP",
+                        total_amount: "9.33",
+                        passenger_id: "pas_0000AUXtjPGOFpXaMEJ1KZ",
+                        id: "ase_0000AUXto7eoZOzYzz2zf1",
+                      },
+                    ],
+                  },
+                  {
+                    type: "seat",
+                    seat_characteristics: null,
+                    name: "Standard Seats",
+                    id: "ele_0000AUXto7lu92fBLyMeiC",
+                    disclosures: [],
+                    designator: "32K",
+                    available_services: [
+                      {
+                        total_currency: "GBP",
+                        total_amount: "8.87",
+                        passenger_id: "pas_0000AUXtjPGOFpXaMEJ1KZ",
+                        id: "ase_0000AUXto7eoZOzYzz2zf2",
+                      },
+                    ],
+                  },
+                  {
+                    type: "seat",
+                    seat_characteristics: null,
+                    name: "Standard Seats",
+                    id: "ele_0000AUXto7lu92fBLyMeiD",
+                    disclosures: [],
+                    designator: "32L",
+                    available_services: [
+                      {
+                        total_currency: "GBP",
+                        total_amount: "9.33",
+                        passenger_id: "pas_0000AUXtjPGOFpXaMEJ1KZ",
+                        id: "ase_0000AUXto7eoZOzYzz2zf3",
+                      },
+                    ],
+                  },
+                ],
+              },
+            ],
+            id: "row_0000AUXto7lCBg61Jm25bx",
+          },
+          {
+            sections: [
+              {
+                id: "sec_0000AUXto7lu92fBLyMeiF",
+                elements: [
+                  {
+                    type: "seat",
+                    seat_characteristics: null,
+                    name: "Standard Seats",
+                    id: "ele_0000AUXto7lu92fBLyMeiG",
+                    disclosures: [],
+                    designator: "33A",
+                    available_services: [
+                      {
+                        total_currency: "GBP",
+                        total_amount: "9.33",
+                        passenger_id: "pas_0000AUXtjPGOFpXaMEJ1KZ",
+                        id: "ase_0000AUXto7eoZOzYzz2zf4",
+                      },
+                    ],
+                  },
+                  {
+                    type: "seat",
+                    seat_characteristics: null,
+                    name: "Standard Seats",
+                    id: "ele_0000AUXto7lu92fBLyMeiH",
+                    disclosures: [],
+                    designator: "33B",
+                    available_services: [
+                      {
+                        total_currency: "GBP",
+                        total_amount: "8.87",
+                        passenger_id: "pas_0000AUXtjPGOFpXaMEJ1KZ",
+                        id: "ase_0000AUXto7eoZOzYzz2zf5",
+                      },
+                    ],
+                  },
+                  {
+                    type: "seat",
+                    seat_characteristics: null,
+                    name: "Standard Seats",
+                    id: "ele_0000AUXto7lu92fBLyMeiI",
+                    disclosures: [],
+                    designator: "33C",
+                    available_services: [
+                      {
+                        total_currency: "GBP",
+                        total_amount: "9.33",
+                        passenger_id: "pas_0000AUXtjPGOFpXaMEJ1KZ",
+                        id: "ase_0000AUXto7eoZOzYzz2zf6",
+                      },
+                    ],
+                  },
+                ],
+              },
+              {
+                id: "sec_0000AUXto7lu92fBLyMeiJ",
+                elements: [
+                  {
+                    type: "seat",
+                    seat_characteristics: null,
+                    name: "Standard Seats",
+                    id: "ele_0000AUXto7lu92fBLyMeiK",
+                    disclosures: [],
+                    designator: "33D",
+                    available_services: [
+                      {
+                        total_currency: "GBP",
+                        total_amount: "9.33",
+                        passenger_id: "pas_0000AUXtjPGOFpXaMEJ1KZ",
+                        id: "ase_0000AUXto7eoZOzYzz2zf7",
+                      },
+                    ],
+                  },
+                  {
+                    type: "seat",
+                    seat_characteristics: null,
+                    name: "Standard Seats",
+                    id: "ele_0000AUXto7lu92fBLyMeiL",
+                    disclosures: [],
+                    designator: "33E",
+                    available_services: [
+                      {
+                        total_currency: "GBP",
+                        total_amount: "8.87",
+                        passenger_id: "pas_0000AUXtjPGOFpXaMEJ1KZ",
+                        id: "ase_0000AUXto7eoZOzYzz2zf8",
+                      },
+                    ],
+                  },
+                  {
+                    type: "seat",
+                    seat_characteristics: null,
+                    name: "Standard Seats",
+                    id: "ele_0000AUXto7lu92fBLyMeiM",
+                    disclosures: [],
+                    designator: "33G",
+                    available_services: [
+                      {
+                        total_currency: "GBP",
+                        total_amount: "8.87",
+                        passenger_id: "pas_0000AUXtjPGOFpXaMEJ1KZ",
+                        id: "ase_0000AUXto7eoZOzYzz2zf9",
+                      },
+                    ],
+                  },
+                  {
+                    type: "seat",
+                    seat_characteristics: null,
+                    name: "Standard Seats",
+                    id: "ele_0000AUXto7lu92fBLyMeiN",
+                    disclosures: [],
+                    designator: "33H",
+                    available_services: [
+                      {
+                        total_currency: "GBP",
+                        total_amount: "9.33",
+                        passenger_id: "pas_0000AUXtjPGOFpXaMEJ1KZ",
+                        id: "ase_0000AUXto7eoZOzYzz2zfB",
+                      },
+                    ],
+                  },
+                ],
+              },
+              {
+                id: "sec_0000AUXto7lu92fBLyMeiO",
+                elements: [
+                  {
+                    type: "seat",
+                    seat_characteristics: null,
+                    name: "Standard Seats",
+                    id: "ele_0000AUXto7mc6PELOAhDof",
+                    disclosures: [],
+                    designator: "33J",
+                    available_services: [
+                      {
+                        total_currency: "GBP",
+                        total_amount: "9.33",
+                        passenger_id: "pas_0000AUXtjPGOFpXaMEJ1KZ",
+                        id: "ase_0000AUXto7eoZOzYzz2zfD",
+                      },
+                    ],
+                  },
+                  {
+                    type: "seat",
+                    seat_characteristics: null,
+                    name: "Standard Seats",
+                    id: "ele_0000AUXto7mc6PELOAhDoh",
+                    disclosures: [],
+                    designator: "33K",
+                    available_services: [
+                      {
+                        total_currency: "GBP",
+                        total_amount: "8.87",
+                        passenger_id: "pas_0000AUXtjPGOFpXaMEJ1KZ",
+                        id: "ase_0000AUXto7eoZOzYzz2zfE",
+                      },
+                    ],
+                  },
+                  {
+                    type: "seat",
+                    seat_characteristics: null,
+                    name: "Standard Seats",
+                    id: "ele_0000AUXto7my55VvPGrVMv",
+                    disclosures: [],
+                    designator: "33L",
+                    available_services: [
+                      {
+                        total_currency: "GBP",
+                        total_amount: "9.33",
+                        passenger_id: "pas_0000AUXtjPGOFpXaMEJ1KZ",
+                        id: "ase_0000AUXto7eoZOzYzz2zfF",
+                      },
+                    ],
+                  },
+                ],
+              },
+            ],
+            id: "row_0000AUXto7lu92fBLyMeiE",
+          },
+          {
+            sections: [
+              {
+                id: "sec_0000AUXto7my55VvPGrVN0",
+                elements: [
+                  {
+                    type: "seat",
+                    seat_characteristics: null,
+                    name: "Standard Seats",
+                    id: "ele_0000AUXto7my55VvPGrVN1",
+                    disclosures: [],
+                    designator: "34A",
+                    available_services: [
+                      {
+                        total_currency: "GBP",
+                        total_amount: "9.33",
+                        passenger_id: "pas_0000AUXtjPGOFpXaMEJ1KZ",
+                        id: "ase_0000AUXto7eoZOzYzz2zfG",
+                      },
+                    ],
+                  },
+                  {
+                    type: "seat",
+                    seat_characteristics: null,
+                    name: "Standard Seats",
+                    id: "ele_0000AUXto7my55VvPGrVN2",
+                    disclosures: [],
+                    designator: "34B",
+                    available_services: [
+                      {
+                        total_currency: "GBP",
+                        total_amount: "8.87",
+                        passenger_id: "pas_0000AUXtjPGOFpXaMEJ1KZ",
+                        id: "ase_0000AUXto7eoZOzYzz2zfH",
+                      },
+                    ],
+                  },
+                  {
+                    type: "seat",
+                    seat_characteristics: null,
+                    name: "Standard Seats",
+                    id: "ele_0000AUXto7my55VvPGrVN3",
+                    disclosures: [],
+                    designator: "34C",
+                    available_services: [
+                      {
+                        total_currency: "GBP",
+                        total_amount: "9.33",
+                        passenger_id: "pas_0000AUXtjPGOFpXaMEJ1KZ",
+                        id: "ase_0000AUXto7eoZOzYzz2zfI",
+                      },
+                    ],
+                  },
+                ],
+              },
+              {
+                id: "sec_0000AUXto7my55VvPGrVN4",
+                elements: [
+                  {
+                    type: "seat",
+                    seat_characteristics: null,
+                    name: "Standard Seats",
+                    id: "ele_0000AUXto7my55VvPGrVN5",
+                    disclosures: [],
+                    designator: "34D",
+                    available_services: [
+                      {
+                        total_currency: "GBP",
+                        total_amount: "9.33",
+                        passenger_id: "pas_0000AUXtjPGOFpXaMEJ1KZ",
+                        id: "ase_0000AUXto7eoZOzYzz2zfJ",
+                      },
+                    ],
+                  },
+                  {
+                    type: "seat",
+                    seat_characteristics: null,
+                    name: "Standard Seats",
+                    id: "ele_0000AUXto7my55VvPGrVN6",
+                    disclosures: [],
+                    designator: "34E",
+                    available_services: [
+                      {
+                        total_currency: "GBP",
+                        total_amount: "8.87",
+                        passenger_id: "pas_0000AUXtjPGOFpXaMEJ1KZ",
+                        id: "ase_0000AUXto7eoZOzYzz2zfK",
+                      },
+                    ],
+                  },
+                  {
+                    type: "seat",
+                    seat_characteristics: null,
+                    name: "Standard Seats",
+                    id: "ele_0000AUXto7my55VvPGrVN7",
+                    disclosures: [],
+                    designator: "34G",
+                    available_services: [
+                      {
+                        total_currency: "GBP",
+                        total_amount: "8.87",
+                        passenger_id: "pas_0000AUXtjPGOFpXaMEJ1KZ",
+                        id: "ase_0000AUXto7eoZOzYzz2zfL",
+                      },
+                    ],
+                  },
+                  {
+                    type: "seat",
+                    seat_characteristics: null,
+                    name: "Standard Seats",
+                    id: "ele_0000AUXto7my55VvPGrVN8",
+                    disclosures: [],
+                    designator: "34H",
+                    available_services: [
+                      {
+                        total_currency: "GBP",
+                        total_amount: "9.33",
+                        passenger_id: "pas_0000AUXtjPGOFpXaMEJ1KZ",
+                        id: "ase_0000AUXto7eoZOzYzz2zfM",
+                      },
+                    ],
+                  },
+                ],
+              },
+              {
+                id: "sec_0000AUXto7my55VvPGrVN9",
+                elements: [
+                  {
+                    type: "seat",
+                    seat_characteristics: null,
+                    name: "Standard Seats",
+                    id: "ele_0000AUXto7my55VvPGrVNA",
+                    disclosures: [],
+                    designator: "34J",
+                    available_services: [
+                      {
+                        total_currency: "GBP",
+                        total_amount: "9.33",
+                        passenger_id: "pas_0000AUXtjPGOFpXaMEJ1KZ",
+                        id: "ase_0000AUXto7eoZOzYzz2zfN",
+                      },
+                    ],
+                  },
+                  {
+                    type: "seat",
+                    seat_characteristics: null,
+                    name: "Standard Seats",
+                    id: "ele_0000AUXto7my55VvPGrVNB",
+                    disclosures: [],
+                    designator: "34K",
+                    available_services: [
+                      {
+                        total_currency: "GBP",
+                        total_amount: "8.87",
+                        passenger_id: "pas_0000AUXtjPGOFpXaMEJ1KZ",
+                        id: "ase_0000AUXto7eoZOzYzz2zfO",
+                      },
+                    ],
+                  },
+                  {
+                    type: "seat",
+                    seat_characteristics: null,
+                    name: "Standard Seats",
+                    id: "ele_0000AUXto7my55VvPGrVNC",
+                    disclosures: [],
+                    designator: "34L",
+                    available_services: [
+                      {
+                        total_currency: "GBP",
+                        total_amount: "9.33",
+                        passenger_id: "pas_0000AUXtjPGOFpXaMEJ1KZ",
+                        id: "ase_0000AUXto7eoZOzYzz2zfP",
+                      },
+                    ],
+                  },
+                ],
+              },
+            ],
+            id: "row_0000AUXto7my55VvPGrVMx",
+          },
+          {
+            sections: [
+              {
+                id: "sec_0000AUXto7nK3lnVQN1mvB",
+                elements: [
+                  {
+                    type: "seat",
+                    seat_characteristics: null,
+                    name: "Standard Seats",
+                    id: "ele_0000AUXto7nK3lnVQN1mvC",
+                    disclosures: [],
+                    designator: "35A",
+                    available_services: [
+                      {
+                        total_currency: "GBP",
+                        total_amount: "9.33",
+                        passenger_id: "pas_0000AUXtjPGOFpXaMEJ1KZ",
+                        id: "ase_0000AUXto7eoZOzYzz2zfQ",
+                      },
+                    ],
+                  },
+                  {
+                    type: "seat",
+                    seat_characteristics: null,
+                    name: "Standard Seats",
+                    id: "ele_0000AUXto7nK3lnVQN1mvE",
+                    disclosures: [],
+                    designator: "35B",
+                    available_services: [
+                      {
+                        total_currency: "GBP",
+                        total_amount: "8.87",
+                        passenger_id: "pas_0000AUXtjPGOFpXaMEJ1KZ",
+                        id: "ase_0000AUXto7eoZOzYzz2zfR",
+                      },
+                    ],
+                  },
+                  {
+                    type: "seat",
+                    seat_characteristics: null,
+                    name: "Standard Seats",
+                    id: "ele_0000AUXto7nK3lnVQN1mvF",
+                    disclosures: [],
+                    designator: "35C",
+                    available_services: [
+                      {
+                        total_currency: "GBP",
+                        total_amount: "9.33",
+                        passenger_id: "pas_0000AUXtjPGOFpXaMEJ1KZ",
+                        id: "ase_0000AUXto7eoZOzYzz2zfS",
+                      },
+                    ],
+                  },
+                ],
+              },
+              {
+                id: "sec_0000AUXto7nK3lnVQN1mvH",
+                elements: [
+                  {
+                    type: "seat",
+                    seat_characteristics: null,
+                    name: "Standard Seats",
+                    id: "ele_0000AUXto7nK3lnVQN1mvI",
+                    disclosures: [],
+                    designator: "35D",
+                    available_services: [
+                      {
+                        total_currency: "GBP",
+                        total_amount: "9.33",
+                        passenger_id: "pas_0000AUXtjPGOFpXaMEJ1KZ",
+                        id: "ase_0000AUXto7eoZOzYzz2zfT",
+                      },
+                    ],
+                  },
+                  {
+                    type: "seat",
+                    seat_characteristics: null,
+                    name: "Standard Seats",
+                    id: "ele_0000AUXto7nK3lnVQN1mvJ",
+                    disclosures: [],
+                    designator: "35E",
+                    available_services: [
+                      {
+                        total_currency: "GBP",
+                        total_amount: "8.87",
+                        passenger_id: "pas_0000AUXtjPGOFpXaMEJ1KZ",
+                        id: "ase_0000AUXto7eoZOzYzz2zfU",
+                      },
+                    ],
+                  },
+                  {
+                    type: "seat",
+                    seat_characteristics: null,
+                    name: "Standard Seats",
+                    id: "ele_0000AUXto7nK3lnVQN1mvK",
+                    disclosures: [],
+                    designator: "35G",
+                    available_services: [
+                      {
+                        total_currency: "GBP",
+                        total_amount: "8.87",
+                        passenger_id: "pas_0000AUXtjPGOFpXaMEJ1KZ",
+                        id: "ase_0000AUXto7eoZOzYzz2zfV",
+                      },
+                    ],
+                  },
+                  {
+                    type: "seat",
+                    seat_characteristics: null,
+                    name: "Standard Seats",
+                    id: "ele_0000AUXto7nK3lnVQN1mvL",
+                    disclosures: [],
+                    designator: "35H",
+                    available_services: [
+                      {
+                        total_currency: "GBP",
+                        total_amount: "9.33",
+                        passenger_id: "pas_0000AUXtjPGOFpXaMEJ1KZ",
+                        id: "ase_0000AUXto7eoZOzYzz2zfW",
+                      },
+                    ],
+                  },
+                ],
+              },
+              {
+                id: "sec_0000AUXto7nK3lnVQN1mvM",
+                elements: [
+                  {
+                    type: "seat",
+                    seat_characteristics: null,
+                    name: "Standard Seats",
+                    id: "ele_0000AUXto7nK3lnVQN1mvN",
+                    disclosures: [],
+                    designator: "35J",
+                    available_services: [
+                      {
+                        total_currency: "GBP",
+                        total_amount: "9.33",
+                        passenger_id: "pas_0000AUXtjPGOFpXaMEJ1KZ",
+                        id: "ase_0000AUXto7fAY5H915DHDE",
+                      },
+                    ],
+                  },
+                  {
+                    type: "seat",
+                    seat_characteristics: null,
+                    name: "Standard Seats",
+                    id: "ele_0000AUXto7nK3lnVQN1mvO",
+                    disclosures: [],
+                    designator: "35K",
+                    available_services: [
+                      {
+                        total_currency: "GBP",
+                        total_amount: "8.87",
+                        passenger_id: "pas_0000AUXtjPGOFpXaMEJ1KZ",
+                        id: "ase_0000AUXto7fAY5H915DHDF",
+                      },
+                    ],
+                  },
+                  {
+                    type: "seat",
+                    seat_characteristics: null,
+                    name: "Standard Seats",
+                    id: "ele_0000AUXto7nK3lnVQN1mvP",
+                    disclosures: [],
+                    designator: "35L",
+                    available_services: [
+                      {
+                        total_currency: "GBP",
+                        total_amount: "9.33",
+                        passenger_id: "pas_0000AUXtjPGOFpXaMEJ1KZ",
+                        id: "ase_0000AUXto7fAY5H915DHDG",
+                      },
+                    ],
+                  },
+                ],
+              },
+            ],
+            id: "row_0000AUXto7nK3lnVQN1mvA",
+          },
+          {
+            sections: [
+              {
+                id: "sec_0000AUXto7nK3lnVQN1mvR",
+                elements: [
+                  {
+                    type: "seat",
+                    seat_characteristics: null,
+                    name: "Standard Seats",
+                    id: "ele_0000AUXto7nK3lnVQN1mvS",
+                    disclosures: [],
+                    designator: "36A",
+                    available_services: [
+                      {
+                        total_currency: "GBP",
+                        total_amount: "9.33",
+                        passenger_id: "pas_0000AUXtjPGOFpXaMEJ1KZ",
+                        id: "ase_0000AUXto7fAY5H915DHDH",
+                      },
+                    ],
+                  },
+                  {
+                    type: "empty",
+                    seat_characteristics: null,
+                    name: null,
+                    id: "ele_0000AUXto7nK3lnVQN1mvT",
+                    disclosures: null,
+                    designator: null,
+                    available_services: [],
+                  },
+                  {
+                    type: "seat",
+                    seat_characteristics: null,
+                    name: "Standard Seats",
+                    id: "ele_0000AUXto7nK3lnVQN1mvU",
+                    disclosures: [],
+                    designator: "36C",
+                    available_services: [
+                      {
+                        total_currency: "GBP",
+                        total_amount: "9.33",
+                        passenger_id: "pas_0000AUXtjPGOFpXaMEJ1KZ",
+                        id: "ase_0000AUXto7fAY5H915DHDI",
+                      },
+                    ],
+                  },
+                ],
+              },
+              {
+                id: "sec_0000AUXto7nK3lnVQN1mvV",
+                elements: [
+                  {
+                    type: "seat",
+                    seat_characteristics: null,
+                    name: "Standard Seats",
+                    id: "ele_0000AUXto7nK3lnVQN1mvW",
+                    disclosures: [],
+                    designator: "36D",
+                    available_services: [
+                      {
+                        total_currency: "GBP",
+                        total_amount: "9.33",
+                        passenger_id: "pas_0000AUXtjPGOFpXaMEJ1KZ",
+                        id: "ase_0000AUXto7fAY5H915DHDJ",
+                      },
+                    ],
+                  },
+                  {
+                    type: "seat",
+                    seat_characteristics: null,
+                    name: "Standard Seats",
+                    id: "ele_0000AUXto7nK3lnVQN1mvX",
+                    disclosures: [],
+                    designator: "36E",
+                    available_services: [
+                      {
+                        total_currency: "GBP",
+                        total_amount: "8.87",
+                        passenger_id: "pas_0000AUXtjPGOFpXaMEJ1KZ",
+                        id: "ase_0000AUXto7fAY5H915DHDK",
+                      },
+                    ],
+                  },
+                  {
+                    type: "seat",
+                    seat_characteristics: null,
+                    name: "Standard Seats",
+                    id: "ele_0000AUXto7nK3lnVQN1mvZ",
+                    disclosures: [],
+                    designator: "36G",
+                    available_services: [
+                      {
+                        total_currency: "GBP",
+                        total_amount: "8.87",
+                        passenger_id: "pas_0000AUXtjPGOFpXaMEJ1KZ",
+                        id: "ase_0000AUXto7fAY5H915DHDL",
+                      },
+                    ],
+                  },
+                  {
+                    type: "seat",
+                    seat_characteristics: null,
+                    name: "Standard Seats",
+                    id: "ele_0000AUXto7nK3lnVQN1mva",
+                    disclosures: [],
+                    designator: "36H",
+                    available_services: [
+                      {
+                        total_currency: "GBP",
+                        total_amount: "9.33",
+                        passenger_id: "pas_0000AUXtjPGOFpXaMEJ1KZ",
+                        id: "ase_0000AUXto7fAY5H915DHDM",
+                      },
+                    ],
+                  },
+                ],
+              },
+              {
+                id: "sec_0000AUXto7nK3lnVQN1mvb",
+                elements: [
+                  {
+                    type: "seat",
+                    seat_characteristics: null,
+                    name: "Standard Seats",
+                    id: "ele_0000AUXto7nK3lnVQN1mvc",
+                    disclosures: [],
+                    designator: "36J",
+                    available_services: [
+                      {
+                        total_currency: "GBP",
+                        total_amount: "9.33",
+                        passenger_id: "pas_0000AUXtjPGOFpXaMEJ1KZ",
+                        id: "ase_0000AUXto7fAY5H915DHDN",
+                      },
+                    ],
+                  },
+                  {
+                    type: "empty",
+                    seat_characteristics: null,
+                    name: null,
+                    id: "ele_0000AUXto7nK3lnVQN1mvd",
+                    disclosures: null,
+                    designator: null,
+                    available_services: [],
+                  },
+                  {
+                    type: "seat",
+                    seat_characteristics: null,
+                    name: "Standard Seats",
+                    id: "ele_0000AUXto7nK3lnVQN1mve",
+                    disclosures: [],
+                    designator: "36L",
+                    available_services: [
+                      {
+                        total_currency: "GBP",
+                        total_amount: "9.33",
+                        passenger_id: "pas_0000AUXtjPGOFpXaMEJ1KZ",
+                        id: "ase_0000AUXto7fAY5H915DHDO",
+                      },
+                    ],
+                  },
+                ],
+              },
+            ],
+            id: "row_0000AUXto7nK3lnVQN1mvQ",
+          },
+          {
+            sections: [
+              {
+                id: "sec_0000AUXto7ng2S55RTC4TR",
+                elements: [
+                  {
+                    type: "seat",
+                    seat_characteristics: null,
+                    name: "Standard Seats",
+                    id: "ele_0000AUXto7ng2S55RTC4TS",
+                    disclosures: [],
+                    designator: "37A",
+                    available_services: [
+                      {
+                        total_currency: "GBP",
+                        total_amount: "9.33",
+                        passenger_id: "pas_0000AUXtjPGOFpXaMEJ1KZ",
+                        id: "ase_0000AUXto7fAY5H915DHDP",
+                      },
+                    ],
+                  },
+                  {
+                    type: "empty",
+                    seat_characteristics: null,
+                    name: null,
+                    id: "ele_0000AUXto7ng2S55RTC4TT",
+                    disclosures: null,
+                    designator: null,
+                    available_services: [],
+                  },
+                  {
+                    type: "seat",
+                    seat_characteristics: null,
+                    name: "Standard Seats",
+                    id: "ele_0000AUXto7ng2S55RTC4TU",
+                    disclosures: [],
+                    designator: "37C",
+                    available_services: [
+                      {
+                        total_currency: "GBP",
+                        total_amount: "9.33",
+                        passenger_id: "pas_0000AUXtjPGOFpXaMEJ1KZ",
+                        id: "ase_0000AUXto7fAY5H915DHDR",
+                      },
+                    ],
+                  },
+                ],
+              },
+              {
+                id: "sec_0000AUXto7ng2S55RTC4TV",
+                elements: [
+                  {
+                    type: "seat",
+                    seat_characteristics: null,
+                    name: "Standard Seats",
+                    id: "ele_0000AUXto7ng2S55RTC4TW",
+                    disclosures: [],
+                    designator: "37D",
+                    available_services: [
+                      {
+                        total_currency: "GBP",
+                        total_amount: "9.33",
+                        passenger_id: "pas_0000AUXtjPGOFpXaMEJ1KZ",
+                        id: "ase_0000AUXto7fAY5H915DHDT",
+                      },
+                    ],
+                  },
+                  {
+                    type: "seat",
+                    seat_characteristics: null,
+                    name: "Standard Seats",
+                    id: "ele_0000AUXto7ng2S55RTC4TX",
+                    disclosures: [],
+                    designator: "37E",
+                    available_services: [
+                      {
+                        total_currency: "GBP",
+                        total_amount: "8.87",
+                        passenger_id: "pas_0000AUXtjPGOFpXaMEJ1KZ",
+                        id: "ase_0000AUXto7fAY5H915DHDU",
+                      },
+                    ],
+                  },
+                  {
+                    type: "seat",
+                    seat_characteristics: null,
+                    name: "Standard Seats",
+                    id: "ele_0000AUXto7ng2S55RTC4TY",
+                    disclosures: [],
+                    designator: "37G",
+                    available_services: [
+                      {
+                        total_currency: "GBP",
+                        total_amount: "8.87",
+                        passenger_id: "pas_0000AUXtjPGOFpXaMEJ1KZ",
+                        id: "ase_0000AUXto7fAY5H915DHDW",
+                      },
+                    ],
+                  },
+                  {
+                    type: "seat",
+                    seat_characteristics: null,
+                    name: "Standard Seats",
+                    id: "ele_0000AUXto7ng2S55RTC4TZ",
+                    disclosures: [],
+                    designator: "37H",
+                    available_services: [
+                      {
+                        total_currency: "GBP",
+                        total_amount: "9.33",
+                        passenger_id: "pas_0000AUXtjPGOFpXaMEJ1KZ",
+                        id: "ase_0000AUXto7fAY5H915DHDX",
+                      },
+                    ],
+                  },
+                ],
+              },
+              {
+                id: "sec_0000AUXto7ng2S55RTC4Ta",
+                elements: [
+                  {
+                    type: "seat",
+                    seat_characteristics: null,
+                    name: "Standard Seats",
+                    id: "ele_0000AUXto7ng2S55RTC4Tb",
+                    disclosures: [],
+                    designator: "37J",
+                    available_services: [
+                      {
+                        total_currency: "GBP",
+                        total_amount: "9.33",
+                        passenger_id: "pas_0000AUXtjPGOFpXaMEJ1KZ",
+                        id: "ase_0000AUXto7fAY5H915DHDY",
+                      },
+                    ],
+                  },
+                  {
+                    type: "empty",
+                    seat_characteristics: null,
+                    name: null,
+                    id: "ele_0000AUXto7ng2S55RTC4Tc",
+                    disclosures: null,
+                    designator: null,
+                    available_services: [],
+                  },
+                  {
+                    type: "seat",
+                    seat_characteristics: null,
+                    name: "Standard Seats",
+                    id: "ele_0000AUXto7ng2S55RTC4Td",
+                    disclosures: [],
+                    designator: "37L",
+                    available_services: [
+                      {
+                        total_currency: "GBP",
+                        total_amount: "9.33",
+                        passenger_id: "pas_0000AUXtjPGOFpXaMEJ1KZ",
+                        id: "ase_0000AUXto7fAY5H915DHDZ",
+                      },
+                    ],
+                  },
+                ],
+              },
+            ],
+            id: "row_0000AUXto7ng2S55RTC4TQ",
+          },
+          {
+            sections: [
+              {
+                id: "sec_0000AUXto7ng2S55RTC4Tf",
+                elements: [
+                  {
+                    type: "seat",
+                    seat_characteristics: null,
+                    name: "Standard Seats",
+                    id: "ele_0000AUXto7ng2S55RTC4Tg",
+                    disclosures: [],
+                    designator: "38A",
+                    available_services: [
+                      {
+                        total_currency: "GBP",
+                        total_amount: "9.33",
+                        passenger_id: "pas_0000AUXtjPGOFpXaMEJ1KZ",
+                        id: "ase_0000AUXto7fAY5H915DHDa",
+                      },
+                    ],
+                  },
+                  {
+                    type: "empty",
+                    seat_characteristics: null,
+                    name: null,
+                    id: "ele_0000AUXto7ng2S55RTC4Th",
+                    disclosures: null,
+                    designator: null,
+                    available_services: [],
+                  },
+                  {
+                    type: "seat",
+                    seat_characteristics: null,
+                    name: "Standard Seats",
+                    id: "ele_0000AUXto7ng2S55RTC4Ti",
+                    disclosures: [],
+                    designator: "38C",
+                    available_services: [
+                      {
+                        total_currency: "GBP",
+                        total_amount: "9.33",
+                        passenger_id: "pas_0000AUXtjPGOFpXaMEJ1KZ",
+                        id: "ase_0000AUXto7fAY5H915DHDb",
+                      },
+                    ],
+                  },
+                ],
+              },
+              {
+                id: "sec_0000AUXto7ng2S55RTC4Tj",
+                elements: [
+                  {
+                    type: "seat",
+                    seat_characteristics: null,
+                    name: "Standard Seats",
+                    id: "ele_0000AUXto7ng2S55RTC4Tk",
+                    disclosures: [],
+                    designator: "38D",
+                    available_services: [
+                      {
+                        total_currency: "GBP",
+                        total_amount: "9.33",
+                        passenger_id: "pas_0000AUXtjPGOFpXaMEJ1KZ",
+                        id: "ase_0000AUXto7fAY5H915DHDd",
+                      },
+                    ],
+                  },
+                  {
+                    type: "seat",
+                    seat_characteristics: null,
+                    name: "Standard Seats",
+                    id: "ele_0000AUXto7ng2S55RTC4Tl",
+                    disclosures: [],
+                    designator: "38E",
+                    available_services: [
+                      {
+                        total_currency: "GBP",
+                        total_amount: "8.87",
+                        passenger_id: "pas_0000AUXtjPGOFpXaMEJ1KZ",
+                        id: "ase_0000AUXto7fAY5H915DHDe",
+                      },
+                    ],
+                  },
+                  {
+                    type: "seat",
+                    seat_characteristics: null,
+                    name: "Standard Seats",
+                    id: "ele_0000AUXto7ng2S55RTC4Tm",
+                    disclosures: [],
+                    designator: "38G",
+                    available_services: [
+                      {
+                        total_currency: "GBP",
+                        total_amount: "8.87",
+                        passenger_id: "pas_0000AUXtjPGOFpXaMEJ1KZ",
+                        id: "ase_0000AUXto7fAY5H915DHDf",
+                      },
+                    ],
+                  },
+                  {
+                    type: "seat",
+                    seat_characteristics: null,
+                    name: "Standard Seats",
+                    id: "ele_0000AUXto7ng2S55RTC4Tn",
+                    disclosures: [],
+                    designator: "38H",
+                    available_services: [
+                      {
+                        total_currency: "GBP",
+                        total_amount: "9.33",
+                        passenger_id: "pas_0000AUXtjPGOFpXaMEJ1KZ",
+                        id: "ase_0000AUXto7fAY5H915DHDg",
+                      },
+                    ],
+                  },
+                ],
+              },
+              {
+                id: "sec_0000AUXto7ng2S55RTC4To",
+                elements: [
+                  {
+                    type: "seat",
+                    seat_characteristics: null,
+                    name: "Standard Seats",
+                    id: "ele_0000AUXto7ng2S55RTC4Tp",
+                    disclosures: [],
+                    designator: "38J",
+                    available_services: [
+                      {
+                        total_currency: "GBP",
+                        total_amount: "9.33",
+                        passenger_id: "pas_0000AUXtjPGOFpXaMEJ1KZ",
+                        id: "ase_0000AUXto7fAY5H915DHDh",
+                      },
+                    ],
+                  },
+                  {
+                    type: "empty",
+                    seat_characteristics: null,
+                    name: null,
+                    id: "ele_0000AUXto7ng2S55RTC4Tq",
+                    disclosures: null,
+                    designator: null,
+                    available_services: [],
+                  },
+                  {
+                    type: "seat",
+                    seat_characteristics: null,
+                    name: "Standard Seats",
+                    id: "ele_0000AUXto7ng2S55RTC4Tr",
+                    disclosures: [],
+                    designator: "38L",
+                    available_services: [
+                      {
+                        total_currency: "GBP",
+                        total_amount: "9.33",
+                        passenger_id: "pas_0000AUXtjPGOFpXaMEJ1KZ",
+                        id: "ase_0000AUXto7fAY5H915DHDi",
+                      },
+                    ],
+                  },
+                ],
+              },
+            ],
+            id: "row_0000AUXto7ng2S55RTC4Te",
+          },
+          {
+            sections: [
+              {
+                id: "sec_0000AUXto7ng2S55RTC4Tu",
+                elements: [
+                  {
+                    type: "lavatory",
+                    seat_characteristics: null,
+                    name: null,
+                    id: "ele_0000AUXto7ng2S55RTC4Tv",
+                    disclosures: null,
+                    designator: null,
+                    available_services: [],
+                  },
+                  {
+                    type: "empty",
+                    seat_characteristics: null,
+                    name: null,
+                    id: "ele_0000AUXto7ng2S55RTC4Tw",
+                    disclosures: null,
+                    designator: null,
+                    available_services: [],
+                  },
+                  {
+                    type: "empty",
+                    seat_characteristics: null,
+                    name: null,
+                    id: "ele_0000AUXto7ng2S55RTC4Tx",
+                    disclosures: null,
+                    designator: null,
+                    available_services: [],
+                  },
+                ],
+              },
+              {
+                id: "sec_0000AUXto7ng2S55RTC4Tz",
+                elements: [
+                  {
+                    type: "seat",
+                    seat_characteristics: null,
+                    name: "Standard Seats",
+                    id: "ele_0000AUXto7ng2S55RTC4U0",
+                    disclosures: [],
+                    designator: "39D",
+                    available_services: [],
+                  },
+                  {
+                    type: "seat",
+                    seat_characteristics: null,
+                    name: "Standard Seats",
+                    id: "ele_0000AUXto7ng2S55RTC4U1",
+                    disclosures: [],
+                    designator: "39E",
+                    available_services: [],
+                  },
+                  {
+                    type: "seat",
+                    seat_characteristics: null,
+                    name: "Standard Seats",
+                    id: "ele_0000AUXto7o218MfSZMM1g",
+                    disclosures: [],
+                    designator: "39G",
+                    available_services: [],
+                  },
+                  {
+                    type: "seat",
+                    seat_characteristics: null,
+                    name: "Standard Seats",
+                    id: "ele_0000AUXto7o218MfSZMM1i",
+                    disclosures: [],
+                    designator: "39H",
+                    available_services: [],
+                  },
+                ],
+              },
+              {
+                id: "sec_0000AUXto7o218MfSZMM1j",
+                elements: [
+                  {
+                    type: "empty",
+                    seat_characteristics: null,
+                    name: null,
+                    id: "ele_0000AUXto7o218MfSZMM1k",
+                    disclosures: null,
+                    designator: null,
+                    available_services: [],
+                  },
+                  {
+                    type: "empty",
+                    seat_characteristics: null,
+                    name: null,
+                    id: "ele_0000AUXto7o218MfSZMM1m",
+                    disclosures: null,
+                    designator: null,
+                    available_services: [],
+                  },
+                  {
+                    type: "lavatory",
+                    seat_characteristics: null,
+                    name: null,
+                    id: "ele_0000AUXto7o218MfSZMM1p",
+                    disclosures: null,
+                    designator: null,
+                    available_services: [],
+                  },
+                ],
+              },
+            ],
+            id: "row_0000AUXto7ng2S55RTC4Tt",
+          },
+          {
+            sections: [
+              {
+                id: "sec_0000AUXto7o218MfSZMM1s",
+                elements: [
+                  {
+                    type: "empty",
+                    seat_characteristics: null,
+                    name: null,
+                    id: "ele_0000AUXto7o218MfSZMM1t",
+                    disclosures: null,
+                    designator: null,
+                    available_services: [],
+                  },
+                  {
+                    type: "empty",
+                    seat_characteristics: null,
+                    name: null,
+                    id: "ele_0000AUXto7o218MfSZMM1v",
+                    disclosures: null,
+                    designator: null,
+                    available_services: [],
+                  },
+                  {
+                    type: "empty",
+                    seat_characteristics: null,
+                    name: null,
+                    id: "ele_0000AUXto7o218MfSZMM1w",
+                    disclosures: null,
+                    designator: null,
+                    available_services: [],
+                  },
+                ],
+              },
+              {
+                id: "sec_0000AUXto7o218MfSZMM1x",
+                elements: [
+                  {
+                    type: "seat",
+                    seat_characteristics: null,
+                    name: "Standard Seats",
+                    id: "ele_0000AUXto7o218MfSZMM1y",
+                    disclosures: [],
+                    designator: "40D",
+                    available_services: [],
+                  },
+                  {
+                    type: "seat",
+                    seat_characteristics: null,
+                    name: "Standard Seats",
+                    id: "ele_0000AUXto7o218MfSZMM1z",
+                    disclosures: [],
+                    designator: "40E",
+                    available_services: [],
+                  },
+                  {
+                    type: "seat",
+                    seat_characteristics: null,
+                    name: "Standard Seats",
+                    id: "ele_0000AUXto7o218MfSZMM20",
+                    disclosures: [],
+                    designator: "40G",
+                    available_services: [],
+                  },
+                  {
+                    type: "seat",
+                    seat_characteristics: null,
+                    name: "Standard Seats",
+                    id: "ele_0000AUXto7o218MfSZMM21",
+                    disclosures: [],
+                    designator: "40H",
+                    available_services: [],
+                  },
+                ],
+              },
+              {
+                id: "sec_0000AUXto7o218MfSZMM22",
+                elements: [
+                  {
+                    type: "empty",
+                    seat_characteristics: null,
+                    name: null,
+                    id: "ele_0000AUXto7o218MfSZMM23",
+                    disclosures: null,
+                    designator: null,
+                    available_services: [],
+                  },
+                  {
+                    type: "empty",
+                    seat_characteristics: null,
+                    name: null,
+                    id: "ele_0000AUXto7o218MfSZMM24",
+                    disclosures: null,
+                    designator: null,
+                    available_services: [],
+                  },
+                  {
+                    type: "empty",
+                    seat_characteristics: null,
+                    name: null,
+                    id: "ele_0000AUXto7o218MfSZMM25",
+                    disclosures: null,
+                    designator: null,
+                    available_services: [],
+                  },
+                ],
+              },
+            ],
+            id: "row_0000AUXto7o218MfSZMM1q",
+          },
+          {
+            sections: [
+              {
+                id: "sec_0000AUXto7o218MfSZMM27",
+                elements: [
+                  {
+                    type: "exit_row",
+                    seat_characteristics: null,
+                    name: null,
+                    id: "ele_0000AUXto7o218MfSZMM28",
+                    disclosures: null,
+                    designator: null,
+                    available_services: [],
+                  },
+                ],
+              },
+              {
+                id: "sec_0000AUXto7o218MfSZMM2A",
+                elements: [],
+              },
+              {
+                id: "sec_0000AUXto7o218MfSZMM2B",
+                elements: [
+                  {
+                    type: "exit_row",
+                    seat_characteristics: null,
+                    name: null,
+                    id: "ele_0000AUXto7o218MfSZMM2C",
+                    disclosures: null,
+                    designator: null,
+                    available_services: [],
+                  },
+                ],
+              },
+            ],
+            id: "row_0000AUXto7o218MfSZMM26",
+          },
+          {
+            sections: [
+              {
+                id: "sec_0000AUXto7o218MfSZMM2E",
+                elements: [
+                  {
+                    type: "galley",
+                    seat_characteristics: null,
+                    name: null,
+                    id: "ele_0000AUXto7o218MfSZMM2G",
+                    disclosures: null,
+                    designator: null,
+                    available_services: [],
+                  },
+                ],
+              },
+              {
+                id: "sec_0000AUXto7o218MfSZMM2H",
+                elements: [
+                  {
+                    type: "galley",
+                    seat_characteristics: null,
+                    name: null,
+                    id: "ele_0000AUXto7o218MfSZMM2I",
+                    disclosures: null,
+                    designator: null,
+                    available_services: [],
+                  },
+                ],
+              },
+              {
+                id: "sec_0000AUXto7o218MfSZMM2J",
+                elements: [
+                  {
+                    type: "galley",
+                    seat_characteristics: null,
+                    name: null,
+                    id: "ele_0000AUXto7o218MfSZMM2K",
+                    disclosures: null,
+                    designator: null,
+                    available_services: [],
+                  },
+                ],
+              },
+            ],
+            id: "row_0000AUXto7o218MfSZMM2D",
+          },
+        ],
+        deck: 0,
+        cabin_class: "economy",
+        aisles: 2,
+      },
+    ],
+  },
+  {
+    slice_id: "pre_00002",
+    segment_id: "seg_00002",
+    id: "sea_0000AUXto7oNzoeFTfWdZw",
+    cabins: [
+      {
+        wings: null,
+        rows: [
+          {
+            sections: [
+              {
+                id: "sec_0000AUXto7oNzoeFTfWdZz",
+                elements: [
+                  {
+                    type: "seat",
+                    seat_characteristics: null,
+                    name: "Main Cabin Extra",
+                    id: "ele_0000AUXto7oNzoeFTfWda1",
+                    disclosures: [],
+                    designator: "17A",
+                    available_services: [
+                      {
+                        total_currency: "GBP",
+                        total_amount: "76.90",
+                        passenger_id: "pas_0000AUXtjPGOFpXaMEJ1KZ",
+                        id: "ase_0000AUXto7fWWlYj2BNYlU",
+                      },
+                    ],
+                  },
+                  {
+                    type: "empty",
+                    seat_characteristics: null,
+                    name: null,
+                    id: "ele_0000AUXto7oNzoeFTfWda2",
+                    disclosures: null,
+                    designator: null,
+                    available_services: [],
+                  },
+                  {
+                    type: "seat",
+                    seat_characteristics: null,
+                    name: "Main Cabin Extra",
+                    id: "ele_0000AUXto7oNzoeFTfWda3",
+                    disclosures: [],
+                    designator: "17C",
+                    available_services: [
+                      {
+                        total_currency: "GBP",
+                        total_amount: "76.90",
+                        passenger_id: "pas_0000AUXtjPGOFpXaMEJ1KZ",
+                        id: "ase_0000AUXto7fWWlYj2BNYlV",
+                      },
+                    ],
+                  },
+                ],
+              },
+              {
+                id: "sec_0000AUXto7oNzoeFTfWda4",
+                elements: [
+                  {
+                    type: "seat",
+                    seat_characteristics: null,
+                    name: "Main Cabin Extra",
+                    id: "ele_0000AUXto7oNzoeFTfWda5",
+                    disclosures: [],
+                    designator: "17D",
+                    available_services: [
+                      {
+                        total_currency: "GBP",
+                        total_amount: "76.90",
+                        passenger_id: "pas_0000AUXtjPGOFpXaMEJ1KZ",
+                        id: "ase_0000AUXto7fWWlYj2BNYlW",
+                      },
+                    ],
+                  },
+                  {
+                    type: "seat",
+                    seat_characteristics: null,
+                    name: "Main Cabin Extra",
+                    id: "ele_0000AUXto7oNzoeFTfWda6",
+                    disclosures: [],
+                    designator: "17E",
+                    available_services: [
+                      {
+                        total_currency: "GBP",
+                        total_amount: "76.90",
+                        passenger_id: "pas_0000AUXtjPGOFpXaMEJ1KZ",
+                        id: "ase_0000AUXto7fWWlYj2BNYlX",
+                      },
+                    ],
+                  },
+                  {
+                    type: "seat",
+                    seat_characteristics: null,
+                    name: "Main Cabin Extra",
+                    id: "ele_0000AUXto7oNzoeFTfWda7",
+                    disclosures: [],
+                    designator: "17G",
+                    available_services: [
+                      {
+                        total_currency: "GBP",
+                        total_amount: "76.90",
+                        passenger_id: "pas_0000AUXtjPGOFpXaMEJ1KZ",
+                        id: "ase_0000AUXto7fWWlYj2BNYlY",
+                      },
+                    ],
+                  },
+                  {
+                    type: "seat",
+                    seat_characteristics: null,
+                    name: "Main Cabin Extra",
+                    id: "ele_0000AUXto7oNzoeFTfWda8",
+                    disclosures: [],
+                    designator: "17H",
+                    available_services: [
+                      {
+                        total_currency: "GBP",
+                        total_amount: "76.90",
+                        passenger_id: "pas_0000AUXtjPGOFpXaMEJ1KZ",
+                        id: "ase_0000AUXto7fWWlYj2BNYlZ",
+                      },
+                    ],
+                  },
+                ],
+              },
+              {
+                id: "sec_0000AUXto7oNzoeFTfWda9",
+                elements: [
+                  {
+                    type: "seat",
+                    seat_characteristics: null,
+                    name: "Main Cabin Extra",
+                    id: "ele_0000AUXto7oNzoeFTfWdaA",
+                    disclosures: [],
+                    designator: "17J",
+                    available_services: [],
+                  },
+                  {
+                    type: "empty",
+                    seat_characteristics: null,
+                    name: null,
+                    id: "ele_0000AUXto7oNzoeFTfWdaB",
+                    disclosures: null,
+                    designator: null,
+                    available_services: [],
+                  },
+                  {
+                    type: "seat",
+                    seat_characteristics: null,
+                    name: "Main Cabin Extra",
+                    id: "ele_0000AUXto7oNzoeFTfWdaC",
+                    disclosures: [],
+                    designator: "17L",
+                    available_services: [],
+                  },
+                ],
+              },
+            ],
+            id: "row_0000AUXto7oNzoeFTfWdZy",
+          },
+          {
+            sections: [
+              {
+                id: "sec_0000AUXto7oNzoeFTfWdaE",
+                elements: [
+                  {
+                    type: "seat",
+                    seat_characteristics: null,
+                    name: "Main Cabin Extra",
+                    id: "ele_0000AUXto7oNzoeFTfWdaF",
+                    disclosures: [],
+                    designator: "18A",
+                    available_services: [
+                      {
+                        total_currency: "GBP",
+                        total_amount: "99.27",
+                        passenger_id: "pas_0000AUXtjPGOFpXaMEJ1KZ",
+                        id: "ase_0000AUXto7fWWlYj2BNYla",
+                      },
+                    ],
+                  },
+                  {
+                    type: "seat",
+                    seat_characteristics: null,
+                    name: "Main Cabin Extra",
+                    id: "ele_0000AUXto7oNzoeFTfWdaG",
+                    disclosures: [],
+                    designator: "18B",
+                    available_services: [
+                      {
+                        total_currency: "GBP",
+                        total_amount: "86.69",
+                        passenger_id: "pas_0000AUXtjPGOFpXaMEJ1KZ",
+                        id: "ase_0000AUXto7fWWlYj2BNYlb",
+                      },
+                    ],
+                  },
+                  {
+                    type: "seat",
+                    seat_characteristics: null,
+                    name: "Main Cabin Extra",
+                    id: "ele_0000AUXto7oNzoeFTfWdaH",
+                    disclosures: [],
+                    designator: "18C",
+                    available_services: [
+                      {
+                        total_currency: "GBP",
+                        total_amount: "99.27",
+                        passenger_id: "pas_0000AUXtjPGOFpXaMEJ1KZ",
+                        id: "ase_0000AUXto7fWWlYj2BNYlc",
+                      },
+                    ],
+                  },
+                ],
+              },
+              {
+                id: "sec_0000AUXto7oNzoeFTfWdaI",
+                elements: [
+                  {
+                    type: "seat",
+                    seat_characteristics: null,
+                    name: "Main Cabin Extra",
+                    id: "ele_0000AUXto7ojyUvpUlgv8C",
+                    disclosures: [],
+                    designator: "18D",
+                    available_services: [
+                      {
+                        total_currency: "GBP",
+                        total_amount: "99.27",
+                        passenger_id: "pas_0000AUXtjPGOFpXaMEJ1KZ",
+                        id: "ase_0000AUXto7fWWlYj2BNYld",
+                      },
+                    ],
+                  },
+                  {
+                    type: "seat",
+                    seat_characteristics: null,
+                    name: "Main Cabin Extra",
+                    id: "ele_0000AUXto7ojyUvpUlgv8D",
+                    disclosures: [],
+                    designator: "18E",
+                    available_services: [
+                      {
+                        total_currency: "GBP",
+                        total_amount: "86.69",
+                        passenger_id: "pas_0000AUXtjPGOFpXaMEJ1KZ",
+                        id: "ase_0000AUXto7fWWlYj2BNYle",
+                      },
+                    ],
+                  },
+                  {
+                    type: "seat",
+                    seat_characteristics: null,
+                    name: "Main Cabin Extra",
+                    id: "ele_0000AUXto7ojyUvpUlgv8E",
+                    disclosures: [],
+                    designator: "18G",
+                    available_services: [
+                      {
+                        total_currency: "GBP",
+                        total_amount: "86.69",
+                        passenger_id: "pas_0000AUXtjPGOFpXaMEJ1KZ",
+                        id: "ase_0000AUXto7fWWlYj2BNYlf",
+                      },
+                    ],
+                  },
+                  {
+                    type: "seat",
+                    seat_characteristics: null,
+                    name: "Main Cabin Extra",
+                    id: "ele_0000AUXto7ojyUvpUlgv8F",
+                    disclosures: [],
+                    designator: "18H",
+                    available_services: [
+                      {
+                        total_currency: "GBP",
+                        total_amount: "99.27",
+                        passenger_id: "pas_0000AUXtjPGOFpXaMEJ1KZ",
+                        id: "ase_0000AUXto7fWWlYj2BNYlg",
+                      },
+                    ],
+                  },
+                ],
+              },
+              {
+                id: "sec_0000AUXto7ojyUvpUlgv8G",
+                elements: [
+                  {
+                    type: "seat",
+                    seat_characteristics: null,
+                    name: "Main Cabin Extra",
+                    id: "ele_0000AUXto7ojyUvpUlgv8H",
+                    disclosures: [],
+                    designator: "18J",
+                    available_services: [
+                      {
+                        total_currency: "GBP",
+                        total_amount: "99.27",
+                        passenger_id: "pas_0000AUXtjPGOFpXaMEJ1KZ",
+                        id: "ase_0000AUXto7fWWlYj2BNYlh",
+                      },
+                    ],
+                  },
+                  {
+                    type: "seat",
+                    seat_characteristics: null,
+                    name: "Main Cabin Extra",
+                    id: "ele_0000AUXto7ojyUvpUlgv8I",
+                    disclosures: [],
+                    designator: "18K",
+                    available_services: [
+                      {
+                        total_currency: "GBP",
+                        total_amount: "86.69",
+                        passenger_id: "pas_0000AUXtjPGOFpXaMEJ1KZ",
+                        id: "ase_0000AUXto7fWWlYj2BNYli",
+                      },
+                    ],
+                  },
+                  {
+                    type: "seat",
+                    seat_characteristics: null,
+                    name: "Main Cabin Extra",
+                    id: "ele_0000AUXto7ojyUvpUlgv8K",
+                    disclosures: [],
+                    designator: "18L",
+                    available_services: [
+                      {
+                        total_currency: "GBP",
+                        total_amount: "99.27",
+                        passenger_id: "pas_0000AUXtjPGOFpXaMEJ1KZ",
+                        id: "ase_0000AUXto7fWWlYj2BNYlj",
+                      },
+                    ],
+                  },
+                ],
+              },
+            ],
+            id: "row_0000AUXto7oNzoeFTfWdaD",
+          },
+          {
+            sections: [
+              {
+                id: "sec_0000AUXto7ojyUvpUlgv8N",
+                elements: [
+                  {
+                    type: "seat",
+                    seat_characteristics: null,
+                    name: "Main Cabin Extra",
+                    id: "ele_0000AUXto7ojyUvpUlgv8O",
+                    disclosures: [],
+                    designator: "19A",
+                    available_services: [
+                      {
+                        total_currency: "GBP",
+                        total_amount: "99.27",
+                        passenger_id: "pas_0000AUXtjPGOFpXaMEJ1KZ",
+                        id: "ase_0000AUXto7fWWlYj2BNYlk",
+                      },
+                    ],
+                  },
+                  {
+                    type: "seat",
+                    seat_characteristics: null,
+                    name: "Main Cabin Extra",
+                    id: "ele_0000AUXto7ojyUvpUlgv8P",
+                    disclosures: [],
+                    designator: "19B",
+                    available_services: [
+                      {
+                        total_currency: "GBP",
+                        total_amount: "86.69",
+                        passenger_id: "pas_0000AUXtjPGOFpXaMEJ1KZ",
+                        id: "ase_0000AUXto7fWWlYj2BNYlm",
+                      },
+                    ],
+                  },
+                  {
+                    type: "seat",
+                    seat_characteristics: null,
+                    name: "Main Cabin Extra",
+                    id: "ele_0000AUXto7ojyUvpUlgv8Q",
+                    disclosures: [],
+                    designator: "19C",
+                    available_services: [
+                      {
+                        total_currency: "GBP",
+                        total_amount: "99.27",
+                        passenger_id: "pas_0000AUXtjPGOFpXaMEJ1KZ",
+                        id: "ase_0000AUXto7fWWlYj2BNYln",
+                      },
+                    ],
+                  },
+                ],
+              },
+              {
+                id: "sec_0000AUXto7ojyUvpUlgv8R",
+                elements: [
+                  {
+                    type: "seat",
+                    seat_characteristics: null,
+                    name: "Main Cabin Extra",
+                    id: "ele_0000AUXto7ojyUvpUlgv8S",
+                    disclosures: [],
+                    designator: "19D",
+                    available_services: [
+                      {
+                        total_currency: "GBP",
+                        total_amount: "99.27",
+                        passenger_id: "pas_0000AUXtjPGOFpXaMEJ1KZ",
+                        id: "ase_0000AUXto7fWWlYj2BNYlo",
+                      },
+                    ],
+                  },
+                  {
+                    type: "seat",
+                    seat_characteristics: null,
+                    name: "Main Cabin Extra",
+                    id: "ele_0000AUXto7ojyUvpUlgv8T",
+                    disclosures: [],
+                    designator: "19E",
+                    available_services: [
+                      {
+                        total_currency: "GBP",
+                        total_amount: "86.69",
+                        passenger_id: "pas_0000AUXtjPGOFpXaMEJ1KZ",
+                        id: "ase_0000AUXto7fWWlYj2BNYlq",
+                      },
+                    ],
+                  },
+                  {
+                    type: "seat",
+                    seat_characteristics: null,
+                    name: "Main Cabin Extra",
+                    id: "ele_0000AUXto7ojyUvpUlgv8U",
+                    disclosures: [],
+                    designator: "19G",
+                    available_services: [
+                      {
+                        total_currency: "GBP",
+                        total_amount: "86.69",
+                        passenger_id: "pas_0000AUXtjPGOFpXaMEJ1KZ",
+                        id: "ase_0000AUXto7fWWlYj2BNYlr",
+                      },
+                    ],
+                  },
+                  {
+                    type: "seat",
+                    seat_characteristics: null,
+                    name: "Main Cabin Extra",
+                    id: "ele_0000AUXto7ojyUvpUlgv8V",
+                    disclosures: [],
+                    designator: "19H",
+                    available_services: [
+                      {
+                        total_currency: "GBP",
+                        total_amount: "99.27",
+                        passenger_id: "pas_0000AUXtjPGOFpXaMEJ1KZ",
+                        id: "ase_0000AUXto7fWWlYj2BNYls",
+                      },
+                    ],
+                  },
+                ],
+              },
+              {
+                id: "sec_0000AUXto7ojyUvpUlgv8W",
+                elements: [
+                  {
+                    type: "seat",
+                    seat_characteristics: null,
+                    name: "Main Cabin Extra",
+                    id: "ele_0000AUXto7ojyUvpUlgv8X",
+                    disclosures: [],
+                    designator: "19J",
+                    available_services: [
+                      {
+                        total_currency: "GBP",
+                        total_amount: "99.27",
+                        passenger_id: "pas_0000AUXtjPGOFpXaMEJ1KZ",
+                        id: "ase_0000AUXto7fWWlYj2BNYlt",
+                      },
+                    ],
+                  },
+                  {
+                    type: "seat",
+                    seat_characteristics: null,
+                    name: "Main Cabin Extra",
+                    id: "ele_0000AUXto7ojyUvpUlgv8Y",
+                    disclosures: [],
+                    designator: "19K",
+                    available_services: [
+                      {
+                        total_currency: "GBP",
+                        total_amount: "86.69",
+                        passenger_id: "pas_0000AUXtjPGOFpXaMEJ1KZ",
+                        id: "ase_0000AUXto7fWWlYj2BNYlu",
+                      },
+                    ],
+                  },
+                  {
+                    type: "seat",
+                    seat_characteristics: null,
+                    name: "Main Cabin Extra",
+                    id: "ele_0000AUXto7ojyUvpUlgv8Z",
+                    disclosures: [],
+                    designator: "19L",
+                    available_services: [
+                      {
+                        total_currency: "GBP",
+                        total_amount: "99.27",
+                        passenger_id: "pas_0000AUXtjPGOFpXaMEJ1KZ",
+                        id: "ase_0000AUXto7fWWlYj2BNYlv",
+                      },
+                    ],
+                  },
+                ],
+              },
+            ],
+            id: "row_0000AUXto7ojyUvpUlgv8M",
+          },
+          {
+            sections: [
+              {
+                id: "sec_0000AUXto7p5xBDPVrrCgT",
+                elements: [
+                  {
+                    type: "seat",
+                    seat_characteristics: null,
+                    name: "Preferred Seats",
+                    id: "ele_0000AUXto7p5xBDPVrrCgU",
+                    disclosures: [],
+                    designator: "20A",
+                    available_services: [
+                      {
+                        total_currency: "GBP",
+                        total_amount: "65.79",
+                        passenger_id: "pas_0000AUXtjPGOFpXaMEJ1KZ",
+                        id: "ase_0000AUXto7fWWlYj2BNYlw",
+                      },
+                    ],
+                  },
+                  {
+                    type: "seat",
+                    seat_characteristics: null,
+                    name: "Preferred Seats",
+                    id: "ele_0000AUXto7p5xBDPVrrCgV",
+                    disclosures: [],
+                    designator: "20B",
+                    available_services: [
+                      {
+                        total_currency: "GBP",
+                        total_amount: "60.31",
+                        passenger_id: "pas_0000AUXtjPGOFpXaMEJ1KZ",
+                        id: "ase_0000AUXto7fWWlYj2BNYlx",
+                      },
+                    ],
+                  },
+                  {
+                    type: "seat",
+                    seat_characteristics: null,
+                    name: "Preferred Seats",
+                    id: "ele_0000AUXto7p5xBDPVrrCgW",
+                    disclosures: [],
+                    designator: "20C",
+                    available_services: [],
+                  },
+                ],
+              },
+              {
+                id: "sec_0000AUXto7p5xBDPVrrCgX",
+                elements: [
+                  {
+                    type: "seat",
+                    seat_characteristics: null,
+                    name: "Main Cabin Extra",
+                    id: "ele_0000AUXto7p5xBDPVrrCgY",
+                    disclosures: [],
+                    designator: "20D",
+                    available_services: [
+                      {
+                        total_currency: "GBP",
+                        total_amount: "73.40",
+                        passenger_id: "pas_0000AUXtjPGOFpXaMEJ1KZ",
+                        id: "ase_0000AUXto7fsVRqJ3HXqJn",
+                      },
+                    ],
+                  },
+                  {
+                    type: "seat",
+                    seat_characteristics: null,
+                    name: "Main Cabin Extra",
+                    id: "ele_0000AUXto7p5xBDPVrrCgZ",
+                    disclosures: [],
+                    designator: "20E",
+                    available_services: [
+                      {
+                        total_currency: "GBP",
+                        total_amount: "66.41",
+                        passenger_id: "pas_0000AUXtjPGOFpXaMEJ1KZ",
+                        id: "ase_0000AUXto7fsVRqJ3HXqJp",
+                      },
+                    ],
+                  },
+                  {
+                    type: "seat",
+                    seat_characteristics: null,
+                    name: "Main Cabin Extra",
+                    id: "ele_0000AUXto7p5xBDPVrrCga",
+                    disclosures: [],
+                    designator: "20G",
+                    available_services: [
+                      {
+                        total_currency: "GBP",
+                        total_amount: "66.41",
+                        passenger_id: "pas_0000AUXtjPGOFpXaMEJ1KZ",
+                        id: "ase_0000AUXto7fsVRqJ3HXqJt",
+                      },
+                    ],
+                  },
+                  {
+                    type: "seat",
+                    seat_characteristics: null,
+                    name: "Main Cabin Extra",
+                    id: "ele_0000AUXto7p5xBDPVrrCgb",
+                    disclosures: [],
+                    designator: "20H",
+                    available_services: [
+                      {
+                        total_currency: "GBP",
+                        total_amount: "73.40",
+                        passenger_id: "pas_0000AUXtjPGOFpXaMEJ1KZ",
+                        id: "ase_0000AUXto7gEU87t4Ni7s1",
+                      },
+                    ],
+                  },
+                ],
+              },
+              {
+                id: "sec_0000AUXto7p5xBDPVrrCgc",
+                elements: [
+                  {
+                    type: "seat",
+                    seat_characteristics: null,
+                    name: "Preferred Seats",
+                    id: "ele_0000AUXto7p5xBDPVrrCgd",
+                    disclosures: [],
+                    designator: "20J",
+                    available_services: [],
+                  },
+                  {
+                    type: "seat",
+                    seat_characteristics: null,
+                    name: "Standard Seats",
+                    id: "ele_0000AUXto7p5xBDPVrrCge",
+                    disclosures: [],
+                    designator: "20K",
+                    available_services: [
+                      {
+                        total_currency: "GBP",
+                        total_amount: "10.64",
+                        passenger_id: "pas_0000AUXtjPGOFpXaMEJ1KZ",
+                        id: "ase_0000AUXto7gEU87t4Ni7s2",
+                      },
+                    ],
+                  },
+                  {
+                    type: "seat",
+                    seat_characteristics: null,
+                    name: "Preferred Seats",
+                    id: "ele_0000AUXto7p5xBDPVrrCgg",
+                    disclosures: [],
+                    designator: "20L",
+                    available_services: [
+                      {
+                        total_currency: "GBP",
+                        total_amount: "65.79",
+                        passenger_id: "pas_0000AUXtjPGOFpXaMEJ1KZ",
+                        id: "ase_0000AUXto7gEU87t4Ni7s3",
+                      },
+                    ],
+                  },
+                ],
+              },
+            ],
+            id: "row_0000AUXto7ojyUvpUlgv8b",
+          },
+          {
+            sections: [
+              {
+                id: "sec_0000AUXto7p5xBDPVrrCgj",
+                elements: [
+                  {
+                    type: "seat",
+                    seat_characteristics: null,
+                    name: "Preferred Seats",
+                    id: "ele_0000AUXto7p5xBDPVrrCgk",
+                    disclosures: [],
+                    designator: "21A",
+                    available_services: [
+                      {
+                        total_currency: "GBP",
+                        total_amount: "65.79",
+                        passenger_id: "pas_0000AUXtjPGOFpXaMEJ1KZ",
+                        id: "ase_0000AUXto7gEU87t4Ni7s4",
+                      },
+                    ],
+                  },
+                  {
+                    type: "seat",
+                    seat_characteristics: null,
+                    name: "Standard Seats",
+                    id: "ele_0000AUXto7p5xBDPVrrCgl",
+                    disclosures: [],
+                    designator: "21B",
+                    available_services: [
+                      {
+                        total_currency: "GBP",
+                        total_amount: "10.64",
+                        passenger_id: "pas_0000AUXtjPGOFpXaMEJ1KZ",
+                        id: "ase_0000AUXto7gEU87t4Ni7s5",
+                      },
+                    ],
+                  },
+                  {
+                    type: "seat",
+                    seat_characteristics: null,
+                    name: "Preferred Seats",
+                    id: "ele_0000AUXto7p5xBDPVrrCgm",
+                    disclosures: [],
+                    designator: "21C",
+                    available_services: [],
+                  },
+                ],
+              },
+              {
+                id: "sec_0000AUXto7p5xBDPVrrCgn",
+                elements: [
+                  {
+                    type: "seat",
+                    seat_characteristics: null,
+                    name: "Preferred Seats",
+                    id: "ele_0000AUXto7p5xBDPVrrCgo",
+                    disclosures: [],
+                    designator: "21D",
+                    available_services: [],
+                  },
+                  {
+                    type: "seat",
+                    seat_characteristics: null,
+                    name: "Preferred Seats",
+                    id: "ele_0000AUXto7p5xBDPVrrCgp",
+                    disclosures: [],
+                    designator: "21E",
+                    available_services: [
+                      {
+                        total_currency: "GBP",
+                        total_amount: "60.31",
+                        passenger_id: "pas_0000AUXtjPGOFpXaMEJ1KZ",
+                        id: "ase_0000AUXto7gEU87t4Ni7s6",
+                      },
+                    ],
+                  },
+                  {
+                    type: "seat",
+                    seat_characteristics: null,
+                    name: "Preferred Seats",
+                    id: "ele_0000AUXto7p5xBDPVrrCgq",
+                    disclosures: [],
+                    designator: "21G",
+                    available_services: [
+                      {
+                        total_currency: "GBP",
+                        total_amount: "60.31",
+                        passenger_id: "pas_0000AUXtjPGOFpXaMEJ1KZ",
+                        id: "ase_0000AUXto7gEU87t4Ni7s7",
+                      },
+                    ],
+                  },
+                  {
+                    type: "seat",
+                    seat_characteristics: null,
+                    name: "Preferred Seats",
+                    id: "ele_0000AUXto7p5xBDPVrrCgr",
+                    disclosures: [],
+                    designator: "21H",
+                    available_services: [],
+                  },
+                ],
+              },
+              {
+                id: "sec_0000AUXto7p5xBDPVrrCgs",
+                elements: [
+                  {
+                    type: "seat",
+                    seat_characteristics: null,
+                    name: "Preferred Seats",
+                    id: "ele_0000AUXto7p5xBDPVrrCgt",
+                    disclosures: [],
+                    designator: "21J",
+                    available_services: [],
+                  },
+                  {
+                    type: "seat",
+                    seat_characteristics: null,
+                    name: "Standard Seats",
+                    id: "ele_0000AUXto7p5xBDPVrrCgu",
+                    disclosures: [],
+                    designator: "21K",
+                    available_services: [
+                      {
+                        total_currency: "GBP",
+                        total_amount: "10.64",
+                        passenger_id: "pas_0000AUXtjPGOFpXaMEJ1KZ",
+                        id: "ase_0000AUXto7gEU87t4Ni7s8",
+                      },
+                    ],
+                  },
+                  {
+                    type: "seat",
+                    seat_characteristics: null,
+                    name: "Preferred Seats",
+                    id: "ele_0000AUXto7p5xBDPVrrCgv",
+                    disclosures: [],
+                    designator: "21L",
+                    available_services: [
+                      {
+                        total_currency: "GBP",
+                        total_amount: "65.79",
+                        passenger_id: "pas_0000AUXtjPGOFpXaMEJ1KZ",
+                        id: "ase_0000AUXto7gEU87t4Ni7s9",
+                      },
+                    ],
+                  },
+                ],
+              },
+            ],
+            id: "row_0000AUXto7p5xBDPVrrCgh",
+          },
+          {
+            sections: [
+              {
+                id: "sec_0000AUXto7p5xBDPVrrCgx",
+                elements: [
+                  {
+                    type: "seat",
+                    seat_characteristics: null,
+                    name: "Preferred Seats",
+                    id: "ele_0000AUXto7p5xBDPVrrCgy",
+                    disclosures: [],
+                    designator: "22A",
+                    available_services: [
+                      {
+                        total_currency: "GBP",
+                        total_amount: "65.79",
+                        passenger_id: "pas_0000AUXtjPGOFpXaMEJ1KZ",
+                        id: "ase_0000AUXto7gEU87t4Ni7sA",
+                      },
+                    ],
+                  },
+                  {
+                    type: "seat",
+                    seat_characteristics: null,
+                    name: "Standard Seats",
+                    id: "ele_0000AUXto7p5xBDPVrrCgz",
+                    disclosures: [],
+                    designator: "22B",
+                    available_services: [
+                      {
+                        total_currency: "GBP",
+                        total_amount: "10.64",
+                        passenger_id: "pas_0000AUXtjPGOFpXaMEJ1KZ",
+                        id: "ase_0000AUXto7gEU87t4Ni7sB",
+                      },
+                    ],
+                  },
+                  {
+                    type: "seat",
+                    seat_characteristics: null,
+                    name: "Preferred Seats",
+                    id: "ele_0000AUXto7pRvrUzWy1UEi",
+                    disclosures: [],
+                    designator: "22C",
+                    available_services: [],
+                  },
+                ],
+              },
+              {
+                id: "sec_0000AUXto7pRvrUzWy1UEj",
+                elements: [
+                  {
+                    type: "seat",
+                    seat_characteristics: null,
+                    name: "Preferred Seats",
+                    id: "ele_0000AUXto7pRvrUzWy1UEk",
+                    disclosures: [],
+                    designator: "22D",
+                    available_services: [
+                      {
+                        total_currency: "GBP",
+                        total_amount: "65.79",
+                        passenger_id: "pas_0000AUXtjPGOFpXaMEJ1KZ",
+                        id: "ase_0000AUXto7gEU87t4Ni7sC",
+                      },
+                    ],
+                  },
+                  {
+                    type: "seat",
+                    seat_characteristics: null,
+                    name: "Preferred Seats",
+                    id: "ele_0000AUXto7pRvrUzWy1UEl",
+                    disclosures: [],
+                    designator: "22E",
+                    available_services: [
+                      {
+                        total_currency: "GBP",
+                        total_amount: "60.31",
+                        passenger_id: "pas_0000AUXtjPGOFpXaMEJ1KZ",
+                        id: "ase_0000AUXto7gEU87t4Ni7sD",
+                      },
+                    ],
+                  },
+                  {
+                    type: "seat",
+                    seat_characteristics: null,
+                    name: "Preferred Seats",
+                    id: "ele_0000AUXto7pRvrUzWy1UEm",
+                    disclosures: [],
+                    designator: "22G",
+                    available_services: [
+                      {
+                        total_currency: "GBP",
+                        total_amount: "60.31",
+                        passenger_id: "pas_0000AUXtjPGOFpXaMEJ1KZ",
+                        id: "ase_0000AUXto7gEU87t4Ni7sE",
+                      },
+                    ],
+                  },
+                  {
+                    type: "seat",
+                    seat_characteristics: null,
+                    name: "Preferred Seats",
+                    id: "ele_0000AUXto7pRvrUzWy1UEn",
+                    disclosures: [],
+                    designator: "22H",
+                    available_services: [
+                      {
+                        total_currency: "GBP",
+                        total_amount: "65.79",
+                        passenger_id: "pas_0000AUXtjPGOFpXaMEJ1KZ",
+                        id: "ase_0000AUXto7gEU87t4Ni7sF",
+                      },
+                    ],
+                  },
+                ],
+              },
+              {
+                id: "sec_0000AUXto7pRvrUzWy1UEo",
+                elements: [
+                  {
+                    type: "seat",
+                    seat_characteristics: null,
+                    name: "Preferred Seats",
+                    id: "ele_0000AUXto7pRvrUzWy1UEp",
+                    disclosures: [],
+                    designator: "22J",
+                    available_services: [],
+                  },
+                  {
+                    type: "seat",
+                    seat_characteristics: null,
+                    name: "Standard Seats",
+                    id: "ele_0000AUXto7pRvrUzWy1UEq",
+                    disclosures: [],
+                    designator: "22K",
+                    available_services: [
+                      {
+                        total_currency: "GBP",
+                        total_amount: "10.64",
+                        passenger_id: "pas_0000AUXtjPGOFpXaMEJ1KZ",
+                        id: "ase_0000AUXto7gEU87t4Ni7sG",
+                      },
+                    ],
+                  },
+                  {
+                    type: "seat",
+                    seat_characteristics: null,
+                    name: "Preferred Seats",
+                    id: "ele_0000AUXto7pRvrUzWy1UEr",
+                    disclosures: [],
+                    designator: "22L",
+                    available_services: [
+                      {
+                        total_currency: "GBP",
+                        total_amount: "65.79",
+                        passenger_id: "pas_0000AUXtjPGOFpXaMEJ1KZ",
+                        id: "ase_0000AUXto7gEU87t4Ni7sI",
+                      },
+                    ],
+                  },
+                ],
+              },
+            ],
+            id: "row_0000AUXto7p5xBDPVrrCgw",
+          },
+          {
+            sections: [
+              {
+                id: "sec_0000AUXto7pRvrUzWy1UEt",
+                elements: [
+                  {
+                    type: "seat",
+                    seat_characteristics: null,
+                    name: "Preferred Seats",
+                    id: "ele_0000AUXto7pRvrUzWy1UEu",
+                    disclosures: [],
+                    designator: "23A",
+                    available_services: [
+                      {
+                        total_currency: "GBP",
+                        total_amount: "65.79",
+                        passenger_id: "pas_0000AUXtjPGOFpXaMEJ1KZ",
+                        id: "ase_0000AUXto7gEU87t4Ni7sJ",
+                      },
+                    ],
+                  },
+                  {
+                    type: "seat",
+                    seat_characteristics: null,
+                    name: "Standard Seats",
+                    id: "ele_0000AUXto7pRvrUzWy1UEv",
+                    disclosures: [],
+                    designator: "23B",
+                    available_services: [
+                      {
+                        total_currency: "GBP",
+                        total_amount: "10.64",
+                        passenger_id: "pas_0000AUXtjPGOFpXaMEJ1KZ",
+                        id: "ase_0000AUXto7gEU87t4Ni7sK",
+                      },
+                    ],
+                  },
+                  {
+                    type: "seat",
+                    seat_characteristics: null,
+                    name: "Preferred Seats",
+                    id: "ele_0000AUXto7pRvrUzWy1UEw",
+                    disclosures: [],
+                    designator: "23C",
+                    available_services: [],
+                  },
+                ],
+              },
+              {
+                id: "sec_0000AUXto7pRvrUzWy1UEx",
+                elements: [
+                  {
+                    type: "seat",
+                    seat_characteristics: null,
+                    name: "Preferred Seats",
+                    id: "ele_0000AUXto7pRvrUzWy1UEy",
+                    disclosures: [],
+                    designator: "23D",
+                    available_services: [
+                      {
+                        total_currency: "GBP",
+                        total_amount: "65.79",
+                        passenger_id: "pas_0000AUXtjPGOFpXaMEJ1KZ",
+                        id: "ase_0000AUXto7gEU87t4Ni7sM",
+                      },
+                    ],
+                  },
+                  {
+                    type: "seat",
+                    seat_characteristics: null,
+                    name: "Preferred Seats",
+                    id: "ele_0000AUXto7pRvrUzWy1UEz",
+                    disclosures: [],
+                    designator: "23E",
+                    available_services: [
+                      {
+                        total_currency: "GBP",
+                        total_amount: "60.31",
+                        passenger_id: "pas_0000AUXtjPGOFpXaMEJ1KZ",
+                        id: "ase_0000AUXto7gEU87t4Ni7sN",
+                      },
+                    ],
+                  },
+                  {
+                    type: "seat",
+                    seat_characteristics: null,
+                    name: "Preferred Seats",
+                    id: "ele_0000AUXto7pRvrUzWy1UF0",
+                    disclosures: [],
+                    designator: "23G",
+                    available_services: [
+                      {
+                        total_currency: "GBP",
+                        total_amount: "60.31",
+                        passenger_id: "pas_0000AUXtjPGOFpXaMEJ1KZ",
+                        id: "ase_0000AUXto7gEU87t4Ni7sO",
+                      },
+                    ],
+                  },
+                  {
+                    type: "seat",
+                    seat_characteristics: null,
+                    name: "Preferred Seats",
+                    id: "ele_0000AUXto7pRvrUzWy1UF1",
+                    disclosures: [],
+                    designator: "23H",
+                    available_services: [
+                      {
+                        total_currency: "GBP",
+                        total_amount: "65.79",
+                        passenger_id: "pas_0000AUXtjPGOFpXaMEJ1KZ",
+                        id: "ase_0000AUXto7gaSoPT5TsPQG",
+                      },
+                    ],
+                  },
+                ],
+              },
+              {
+                id: "sec_0000AUXto7pRvrUzWy1UF2",
+                elements: [
+                  {
+                    type: "seat",
+                    seat_characteristics: null,
+                    name: "Preferred Seats",
+                    id: "ele_0000AUXto7pRvrUzWy1UF4",
+                    disclosures: [],
+                    designator: "23J",
+                    available_services: [],
+                  },
+                  {
+                    type: "seat",
+                    seat_characteristics: null,
+                    name: "Standard Seats",
+                    id: "ele_0000AUXto7pRvrUzWy1UF5",
+                    disclosures: [],
+                    designator: "23K",
+                    available_services: [
+                      {
+                        total_currency: "GBP",
+                        total_amount: "10.64",
+                        passenger_id: "pas_0000AUXtjPGOFpXaMEJ1KZ",
+                        id: "ase_0000AUXto7gaSoPT5TsPQH",
+                      },
+                    ],
+                  },
+                  {
+                    type: "seat",
+                    seat_characteristics: null,
+                    name: "Preferred Seats",
+                    id: "ele_0000AUXto7pnuXmZY4Blmy",
+                    disclosures: [],
+                    designator: "23L",
+                    available_services: [
+                      {
+                        total_currency: "GBP",
+                        total_amount: "65.79",
+                        passenger_id: "pas_0000AUXtjPGOFpXaMEJ1KZ",
+                        id: "ase_0000AUXto7gaSoPT5TsPQI",
+                      },
+                    ],
+                  },
+                ],
+              },
+            ],
+            id: "row_0000AUXto7pRvrUzWy1UEs",
+          },
+          {
+            sections: [
+              {
+                id: "sec_0000AUXto7pnuXmZY4Bln0",
+                elements: [
+                  {
+                    type: "seat",
+                    seat_characteristics: null,
+                    name: "Preferred Seats",
+                    id: "ele_0000AUXto7pnuXmZY4Bln1",
+                    disclosures: [],
+                    designator: "24A",
+                    available_services: [
+                      {
+                        total_currency: "GBP",
+                        total_amount: "65.79",
+                        passenger_id: "pas_0000AUXtjPGOFpXaMEJ1KZ",
+                        id: "ase_0000AUXto7gaSoPT5TsPQJ",
+                      },
+                    ],
+                  },
+                  {
+                    type: "seat",
+                    seat_characteristics: null,
+                    name: "Standard Seats",
+                    id: "ele_0000AUXto7pnuXmZY4Bln2",
+                    disclosures: [],
+                    designator: "24B",
+                    available_services: [
+                      {
+                        total_currency: "GBP",
+                        total_amount: "10.64",
+                        passenger_id: "pas_0000AUXtjPGOFpXaMEJ1KZ",
+                        id: "ase_0000AUXto7gaSoPT5TsPQK",
+                      },
+                    ],
+                  },
+                  {
+                    type: "seat",
+                    seat_characteristics: null,
+                    name: "Standard Seats",
+                    id: "ele_0000AUXto7pnuXmZY4Bln3",
+                    disclosures: [],
+                    designator: "24C",
+                    available_services: [],
+                  },
+                ],
+              },
+              {
+                id: "sec_0000AUXto7pnuXmZY4Bln4",
+                elements: [
+                  {
+                    type: "seat",
+                    seat_characteristics: null,
+                    name: "Preferred Seats",
+                    id: "ele_0000AUXto7pnuXmZY4Bln5",
+                    disclosures: [],
+                    designator: "24D",
+                    available_services: [
+                      {
+                        total_currency: "GBP",
+                        total_amount: "65.79",
+                        passenger_id: "pas_0000AUXtjPGOFpXaMEJ1KZ",
+                        id: "ase_0000AUXto7gaSoPT5TsPQL",
+                      },
+                    ],
+                  },
+                  {
+                    type: "seat",
+                    seat_characteristics: null,
+                    name: "Standard Seats",
+                    id: "ele_0000AUXto7pnuXmZY4Bln6",
+                    disclosures: [],
+                    designator: "24E",
+                    available_services: [
+                      {
+                        total_currency: "GBP",
+                        total_amount: "10.64",
+                        passenger_id: "pas_0000AUXtjPGOFpXaMEJ1KZ",
+                        id: "ase_0000AUXto7gaSoPT5TsPQM",
+                      },
+                    ],
+                  },
+                  {
+                    type: "seat",
+                    seat_characteristics: null,
+                    name: "Standard Seats",
+                    id: "ele_0000AUXto7pnuXmZY4Bln7",
+                    disclosures: [],
+                    designator: "24G",
+                    available_services: [
+                      {
+                        total_currency: "GBP",
+                        total_amount: "10.64",
+                        passenger_id: "pas_0000AUXtjPGOFpXaMEJ1KZ",
+                        id: "ase_0000AUXto7gaSoPT5TsPQN",
+                      },
+                    ],
+                  },
+                  {
+                    type: "seat",
+                    seat_characteristics: null,
+                    name: "Preferred Seats",
+                    id: "ele_0000AUXto7pnuXmZY4Bln8",
+                    disclosures: [],
+                    designator: "24H",
+                    available_services: [
+                      {
+                        total_currency: "GBP",
+                        total_amount: "65.79",
+                        passenger_id: "pas_0000AUXtjPGOFpXaMEJ1KZ",
+                        id: "ase_0000AUXto7gaSoPT5TsPQO",
+                      },
+                    ],
+                  },
+                ],
+              },
+              {
+                id: "sec_0000AUXto7pnuXmZY4Bln9",
+                elements: [
+                  {
+                    type: "seat",
+                    seat_characteristics: null,
+                    name: "Standard Seats",
+                    id: "ele_0000AUXto7pnuXmZY4BlnA",
+                    disclosures: [],
+                    designator: "24J",
+                    available_services: [],
+                  },
+                  {
+                    type: "seat",
+                    seat_characteristics: null,
+                    name: "Standard Seats",
+                    id: "ele_0000AUXto7pnuXmZY4BlnB",
+                    disclosures: [],
+                    designator: "24K",
+                    available_services: [
+                      {
+                        total_currency: "GBP",
+                        total_amount: "10.64",
+                        passenger_id: "pas_0000AUXtjPGOFpXaMEJ1KZ",
+                        id: "ase_0000AUXto7gaSoPT5TsPQP",
+                      },
+                    ],
+                  },
+                  {
+                    type: "seat",
+                    seat_characteristics: null,
+                    name: "Standard Seats",
+                    id: "ele_0000AUXto7pnuXmZY4BlnC",
+                    disclosures: [],
+                    designator: "24L",
+                    available_services: [
+                      {
+                        total_currency: "GBP",
+                        total_amount: "11.20",
+                        passenger_id: "pas_0000AUXtjPGOFpXaMEJ1KZ",
+                        id: "ase_0000AUXto7gaSoPT5TsPQQ",
+                      },
+                    ],
+                  },
+                ],
+              },
+            ],
+            id: "row_0000AUXto7pnuXmZY4Blmz",
+          },
+          {
+            sections: [
+              {
+                id: "sec_0000AUXto7pnuXmZY4BlnE",
+                elements: [],
+              },
+              {
+                id: "sec_0000AUXto7pnuXmZY4BlnF",
+                elements: [],
+              },
+              {
+                id: "sec_0000AUXto7pnuXmZY4BlnH",
+                elements: [
+                  {
+                    type: "lavatory",
+                    seat_characteristics: null,
+                    name: null,
+                    id: "ele_0000AUXto7pnuXmZY4BlnI",
+                    disclosures: null,
+                    designator: null,
+                    available_services: [],
+                  },
+                ],
+              },
+            ],
+            id: "row_0000AUXto7pnuXmZY4BlnD",
+          },
+          {
+            sections: [
+              {
+                id: "sec_0000AUXto7pnuXmZY4BlnL",
+                elements: [
+                  {
+                    type: "seat",
+                    seat_characteristics: null,
+                    name: "Preferred Seats",
+                    id: "ele_0000AUXto7pnuXmZY4BlnM",
+                    disclosures: [],
+                    designator: "25A",
+                    available_services: [
+                      {
+                        total_currency: "GBP",
+                        total_amount: "65.79",
+                        passenger_id: "pas_0000AUXtjPGOFpXaMEJ1KZ",
+                        id: "ase_0000AUXto7gaSoPT5TsPQR",
+                      },
+                    ],
+                  },
+                  {
+                    type: "empty",
+                    seat_characteristics: null,
+                    name: null,
+                    id: "ele_0000AUXto7pnuXmZY4BlnO",
+                    disclosures: null,
+                    designator: null,
+                    available_services: [],
+                  },
+                  {
+                    type: "seat",
+                    seat_characteristics: null,
+                    name: "Preferred Seats",
+                    id: "ele_0000AUXto7pnuXmZY4BlnP",
+                    disclosures: [],
+                    designator: "25C",
+                    available_services: [
+                      {
+                        total_currency: "GBP",
+                        total_amount: "65.79",
+                        passenger_id: "pas_0000AUXtjPGOFpXaMEJ1KZ",
+                        id: "ase_0000AUXto7gaSoPT5TsPQS",
+                      },
+                    ],
+                  },
+                ],
+              },
+              {
+                id: "sec_0000AUXto7pnuXmZY4BlnQ",
+                elements: [
+                  {
+                    type: "empty",
+                    seat_characteristics: null,
+                    name: null,
+                    id: "ele_0000AUXto7pnuXmZY4BlnR",
+                    disclosures: null,
+                    designator: null,
+                    available_services: [],
+                  },
+                  {
+                    type: "empty",
+                    seat_characteristics: null,
+                    name: null,
+                    id: "ele_0000AUXto7pnuXmZY4BlnS",
+                    disclosures: null,
+                    designator: null,
+                    available_services: [],
+                  },
+                  {
+                    type: "empty",
+                    seat_characteristics: null,
+                    name: null,
+                    id: "ele_0000AUXto7pnuXmZY4BlnT",
+                    disclosures: null,
+                    designator: null,
+                    available_services: [],
+                  },
+                  {
+                    type: "empty",
+                    seat_characteristics: null,
+                    name: null,
+                    id: "ele_0000AUXto7pnuXmZY4BlnU",
+                    disclosures: null,
+                    designator: null,
+                    available_services: [],
+                  },
+                ],
+              },
+              {
+                id: "sec_0000AUXto7pnuXmZY4BlnV",
+                elements: [
+                  {
+                    type: "empty",
+                    seat_characteristics: null,
+                    name: null,
+                    id: "ele_0000AUXto7pnuXmZY4BlnW",
+                    disclosures: null,
+                    designator: null,
+                    available_services: [],
+                  },
+                  {
+                    type: "empty",
+                    seat_characteristics: null,
+                    name: null,
+                    id: "ele_0000AUXto7pnuXmZY4BlnX",
+                    disclosures: null,
+                    designator: null,
+                    available_services: [],
+                  },
+                  {
+                    type: "lavatory",
+                    seat_characteristics: null,
+                    name: null,
+                    id: "ele_0000AUXto7pnuXmZY4BlnY",
+                    disclosures: null,
+                    designator: null,
+                    available_services: [],
+                  },
+                ],
+              },
+            ],
+            id: "row_0000AUXto7pnuXmZY4BlnK",
+          },
+          {
+            sections: [
+              {
+                id: "sec_0000AUXto7pnuXmZY4Blna",
+                elements: [
+                  {
+                    type: "lavatory",
+                    seat_characteristics: null,
+                    name: null,
+                    id: "ele_0000AUXto7pnuXmZY4Blnb",
+                    disclosures: null,
+                    designator: null,
+                    available_services: [],
+                  },
+                ],
+              },
+              {
+                id: "sec_0000AUXto7pnuXmZY4Blnc",
+                elements: [],
+              },
+              {
+                id: "sec_0000AUXto7pnuXmZY4Blnd",
+                elements: [],
+              },
+            ],
+            id: "row_0000AUXto7pnuXmZY4BlnZ",
+          },
+          {
+            sections: [
+              {
+                id: "sec_0000AUXto7pnuXmZY4Blng",
+                elements: [
+                  {
+                    type: "exit_row",
+                    seat_characteristics: null,
+                    name: null,
+                    id: "ele_0000AUXto7q9tE49ZAM3LE",
+                    disclosures: null,
+                    designator: null,
+                    available_services: [],
+                  },
+                ],
+              },
+              {
+                id: "sec_0000AUXto7q9tE49ZAM3LH",
+                elements: [],
+              },
+              {
+                id: "sec_0000AUXto7q9tE49ZAM3LI",
+                elements: [
+                  {
+                    type: "exit_row",
+                    seat_characteristics: null,
+                    name: null,
+                    id: "ele_0000AUXto7q9tE49ZAM3LJ",
+                    disclosures: null,
+                    designator: null,
+                    available_services: [],
+                  },
+                ],
+              },
+            ],
+            id: "row_0000AUXto7pnuXmZY4Blne",
+          },
+          {
+            sections: [
+              {
+                id: "sec_0000AUXto7q9tE49ZAM3LL",
+                elements: [
+                  {
+                    type: "seat",
+                    seat_characteristics: null,
+                    name: "Main Cabin Extra",
+                    id: "ele_0000AUXto7q9tE49ZAM3LM",
+                    disclosures: [],
+                    designator: "26A",
+                    available_services: [
+                      {
+                        total_currency: "GBP",
+                        total_amount: "76.90",
+                        passenger_id: "pas_0000AUXtjPGOFpXaMEJ1KZ",
+                        id: "ase_0000AUXto7gaSoPT5TsPQT",
+                      },
+                    ],
+                  },
+                  {
+                    type: "seat",
+                    seat_characteristics: null,
+                    name: "Main Cabin Extra",
+                    id: "ele_0000AUXto7q9tE49ZAM3LN",
+                    disclosures: [],
+                    designator: "26B",
+                    available_services: [
+                      {
+                        total_currency: "GBP",
+                        total_amount: "76.90",
+                        passenger_id: "pas_0000AUXtjPGOFpXaMEJ1KZ",
+                        id: "ase_0000AUXto7gaSoPT5TsPQU",
+                      },
+                    ],
+                  },
+                  {
+                    type: "seat",
+                    seat_characteristics: null,
+                    name: "Main Cabin Extra",
+                    id: "ele_0000AUXto7q9tE49ZAM3LO",
+                    disclosures: [],
+                    designator: "26C",
+                    available_services: [
+                      {
+                        total_currency: "GBP",
+                        total_amount: "76.90",
+                        passenger_id: "pas_0000AUXtjPGOFpXaMEJ1KZ",
+                        id: "ase_0000AUXto7gaSoPT5TsPQV",
+                      },
+                    ],
+                  },
+                ],
+              },
+              {
+                id: "sec_0000AUXto7q9tE49ZAM3LP",
+                elements: [
+                  {
+                    type: "seat",
+                    seat_characteristics: null,
+                    name: "Main Cabin Extra",
+                    id: "ele_0000AUXto7q9tE49ZAM3LQ",
+                    disclosures: [],
+                    designator: "26D",
+                    available_services: [
+                      {
+                        total_currency: "GBP",
+                        total_amount: "76.90",
+                        passenger_id: "pas_0000AUXtjPGOFpXaMEJ1KZ",
+                        id: "ase_0000AUXto7gaSoPT5TsPQW",
+                      },
+                    ],
+                  },
+                  {
+                    type: "seat",
+                    seat_characteristics: null,
+                    name: "Main Cabin Extra",
+                    id: "ele_0000AUXto7q9tE49ZAM3LR",
+                    disclosures: [],
+                    designator: "26E",
+                    available_services: [
+                      {
+                        total_currency: "GBP",
+                        total_amount: "76.90",
+                        passenger_id: "pas_0000AUXtjPGOFpXaMEJ1KZ",
+                        id: "ase_0000AUXto7gaSoPT5TsPQX",
+                      },
+                    ],
+                  },
+                  {
+                    type: "seat",
+                    seat_characteristics: null,
+                    name: "Main Cabin Extra",
+                    id: "ele_0000AUXto7q9tE49ZAM3LS",
+                    disclosures: [],
+                    designator: "26G",
+                    available_services: [
+                      {
+                        total_currency: "GBP",
+                        total_amount: "76.90",
+                        passenger_id: "pas_0000AUXtjPGOFpXaMEJ1KZ",
+                        id: "ase_0000AUXto7gaSoPT5TsPQY",
+                      },
+                    ],
+                  },
+                  {
+                    type: "seat",
+                    seat_characteristics: null,
+                    name: "Main Cabin Extra",
+                    id: "ele_0000AUXto7q9tE49ZAM3LT",
+                    disclosures: [],
+                    designator: "26H",
+                    available_services: [
+                      {
+                        total_currency: "GBP",
+                        total_amount: "76.90",
+                        passenger_id: "pas_0000AUXtjPGOFpXaMEJ1KZ",
+                        id: "ase_0000AUXto7gaSoPT5TsPQZ",
+                      },
+                    ],
+                  },
+                ],
+              },
+              {
+                id: "sec_0000AUXto7q9tE49ZAM3LU",
+                elements: [
+                  {
+                    type: "seat",
+                    seat_characteristics: null,
+                    name: "Main Cabin Extra",
+                    id: "ele_0000AUXto7q9tE49ZAM3LV",
+                    disclosures: [],
+                    designator: "26J",
+                    available_services: [
+                      {
+                        total_currency: "GBP",
+                        total_amount: "76.90",
+                        passenger_id: "pas_0000AUXtjPGOFpXaMEJ1KZ",
+                        id: "ase_0000AUXto7gaSoPT5TsPQa",
+                      },
+                    ],
+                  },
+                  {
+                    type: "seat",
+                    seat_characteristics: null,
+                    name: "Main Cabin Extra",
+                    id: "ele_0000AUXto7q9tE49ZAM3LW",
+                    disclosures: [],
+                    designator: "26K",
+                    available_services: [
+                      {
+                        total_currency: "GBP",
+                        total_amount: "76.90",
+                        passenger_id: "pas_0000AUXtjPGOFpXaMEJ1KZ",
+                        id: "ase_0000AUXto7gaSoPT5TsPQb",
+                      },
+                    ],
+                  },
+                  {
+                    type: "seat",
+                    seat_characteristics: null,
+                    name: "Main Cabin Extra",
+                    id: "ele_0000AUXto7q9tE49ZAM3LX",
+                    disclosures: [],
+                    designator: "26L",
+                    available_services: [
+                      {
+                        total_currency: "GBP",
+                        total_amount: "76.90",
+                        passenger_id: "pas_0000AUXtjPGOFpXaMEJ1KZ",
+                        id: "ase_0000AUXto7gaSoPT5TsPQc",
+                      },
+                    ],
+                  },
+                ],
+              },
+            ],
+            id: "row_0000AUXto7q9tE49ZAM3LK",
+          },
+          {
+            sections: [
+              {
+                id: "sec_0000AUXto7q9tE49ZAM3LZ",
+                elements: [
+                  {
+                    type: "seat",
+                    seat_characteristics: null,
+                    name: "Main Cabin Extra",
+                    id: "ele_0000AUXto7q9tE49ZAM3La",
+                    disclosures: [],
+                    designator: "27A",
+                    available_services: [
+                      {
+                        total_currency: "GBP",
+                        total_amount: "73.40",
+                        passenger_id: "pas_0000AUXtjPGOFpXaMEJ1KZ",
+                        id: "ase_0000AUXto7gaSoPT5TsPQd",
+                      },
+                    ],
+                  },
+                  {
+                    type: "seat",
+                    seat_characteristics: null,
+                    name: "Main Cabin Extra",
+                    id: "ele_0000AUXto7q9tE49ZAM3Ld",
+                    disclosures: [],
+                    designator: "27B",
+                    available_services: [
+                      {
+                        total_currency: "GBP",
+                        total_amount: "66.41",
+                        passenger_id: "pas_0000AUXtjPGOFpXaMEJ1KZ",
+                        id: "ase_0000AUXto7gaSoPT5TsPQe",
+                      },
+                    ],
+                  },
+                  {
+                    type: "seat",
+                    seat_characteristics: null,
+                    name: "Main Cabin Extra",
+                    id: "ele_0000AUXto7qrqadJbMgcRl",
+                    disclosures: [],
+                    designator: "27C",
+                    available_services: [
+                      {
+                        total_currency: "GBP",
+                        total_amount: "73.40",
+                        passenger_id: "pas_0000AUXtjPGOFpXaMEJ1KZ",
+                        id: "ase_0000AUXto7gaSoPT5TsPQf",
+                      },
+                    ],
+                  },
+                ],
+              },
+              {
+                id: "sec_0000AUXto7qrqadJbMgcRn",
+                elements: [
+                  {
+                    type: "seat",
+                    seat_characteristics: null,
+                    name: "Main Cabin Extra",
+                    id: "ele_0000AUXto7qrqadJbMgcRo",
+                    disclosures: [],
+                    designator: "27D",
+                    available_services: [
+                      {
+                        total_currency: "GBP",
+                        total_amount: "73.40",
+                        passenger_id: "pas_0000AUXtjPGOFpXaMEJ1KZ",
+                        id: "ase_0000AUXto7gaSoPT5TsPQg",
+                      },
+                    ],
+                  },
+                  {
+                    type: "seat",
+                    seat_characteristics: null,
+                    name: "Main Cabin Extra",
+                    id: "ele_0000AUXto7rDpGutcSqu01",
+                    disclosures: [],
+                    designator: "27E",
+                    available_services: [
+                      {
+                        total_currency: "GBP",
+                        total_amount: "66.41",
+                        passenger_id: "pas_0000AUXtjPGOFpXaMEJ1KZ",
+                        id: "ase_0000AUXto7gaSoPT5TsPQh",
+                      },
+                    ],
+                  },
+                  {
+                    type: "seat",
+                    seat_characteristics: null,
+                    name: "Main Cabin Extra",
+                    id: "ele_0000AUXto7rDpGutcSqu02",
+                    disclosures: [],
+                    designator: "27G",
+                    available_services: [
+                      {
+                        total_currency: "GBP",
+                        total_amount: "66.41",
+                        passenger_id: "pas_0000AUXtjPGOFpXaMEJ1KZ",
+                        id: "ase_0000AUXto7gaSoPT5TsPQi",
+                      },
+                    ],
+                  },
+                  {
+                    type: "seat",
+                    seat_characteristics: null,
+                    name: "Main Cabin Extra",
+                    id: "ele_0000AUXto7rDpGutcSqu03",
+                    disclosures: [],
+                    designator: "27H",
+                    available_services: [
+                      {
+                        total_currency: "GBP",
+                        total_amount: "73.40",
+                        passenger_id: "pas_0000AUXtjPGOFpXaMEJ1KZ",
+                        id: "ase_0000AUXto7gaSoPT5TsPQk",
+                      },
+                    ],
+                  },
+                ],
+              },
+              {
+                id: "sec_0000AUXto7rDpGutcSqu04",
+                elements: [
+                  {
+                    type: "seat",
+                    seat_characteristics: null,
+                    name: "Main Cabin Extra",
+                    id: "ele_0000AUXto7rDpGutcSqu05",
+                    disclosures: [],
+                    designator: "27J",
+                    available_services: [
+                      {
+                        total_currency: "GBP",
+                        total_amount: "73.40",
+                        passenger_id: "pas_0000AUXtjPGOFpXaMEJ1KZ",
+                        id: "ase_0000AUXto7gaSoPT5TsPQm",
+                      },
+                    ],
+                  },
+                  {
+                    type: "seat",
+                    seat_characteristics: null,
+                    name: "Main Cabin Extra",
+                    id: "ele_0000AUXto7rDpGutcSqu06",
+                    disclosures: [],
+                    designator: "27K",
+                    available_services: [
+                      {
+                        total_currency: "GBP",
+                        total_amount: "66.41",
+                        passenger_id: "pas_0000AUXtjPGOFpXaMEJ1KZ",
+                        id: "ase_0000AUXto7gaSoPT5TsPQn",
+                      },
+                    ],
+                  },
+                  {
+                    type: "seat",
+                    seat_characteristics: null,
+                    name: "Main Cabin Extra",
+                    id: "ele_0000AUXto7rDpGutcSqu07",
+                    disclosures: [],
+                    designator: "27L",
+                    available_services: [
+                      {
+                        total_currency: "GBP",
+                        total_amount: "73.40",
+                        passenger_id: "pas_0000AUXtjPGOFpXaMEJ1KZ",
+                        id: "ase_0000AUXto7gaSoPT5TsPQo",
+                      },
+                    ],
+                  },
+                ],
+              },
+            ],
+            id: "row_0000AUXto7q9tE49ZAM3LY",
+          },
+          {
+            sections: [
+              {
+                id: "sec_0000AUXto7rDpGutcSqu09",
+                elements: [
+                  {
+                    type: "seat",
+                    seat_characteristics: null,
+                    name: "Main Cabin Extra",
+                    id: "ele_0000AUXto7rDpGutcSqu0A",
+                    disclosures: [],
+                    designator: "28A",
+                    available_services: [
+                      {
+                        total_currency: "GBP",
+                        total_amount: "73.40",
+                        passenger_id: "pas_0000AUXtjPGOFpXaMEJ1KZ",
+                        id: "ase_0000AUXto7gaSoPT5TsPQp",
+                      },
+                    ],
+                  },
+                  {
+                    type: "seat",
+                    seat_characteristics: null,
+                    name: "Main Cabin Extra",
+                    id: "ele_0000AUXto7rDpGutcSqu0B",
+                    disclosures: [],
+                    designator: "28B",
+                    available_services: [
+                      {
+                        total_currency: "GBP",
+                        total_amount: "66.41",
+                        passenger_id: "pas_0000AUXtjPGOFpXaMEJ1KZ",
+                        id: "ase_0000AUXto7gaSoPT5TsPQq",
+                      },
+                    ],
+                  },
+                  {
+                    type: "seat",
+                    seat_characteristics: null,
+                    name: "Main Cabin Extra",
+                    id: "ele_0000AUXto7rDpGutcSqu0C",
+                    disclosures: [],
+                    designator: "28C",
+                    available_services: [
+                      {
+                        total_currency: "GBP",
+                        total_amount: "73.40",
+                        passenger_id: "pas_0000AUXtjPGOFpXaMEJ1KZ",
+                        id: "ase_0000AUXto7gaSoPT5TsPQr",
+                      },
+                    ],
+                  },
+                ],
+              },
+              {
+                id: "sec_0000AUXto7rDpGutcSqu0D",
+                elements: [
+                  {
+                    type: "seat",
+                    seat_characteristics: null,
+                    name: "Main Cabin Extra",
+                    id: "ele_0000AUXto7rDpGutcSqu0E",
+                    disclosures: [],
+                    designator: "28D",
+                    available_services: [
+                      {
+                        total_currency: "GBP",
+                        total_amount: "73.40",
+                        passenger_id: "pas_0000AUXtjPGOFpXaMEJ1KZ",
+                        id: "ase_0000AUXto7gaSoPT5TsPQs",
+                      },
+                    ],
+                  },
+                  {
+                    type: "seat",
+                    seat_characteristics: null,
+                    name: "Main Cabin Extra",
+                    id: "ele_0000AUXto7rDpGutcSqu0F",
+                    disclosures: [],
+                    designator: "28E",
+                    available_services: [
+                      {
+                        total_currency: "GBP",
+                        total_amount: "66.41",
+                        passenger_id: "pas_0000AUXtjPGOFpXaMEJ1KZ",
+                        id: "ase_0000AUXto7gaSoPT5TsPQt",
+                      },
+                    ],
+                  },
+                  {
+                    type: "seat",
+                    seat_characteristics: null,
+                    name: "Main Cabin Extra",
+                    id: "ele_0000AUXto7rDpGutcSqu0G",
+                    disclosures: [],
+                    designator: "28G",
+                    available_services: [
+                      {
+                        total_currency: "GBP",
+                        total_amount: "66.41",
+                        passenger_id: "pas_0000AUXtjPGOFpXaMEJ1KZ",
+                        id: "ase_0000AUXto7gaSoPT5TsPQu",
+                      },
+                    ],
+                  },
+                  {
+                    type: "seat",
+                    seat_characteristics: null,
+                    name: "Main Cabin Extra",
+                    id: "ele_0000AUXto7rDpGutcSqu0H",
+                    disclosures: [],
+                    designator: "28H",
+                    available_services: [
+                      {
+                        total_currency: "GBP",
+                        total_amount: "73.40",
+                        passenger_id: "pas_0000AUXtjPGOFpXaMEJ1KZ",
+                        id: "ase_0000AUXto7gaSoPT5TsPQv",
+                      },
+                    ],
+                  },
+                ],
+              },
+              {
+                id: "sec_0000AUXto7rDpGutcSqu0I",
+                elements: [
+                  {
+                    type: "seat",
+                    seat_characteristics: null,
+                    name: "Main Cabin Extra",
+                    id: "ele_0000AUXto7rDpGutcSqu0J",
+                    disclosures: [],
+                    designator: "28J",
+                    available_services: [
+                      {
+                        total_currency: "GBP",
+                        total_amount: "73.40",
+                        passenger_id: "pas_0000AUXtjPGOFpXaMEJ1KZ",
+                        id: "ase_0000AUXto7gaSoPT5TsPQw",
+                      },
+                    ],
+                  },
+                  {
+                    type: "seat",
+                    seat_characteristics: null,
+                    name: "Main Cabin Extra",
+                    id: "ele_0000AUXto7rDpGutcSqu0K",
+                    disclosures: [],
+                    designator: "28K",
+                    available_services: [
+                      {
+                        total_currency: "GBP",
+                        total_amount: "66.41",
+                        passenger_id: "pas_0000AUXtjPGOFpXaMEJ1KZ",
+                        id: "ase_0000AUXto7gaSoPT5TsPQx",
+                      },
+                    ],
+                  },
+                  {
+                    type: "seat",
+                    seat_characteristics: null,
+                    name: "Main Cabin Extra",
+                    id: "ele_0000AUXto7rDpGutcSqu0M",
+                    disclosures: [],
+                    designator: "28L",
+                    available_services: [
+                      {
+                        total_currency: "GBP",
+                        total_amount: "73.40",
+                        passenger_id: "pas_0000AUXtjPGOFpXaMEJ1KZ",
+                        id: "ase_0000AUXto7gaSoPT5TsPQy",
+                      },
+                    ],
+                  },
+                ],
+              },
+            ],
+            id: "row_0000AUXto7rDpGutcSqu08",
+          },
+          {
+            sections: [
+              {
+                id: "sec_0000AUXto7rDpGutcSqu0P",
+                elements: [
+                  {
+                    type: "seat",
+                    seat_characteristics: null,
+                    name: "Preferred Seats",
+                    id: "ele_0000AUXto7rDpGutcSqu0Q",
+                    disclosures: [],
+                    designator: "29A",
+                    available_services: [
+                      {
+                        total_currency: "GBP",
+                        total_amount: "65.79",
+                        passenger_id: "pas_0000AUXtjPGOFpXaMEJ1KZ",
+                        id: "ase_0000AUXto7gwRUh36a2gyW",
+                      },
+                    ],
+                  },
+                  {
+                    type: "seat",
+                    seat_characteristics: null,
+                    name: "Preferred Seats",
+                    id: "ele_0000AUXto7rDpGutcSqu0R",
+                    disclosures: [],
+                    designator: "29B",
+                    available_services: [
+                      {
+                        total_currency: "GBP",
+                        total_amount: "60.31",
+                        passenger_id: "pas_0000AUXtjPGOFpXaMEJ1KZ",
+                        id: "ase_0000AUXto7gwRUh36a2gyX",
+                      },
+                    ],
+                  },
+                  {
+                    type: "seat",
+                    seat_characteristics: null,
+                    name: "Preferred Seats",
+                    id: "ele_0000AUXto7rDpGutcSqu0S",
+                    disclosures: [],
+                    designator: "29C",
+                    available_services: [
+                      {
+                        total_currency: "GBP",
+                        total_amount: "65.79",
+                        passenger_id: "pas_0000AUXtjPGOFpXaMEJ1KZ",
+                        id: "ase_0000AUXto7gwRUh36a2gyY",
+                      },
+                    ],
+                  },
+                ],
+              },
+              {
+                id: "sec_0000AUXto7rDpGutcSqu0T",
+                elements: [
+                  {
+                    type: "seat",
+                    seat_characteristics: null,
+                    name: "Main Cabin Extra",
+                    id: "ele_0000AUXto7rDpGutcSqu0U",
+                    disclosures: [],
+                    designator: "29D",
+                    available_services: [
+                      {
+                        total_currency: "GBP",
+                        total_amount: "73.40",
+                        passenger_id: "pas_0000AUXtjPGOFpXaMEJ1KZ",
+                        id: "ase_0000AUXto7gwRUh36a2gyZ",
+                      },
+                    ],
+                  },
+                  {
+                    type: "seat",
+                    seat_characteristics: null,
+                    name: "Main Cabin Extra",
+                    id: "ele_0000AUXto7rDpGutcSqu0V",
+                    disclosures: [],
+                    designator: "29E",
+                    available_services: [
+                      {
+                        total_currency: "GBP",
+                        total_amount: "66.41",
+                        passenger_id: "pas_0000AUXtjPGOFpXaMEJ1KZ",
+                        id: "ase_0000AUXto7gwRUh36a2gya",
+                      },
+                    ],
+                  },
+                  {
+                    type: "seat",
+                    seat_characteristics: null,
+                    name: "Main Cabin Extra",
+                    id: "ele_0000AUXto7rDpGutcSqu0W",
+                    disclosures: [],
+                    designator: "29G",
+                    available_services: [
+                      {
+                        total_currency: "GBP",
+                        total_amount: "66.41",
+                        passenger_id: "pas_0000AUXtjPGOFpXaMEJ1KZ",
+                        id: "ase_0000AUXto7gwRUh36a2gyb",
+                      },
+                    ],
+                  },
+                  {
+                    type: "seat",
+                    seat_characteristics: null,
+                    name: "Main Cabin Extra",
+                    id: "ele_0000AUXto7rDpGutcSqu0X",
+                    disclosures: [],
+                    designator: "29H",
+                    available_services: [
+                      {
+                        total_currency: "GBP",
+                        total_amount: "73.40",
+                        passenger_id: "pas_0000AUXtjPGOFpXaMEJ1KZ",
+                        id: "ase_0000AUXto7gwRUh36a2gyd",
+                      },
+                    ],
+                  },
+                ],
+              },
+              {
+                id: "sec_0000AUXto7rDpGutcSqu0Y",
+                elements: [
+                  {
+                    type: "seat",
+                    seat_characteristics: null,
+                    name: "Preferred Seats",
+                    id: "ele_0000AUXto7rDpGutcSqu0Z",
+                    disclosures: [],
+                    designator: "29J",
+                    available_services: [
+                      {
+                        total_currency: "GBP",
+                        total_amount: "65.79",
+                        passenger_id: "pas_0000AUXtjPGOFpXaMEJ1KZ",
+                        id: "ase_0000AUXto7gwRUh36a2gye",
+                      },
+                    ],
+                  },
+                  {
+                    type: "seat",
+                    seat_characteristics: null,
+                    name: "Preferred Seats",
+                    id: "ele_0000AUXto7rDpGutcSqu0a",
+                    disclosures: [],
+                    designator: "29K",
+                    available_services: [
+                      {
+                        total_currency: "GBP",
+                        total_amount: "60.31",
+                        passenger_id: "pas_0000AUXtjPGOFpXaMEJ1KZ",
+                        id: "ase_0000AUXto7gwRUh36a2gyf",
+                      },
+                    ],
+                  },
+                  {
+                    type: "seat",
+                    seat_characteristics: null,
+                    name: "Preferred Seats",
+                    id: "ele_0000AUXto7rDpGutcSqu0b",
+                    disclosures: [],
+                    designator: "29L",
+                    available_services: [
+                      {
+                        total_currency: "GBP",
+                        total_amount: "65.79",
+                        passenger_id: "pas_0000AUXtjPGOFpXaMEJ1KZ",
+                        id: "ase_0000AUXto7gwRUh36a2gyg",
+                      },
+                    ],
+                  },
+                ],
+              },
+            ],
+            id: "row_0000AUXto7rDpGutcSqu0O",
+          },
+          {
+            sections: [
+              {
+                id: "sec_0000AUXto7rDpGutcSqu0d",
+                elements: [
+                  {
+                    type: "seat",
+                    seat_characteristics: null,
+                    name: "Standard Seats",
+                    id: "ele_0000AUXto7rDpGutcSqu0e",
+                    disclosures: [],
+                    designator: "30A",
+                    available_services: [
+                      {
+                        total_currency: "GBP",
+                        total_amount: "11.20",
+                        passenger_id: "pas_0000AUXtjPGOFpXaMEJ1KZ",
+                        id: "ase_0000AUXto7gwRUh36a2gyh",
+                      },
+                    ],
+                  },
+                  {
+                    type: "seat",
+                    seat_characteristics: null,
+                    name: "Standard Seats",
+                    id: "ele_0000AUXto7rZnxCTdZ1BYG",
+                    disclosures: [],
+                    designator: "30B",
+                    available_services: [
+                      {
+                        total_currency: "GBP",
+                        total_amount: "10.64",
+                        passenger_id: "pas_0000AUXtjPGOFpXaMEJ1KZ",
+                        id: "ase_0000AUXto7gwRUh36a2gyi",
+                      },
+                    ],
+                  },
+                  {
+                    type: "seat",
+                    seat_characteristics: null,
+                    name: "Standard Seats",
+                    id: "ele_0000AUXto7rZnxCTdZ1BYH",
+                    disclosures: [],
+                    designator: "30C",
+                    available_services: [
+                      {
+                        total_currency: "GBP",
+                        total_amount: "11.20",
+                        passenger_id: "pas_0000AUXtjPGOFpXaMEJ1KZ",
+                        id: "ase_0000AUXto7gwRUh36a2gyj",
+                      },
+                    ],
+                  },
+                ],
+              },
+              {
+                id: "sec_0000AUXto7rZnxCTdZ1BYI",
+                elements: [
+                  {
+                    type: "seat",
+                    seat_characteristics: null,
+                    name: "Standard Seats",
+                    id: "ele_0000AUXto7rZnxCTdZ1BYJ",
+                    disclosures: [],
+                    designator: "30D",
+                    available_services: [
+                      {
+                        total_currency: "GBP",
+                        total_amount: "11.20",
+                        passenger_id: "pas_0000AUXtjPGOFpXaMEJ1KZ",
+                        id: "ase_0000AUXto7gwRUh36a2gyk",
+                      },
+                    ],
+                  },
+                  {
+                    type: "seat",
+                    seat_characteristics: null,
+                    name: "Standard Seats",
+                    id: "ele_0000AUXto7rZnxCTdZ1BYK",
+                    disclosures: [],
+                    designator: "30E",
+                    available_services: [
+                      {
+                        total_currency: "GBP",
+                        total_amount: "10.64",
+                        passenger_id: "pas_0000AUXtjPGOFpXaMEJ1KZ",
+                        id: "ase_0000AUXto7gwRUh36a2gyl",
+                      },
+                    ],
+                  },
+                  {
+                    type: "seat",
+                    seat_characteristics: null,
+                    name: "Standard Seats",
+                    id: "ele_0000AUXto7rZnxCTdZ1BYM",
+                    disclosures: [],
+                    designator: "30G",
+                    available_services: [
+                      {
+                        total_currency: "GBP",
+                        total_amount: "10.64",
+                        passenger_id: "pas_0000AUXtjPGOFpXaMEJ1KZ",
+                        id: "ase_0000AUXto7gwRUh36a2gym",
+                      },
+                    ],
+                  },
+                  {
+                    type: "seat",
+                    seat_characteristics: null,
+                    name: "Standard Seats",
+                    id: "ele_0000AUXto7rZnxCTdZ1BYN",
+                    disclosures: [],
+                    designator: "30H",
+                    available_services: [
+                      {
+                        total_currency: "GBP",
+                        total_amount: "11.20",
+                        passenger_id: "pas_0000AUXtjPGOFpXaMEJ1KZ",
+                        id: "ase_0000AUXto7gwRUh36a2gyn",
+                      },
+                    ],
+                  },
+                ],
+              },
+              {
+                id: "sec_0000AUXto7rZnxCTdZ1BYO",
+                elements: [
+                  {
+                    type: "seat",
+                    seat_characteristics: null,
+                    name: "Standard Seats",
+                    id: "ele_0000AUXto7rZnxCTdZ1BYP",
+                    disclosures: [],
+                    designator: "30J",
+                    available_services: [
+                      {
+                        total_currency: "GBP",
+                        total_amount: "11.20",
+                        passenger_id: "pas_0000AUXtjPGOFpXaMEJ1KZ",
+                        id: "ase_0000AUXto7gwRUh36a2gyo",
+                      },
+                    ],
+                  },
+                  {
+                    type: "seat",
+                    seat_characteristics: null,
+                    name: "Standard Seats",
+                    id: "ele_0000AUXto7rZnxCTdZ1BYQ",
+                    disclosures: [],
+                    designator: "30K",
+                    available_services: [
+                      {
+                        total_currency: "GBP",
+                        total_amount: "10.64",
+                        passenger_id: "pas_0000AUXtjPGOFpXaMEJ1KZ",
+                        id: "ase_0000AUXto7gwRUh36a2gyp",
+                      },
+                    ],
+                  },
+                  {
+                    type: "seat",
+                    seat_characteristics: null,
+                    name: "Standard Seats",
+                    id: "ele_0000AUXto7rZnxCTdZ1BYR",
+                    disclosures: [],
+                    designator: "30L",
+                    available_services: [
+                      {
+                        total_currency: "GBP",
+                        total_amount: "11.20",
+                        passenger_id: "pas_0000AUXtjPGOFpXaMEJ1KZ",
+                        id: "ase_0000AUXto7gwRUh36a2gyq",
+                      },
+                    ],
+                  },
+                ],
+              },
+            ],
+            id: "row_0000AUXto7rDpGutcSqu0c",
+          },
+          {
+            sections: [
+              {
+                id: "sec_0000AUXto7rZnxCTdZ1BYT",
+                elements: [
+                  {
+                    type: "seat",
+                    seat_characteristics: null,
+                    name: "Standard Seats",
+                    id: "ele_0000AUXto7rZnxCTdZ1BYU",
+                    disclosures: [],
+                    designator: "31A",
+                    available_services: [
+                      {
+                        total_currency: "GBP",
+                        total_amount: "11.20",
+                        passenger_id: "pas_0000AUXtjPGOFpXaMEJ1KZ",
+                        id: "ase_0000AUXto7gwRUh36a2gyr",
+                      },
+                    ],
+                  },
+                  {
+                    type: "seat",
+                    seat_characteristics: null,
+                    name: "Standard Seats",
+                    id: "ele_0000AUXto7rZnxCTdZ1BYV",
+                    disclosures: [],
+                    designator: "31B",
+                    available_services: [
+                      {
+                        total_currency: "GBP",
+                        total_amount: "10.64",
+                        passenger_id: "pas_0000AUXtjPGOFpXaMEJ1KZ",
+                        id: "ase_0000AUXto7gwRUh36a2gys",
+                      },
+                    ],
+                  },
+                  {
+                    type: "seat",
+                    seat_characteristics: null,
+                    name: "Standard Seats",
+                    id: "ele_0000AUXto7rZnxCTdZ1BYa",
+                    disclosures: [],
+                    designator: "31C",
+                    available_services: [
+                      {
+                        total_currency: "GBP",
+                        total_amount: "11.20",
+                        passenger_id: "pas_0000AUXtjPGOFpXaMEJ1KZ",
+                        id: "ase_0000AUXto7gwRUh36a2gyt",
+                      },
+                    ],
+                  },
+                ],
+              },
+              {
+                id: "sec_0000AUXto7rZnxCTdZ1BYb",
+                elements: [
+                  {
+                    type: "seat",
+                    seat_characteristics: null,
+                    name: "Standard Seats",
+                    id: "ele_0000AUXto7rvmdU3efBT6W",
+                    disclosures: [],
+                    designator: "31D",
+                    available_services: [
+                      {
+                        total_currency: "GBP",
+                        total_amount: "11.20",
+                        passenger_id: "pas_0000AUXtjPGOFpXaMEJ1KZ",
+                        id: "ase_0000AUXto7gwRUh36a2gyw",
+                      },
+                    ],
+                  },
+                  {
+                    type: "seat",
+                    seat_characteristics: null,
+                    name: "Standard Seats",
+                    id: "ele_0000AUXto7rvmdU3efBT6X",
+                    disclosures: [],
+                    designator: "31E",
+                    available_services: [
+                      {
+                        total_currency: "GBP",
+                        total_amount: "10.64",
+                        passenger_id: "pas_0000AUXtjPGOFpXaMEJ1KZ",
+                        id: "ase_0000AUXto7gwRUh36a2gyx",
+                      },
+                    ],
+                  },
+                  {
+                    type: "seat",
+                    seat_characteristics: null,
+                    name: "Standard Seats",
+                    id: "ele_0000AUXto7rvmdU3efBT6Y",
+                    disclosures: [],
+                    designator: "31G",
+                    available_services: [
+                      {
+                        total_currency: "GBP",
+                        total_amount: "10.64",
+                        passenger_id: "pas_0000AUXtjPGOFpXaMEJ1KZ",
+                        id: "ase_0000AUXto7gwRUh36a2gyy",
+                      },
+                    ],
+                  },
+                  {
+                    type: "seat",
+                    seat_characteristics: null,
+                    name: "Standard Seats",
+                    id: "ele_0000AUXto7rvmdU3efBT6Z",
+                    disclosures: [],
+                    designator: "31H",
+                    available_services: [
+                      {
+                        total_currency: "GBP",
+                        total_amount: "11.20",
+                        passenger_id: "pas_0000AUXtjPGOFpXaMEJ1KZ",
+                        id: "ase_0000AUXto7gwRUh36a2gyz",
+                      },
+                    ],
+                  },
+                ],
+              },
+              {
+                id: "sec_0000AUXto7rvmdU3efBT6a",
+                elements: [
+                  {
+                    type: "seat",
+                    seat_characteristics: null,
+                    name: "Standard Seats",
+                    id: "ele_0000AUXto7rvmdU3efBT6b",
+                    disclosures: [],
+                    designator: "31J",
+                    available_services: [
+                      {
+                        total_currency: "GBP",
+                        total_amount: "11.20",
+                        passenger_id: "pas_0000AUXtjPGOFpXaMEJ1KZ",
+                        id: "ase_0000AUXto7gwRUh36a2gz0",
+                      },
+                    ],
+                  },
+                  {
+                    type: "seat",
+                    seat_characteristics: null,
+                    name: "Standard Seats",
+                    id: "ele_0000AUXto7rvmdU3efBT6d",
+                    disclosures: [],
+                    designator: "31K",
+                    available_services: [
+                      {
+                        total_currency: "GBP",
+                        total_amount: "10.64",
+                        passenger_id: "pas_0000AUXtjPGOFpXaMEJ1KZ",
+                        id: "ase_0000AUXto7gwRUh36a2gz1",
+                      },
+                    ],
+                  },
+                  {
+                    type: "seat",
+                    seat_characteristics: null,
+                    name: "Standard Seats",
+                    id: "ele_0000AUXto7rvmdU3efBT6e",
+                    disclosures: [],
+                    designator: "31L",
+                    available_services: [
+                      {
+                        total_currency: "GBP",
+                        total_amount: "11.20",
+                        passenger_id: "pas_0000AUXtjPGOFpXaMEJ1KZ",
+                        id: "ase_0000AUXto7gwRUh36a2gz2",
+                      },
+                    ],
+                  },
+                ],
+              },
+            ],
+            id: "row_0000AUXto7rZnxCTdZ1BYS",
+          },
+          {
+            sections: [
+              {
+                id: "sec_0000AUXto7rvmdU3efBT6h",
+                elements: [
+                  {
+                    type: "seat",
+                    seat_characteristics: null,
+                    name: "Standard Seats",
+                    id: "ele_0000AUXto7sHlJldflLken",
+                    disclosures: [],
+                    designator: "32A",
+                    available_services: [
+                      {
+                        total_currency: "GBP",
+                        total_amount: "11.20",
+                        passenger_id: "pas_0000AUXtjPGOFpXaMEJ1KZ",
+                        id: "ase_0000AUXto7gwRUh36a2gz4",
+                      },
+                    ],
+                  },
+                  {
+                    type: "seat",
+                    seat_characteristics: null,
+                    name: "Standard Seats",
+                    id: "ele_0000AUXto7sHlJldflLkeo",
+                    disclosures: [],
+                    designator: "32B",
+                    available_services: [
+                      {
+                        total_currency: "GBP",
+                        total_amount: "10.64",
+                        passenger_id: "pas_0000AUXtjPGOFpXaMEJ1KZ",
+                        id: "ase_0000AUXto7hIQAyd7gCyWm",
+                      },
+                    ],
+                  },
+                  {
+                    type: "seat",
+                    seat_characteristics: null,
+                    name: "Standard Seats",
+                    id: "ele_0000AUXto7sdk03DgrW2D4",
+                    disclosures: [],
+                    designator: "32C",
+                    available_services: [
+                      {
+                        total_currency: "GBP",
+                        total_amount: "11.20",
+                        passenger_id: "pas_0000AUXtjPGOFpXaMEJ1KZ",
+                        id: "ase_0000AUXto7hIQAyd7gCyWn",
+                      },
+                    ],
+                  },
+                ],
+              },
+              {
+                id: "sec_0000AUXto7sdk03DgrW2D6",
+                elements: [
+                  {
+                    type: "seat",
+                    seat_characteristics: null,
+                    name: "Standard Seats",
+                    id: "ele_0000AUXto7sdk03DgrW2D9",
+                    disclosures: [],
+                    designator: "32D",
+                    available_services: [
+                      {
+                        total_currency: "GBP",
+                        total_amount: "11.20",
+                        passenger_id: "pas_0000AUXtjPGOFpXaMEJ1KZ",
+                        id: "ase_0000AUXto7hIQAyd7gCyWo",
+                      },
+                    ],
+                  },
+                  {
+                    type: "seat",
+                    seat_characteristics: null,
+                    name: "Standard Seats",
+                    id: "ele_0000AUXto7sdk03DgrW2DC",
+                    disclosures: [],
+                    designator: "32E",
+                    available_services: [
+                      {
+                        total_currency: "GBP",
+                        total_amount: "10.64",
+                        passenger_id: "pas_0000AUXtjPGOFpXaMEJ1KZ",
+                        id: "ase_0000AUXto7hIQAyd7gCyWp",
+                      },
+                    ],
+                  },
+                  {
+                    type: "seat",
+                    seat_characteristics: null,
+                    name: "Standard Seats",
+                    id: "ele_0000AUXto7sdk03DgrW2DE",
+                    disclosures: [],
+                    designator: "32G",
+                    available_services: [
+                      {
+                        total_currency: "GBP",
+                        total_amount: "10.64",
+                        passenger_id: "pas_0000AUXtjPGOFpXaMEJ1KZ",
+                        id: "ase_0000AUXto7hIQAyd7gCyWq",
+                      },
+                    ],
+                  },
+                  {
+                    type: "seat",
+                    seat_characteristics: null,
+                    name: "Standard Seats",
+                    id: "ele_0000AUXto7sdk03DgrW2DG",
+                    disclosures: [],
+                    designator: "32H",
+                    available_services: [
+                      {
+                        total_currency: "GBP",
+                        total_amount: "11.20",
+                        passenger_id: "pas_0000AUXtjPGOFpXaMEJ1KZ",
+                        id: "ase_0000AUXto7hIQAyd7gCyWr",
+                      },
+                    ],
+                  },
+                ],
+              },
+              {
+                id: "sec_0000AUXto7szigKnhxgJlI",
+                elements: [
+                  {
+                    type: "seat",
+                    seat_characteristics: null,
+                    name: "Standard Seats",
+                    id: "ele_0000AUXto7szigKnhxgJlJ",
+                    disclosures: [],
+                    designator: "32J",
+                    available_services: [
+                      {
+                        total_currency: "GBP",
+                        total_amount: "11.20",
+                        passenger_id: "pas_0000AUXtjPGOFpXaMEJ1KZ",
+                        id: "ase_0000AUXto7hIQAyd7gCyWs",
+                      },
+                    ],
+                  },
+                  {
+                    type: "seat",
+                    seat_characteristics: null,
+                    name: "Standard Seats",
+                    id: "ele_0000AUXto7szigKnhxgJlK",
+                    disclosures: [],
+                    designator: "32K",
+                    available_services: [
+                      {
+                        total_currency: "GBP",
+                        total_amount: "10.64",
+                        passenger_id: "pas_0000AUXtjPGOFpXaMEJ1KZ",
+                        id: "ase_0000AUXto7hIQAyd7gCyWt",
+                      },
+                    ],
+                  },
+                  {
+                    type: "seat",
+                    seat_characteristics: null,
+                    name: "Standard Seats",
+                    id: "ele_0000AUXto7szigKnhxgJlL",
+                    disclosures: [],
+                    designator: "32L",
+                    available_services: [
+                      {
+                        total_currency: "GBP",
+                        total_amount: "11.20",
+                        passenger_id: "pas_0000AUXtjPGOFpXaMEJ1KZ",
+                        id: "ase_0000AUXto7hIQAyd7gCyWu",
+                      },
+                    ],
+                  },
+                ],
+              },
+            ],
+            id: "row_0000AUXto7rvmdU3efBT6g",
+          },
+          {
+            sections: [
+              {
+                id: "sec_0000AUXto7szigKnhxgJlN",
+                elements: [
+                  {
+                    type: "seat",
+                    seat_characteristics: null,
+                    name: "Standard Seats",
+                    id: "ele_0000AUXto7szigKnhxgJlO",
+                    disclosures: [],
+                    designator: "33A",
+                    available_services: [
+                      {
+                        total_currency: "GBP",
+                        total_amount: "11.20",
+                        passenger_id: "pas_0000AUXtjPGOFpXaMEJ1KZ",
+                        id: "ase_0000AUXto7hIQAyd7gCyWv",
+                      },
+                    ],
+                  },
+                  {
+                    type: "seat",
+                    seat_characteristics: null,
+                    name: "Standard Seats",
+                    id: "ele_0000AUXto7szigKnhxgJlP",
+                    disclosures: [],
+                    designator: "33B",
+                    available_services: [
+                      {
+                        total_currency: "GBP",
+                        total_amount: "10.64",
+                        passenger_id: "pas_0000AUXtjPGOFpXaMEJ1KZ",
+                        id: "ase_0000AUXto7hIQAyd7gCyWw",
+                      },
+                    ],
+                  },
+                  {
+                    type: "seat",
+                    seat_characteristics: null,
+                    name: "Standard Seats",
+                    id: "ele_0000AUXto7szigKnhxgJlQ",
+                    disclosures: [],
+                    designator: "33C",
+                    available_services: [
+                      {
+                        total_currency: "GBP",
+                        total_amount: "11.20",
+                        passenger_id: "pas_0000AUXtjPGOFpXaMEJ1KZ",
+                        id: "ase_0000AUXto7hIQAyd7gCyWx",
+                      },
+                    ],
+                  },
+                ],
+              },
+              {
+                id: "sec_0000AUXto7szigKnhxgJlR",
+                elements: [
+                  {
+                    type: "seat",
+                    seat_characteristics: null,
+                    name: "Standard Seats",
+                    id: "ele_0000AUXto7szigKnhxgJlS",
+                    disclosures: [],
+                    designator: "33D",
+                    available_services: [
+                      {
+                        total_currency: "GBP",
+                        total_amount: "11.20",
+                        passenger_id: "pas_0000AUXtjPGOFpXaMEJ1KZ",
+                        id: "ase_0000AUXto7hIQAyd7gCyWy",
+                      },
+                    ],
+                  },
+                  {
+                    type: "seat",
+                    seat_characteristics: null,
+                    name: "Standard Seats",
+                    id: "ele_0000AUXto7szigKnhxgJlT",
+                    disclosures: [],
+                    designator: "33E",
+                    available_services: [
+                      {
+                        total_currency: "GBP",
+                        total_amount: "10.64",
+                        passenger_id: "pas_0000AUXtjPGOFpXaMEJ1KZ",
+                        id: "ase_0000AUXto7hIQAyd7gCyWz",
+                      },
+                    ],
+                  },
+                  {
+                    type: "seat",
+                    seat_characteristics: null,
+                    name: "Standard Seats",
+                    id: "ele_0000AUXto7szigKnhxgJlU",
+                    disclosures: [],
+                    designator: "33G",
+                    available_services: [
+                      {
+                        total_currency: "GBP",
+                        total_amount: "10.64",
+                        passenger_id: "pas_0000AUXtjPGOFpXaMEJ1KZ",
+                        id: "ase_0000AUXto7hIQAyd7gCyX0",
+                      },
+                    ],
+                  },
+                  {
+                    type: "seat",
+                    seat_characteristics: null,
+                    name: "Standard Seats",
+                    id: "ele_0000AUXto7szigKnhxgJlV",
+                    disclosures: [],
+                    designator: "33H",
+                    available_services: [
+                      {
+                        total_currency: "GBP",
+                        total_amount: "11.20",
+                        passenger_id: "pas_0000AUXtjPGOFpXaMEJ1KZ",
+                        id: "ase_0000AUXto7hIQAyd7gCyX1",
+                      },
+                    ],
+                  },
+                ],
+              },
+              {
+                id: "sec_0000AUXto7szigKnhxgJlW",
+                elements: [
+                  {
+                    type: "seat",
+                    seat_characteristics: null,
+                    name: "Standard Seats",
+                    id: "ele_0000AUXto7szigKnhxgJlX",
+                    disclosures: [],
+                    designator: "33J",
+                    available_services: [
+                      {
+                        total_currency: "GBP",
+                        total_amount: "11.20",
+                        passenger_id: "pas_0000AUXtjPGOFpXaMEJ1KZ",
+                        id: "ase_0000AUXto7hIQAyd7gCyX2",
+                      },
+                    ],
+                  },
+                  {
+                    type: "seat",
+                    seat_characteristics: null,
+                    name: "Standard Seats",
+                    id: "ele_0000AUXto7szigKnhxgJlY",
+                    disclosures: [],
+                    designator: "33K",
+                    available_services: [
+                      {
+                        total_currency: "GBP",
+                        total_amount: "10.64",
+                        passenger_id: "pas_0000AUXtjPGOFpXaMEJ1KZ",
+                        id: "ase_0000AUXto7hIQAyd7gCyX3",
+                      },
+                    ],
+                  },
+                  {
+                    type: "seat",
+                    seat_characteristics: null,
+                    name: "Standard Seats",
+                    id: "ele_0000AUXto7tLhMcNj3qbJY",
+                    disclosures: [],
+                    designator: "33L",
+                    available_services: [
+                      {
+                        total_currency: "GBP",
+                        total_amount: "11.20",
+                        passenger_id: "pas_0000AUXtjPGOFpXaMEJ1KZ",
+                        id: "ase_0000AUXto7hIQAyd7gCyX4",
+                      },
+                    ],
+                  },
+                ],
+              },
+            ],
+            id: "row_0000AUXto7szigKnhxgJlM",
+          },
+          {
+            sections: [
+              {
+                id: "sec_0000AUXto7tLhMcNj3qbJa",
+                elements: [
+                  {
+                    type: "seat",
+                    seat_characteristics: null,
+                    name: "Standard Seats",
+                    id: "ele_0000AUXto7tLhMcNj3qbJb",
+                    disclosures: [],
+                    designator: "34A",
+                    available_services: [
+                      {
+                        total_currency: "GBP",
+                        total_amount: "11.20",
+                        passenger_id: "pas_0000AUXtjPGOFpXaMEJ1KZ",
+                        id: "ase_0000AUXto7hIQAyd7gCyX5",
+                      },
+                    ],
+                  },
+                  {
+                    type: "seat",
+                    seat_characteristics: null,
+                    name: "Standard Seats",
+                    id: "ele_0000AUXto7tLhMcNj3qbJc",
+                    disclosures: [],
+                    designator: "34B",
+                    available_services: [
+                      {
+                        total_currency: "GBP",
+                        total_amount: "10.64",
+                        passenger_id: "pas_0000AUXtjPGOFpXaMEJ1KZ",
+                        id: "ase_0000AUXto7hIQAyd7gCyX6",
+                      },
+                    ],
+                  },
+                  {
+                    type: "seat",
+                    seat_characteristics: null,
+                    name: "Standard Seats",
+                    id: "ele_0000AUXto7tLhMcNj3qbJd",
+                    disclosures: [],
+                    designator: "34C",
+                    available_services: [
+                      {
+                        total_currency: "GBP",
+                        total_amount: "11.20",
+                        passenger_id: "pas_0000AUXtjPGOFpXaMEJ1KZ",
+                        id: "ase_0000AUXto7hIQAyd7gCyX7",
+                      },
+                    ],
+                  },
+                ],
+              },
+              {
+                id: "sec_0000AUXto7tLhMcNj3qbJe",
+                elements: [
+                  {
+                    type: "seat",
+                    seat_characteristics: null,
+                    name: "Standard Seats",
+                    id: "ele_0000AUXto7tLhMcNj3qbJf",
+                    disclosures: [],
+                    designator: "34D",
+                    available_services: [
+                      {
+                        total_currency: "GBP",
+                        total_amount: "11.20",
+                        passenger_id: "pas_0000AUXtjPGOFpXaMEJ1KZ",
+                        id: "ase_0000AUXto7hIQAyd7gCyX8",
+                      },
+                    ],
+                  },
+                  {
+                    type: "seat",
+                    seat_characteristics: null,
+                    name: "Standard Seats",
+                    id: "ele_0000AUXto7tLhMcNj3qbJg",
+                    disclosures: [],
+                    designator: "34E",
+                    available_services: [
+                      {
+                        total_currency: "GBP",
+                        total_amount: "10.64",
+                        passenger_id: "pas_0000AUXtjPGOFpXaMEJ1KZ",
+                        id: "ase_0000AUXto7hIQAyd7gCyX9",
+                      },
+                    ],
+                  },
+                  {
+                    type: "seat",
+                    seat_characteristics: null,
+                    name: "Standard Seats",
+                    id: "ele_0000AUXto7tLhMcNj3qbJh",
+                    disclosures: [],
+                    designator: "34G",
+                    available_services: [
+                      {
+                        total_currency: "GBP",
+                        total_amount: "10.64",
+                        passenger_id: "pas_0000AUXtjPGOFpXaMEJ1KZ",
+                        id: "ase_0000AUXto7hIQAyd7gCyXB",
+                      },
+                    ],
+                  },
+                  {
+                    type: "seat",
+                    seat_characteristics: null,
+                    name: "Standard Seats",
+                    id: "ele_0000AUXto7tLhMcNj3qbJi",
+                    disclosures: [],
+                    designator: "34H",
+                    available_services: [
+                      {
+                        total_currency: "GBP",
+                        total_amount: "11.20",
+                        passenger_id: "pas_0000AUXtjPGOFpXaMEJ1KZ",
+                        id: "ase_0000AUXto7hIQAyd7gCyXC",
+                      },
+                    ],
+                  },
+                ],
+              },
+              {
+                id: "sec_0000AUXto7tLhMcNj3qbJj",
+                elements: [
+                  {
+                    type: "seat",
+                    seat_characteristics: null,
+                    name: "Standard Seats",
+                    id: "ele_0000AUXto7tLhMcNj3qbJk",
+                    disclosures: [],
+                    designator: "34J",
+                    available_services: [
+                      {
+                        total_currency: "GBP",
+                        total_amount: "11.20",
+                        passenger_id: "pas_0000AUXtjPGOFpXaMEJ1KZ",
+                        id: "ase_0000AUXto7hIQAyd7gCyXD",
+                      },
+                    ],
+                  },
+                  {
+                    type: "seat",
+                    seat_characteristics: null,
+                    name: "Standard Seats",
+                    id: "ele_0000AUXto7tLhMcNj3qbJl",
+                    disclosures: [],
+                    designator: "34K",
+                    available_services: [
+                      {
+                        total_currency: "GBP",
+                        total_amount: "10.64",
+                        passenger_id: "pas_0000AUXtjPGOFpXaMEJ1KZ",
+                        id: "ase_0000AUXto7hIQAyd7gCyXF",
+                      },
+                    ],
+                  },
+                  {
+                    type: "seat",
+                    seat_characteristics: null,
+                    name: "Standard Seats",
+                    id: "ele_0000AUXto7tLhMcNj3qbJn",
+                    disclosures: [],
+                    designator: "34L",
+                    available_services: [
+                      {
+                        total_currency: "GBP",
+                        total_amount: "11.20",
+                        passenger_id: "pas_0000AUXtjPGOFpXaMEJ1KZ",
+                        id: "ase_0000AUXto7hIQAyd7gCyXG",
+                      },
+                    ],
+                  },
+                ],
+              },
+            ],
+            id: "row_0000AUXto7tLhMcNj3qbJZ",
+          },
+          {
+            sections: [
+              {
+                id: "sec_0000AUXto7tLhMcNj3qbJp",
+                elements: [
+                  {
+                    type: "seat",
+                    seat_characteristics: null,
+                    name: "Standard Seats",
+                    id: "ele_0000AUXto7tLhMcNj3qbJq",
+                    disclosures: [],
+                    designator: "35A",
+                    available_services: [
+                      {
+                        total_currency: "GBP",
+                        total_amount: "11.20",
+                        passenger_id: "pas_0000AUXtjPGOFpXaMEJ1KZ",
+                        id: "ase_0000AUXto7heOrGD8mNG56",
+                      },
+                    ],
+                  },
+                  {
+                    type: "seat",
+                    seat_characteristics: null,
+                    name: "Standard Seats",
+                    id: "ele_0000AUXto7tLhMcNj3qbJr",
+                    disclosures: [],
+                    designator: "35B",
+                    available_services: [
+                      {
+                        total_currency: "GBP",
+                        total_amount: "10.64",
+                        passenger_id: "pas_0000AUXtjPGOFpXaMEJ1KZ",
+                        id: "ase_0000AUXto7heOrGD8mNG57",
+                      },
+                    ],
+                  },
+                  {
+                    type: "seat",
+                    seat_characteristics: null,
+                    name: "Standard Seats",
+                    id: "ele_0000AUXto7tLhMcNj3qbJt",
+                    disclosures: [],
+                    designator: "35C",
+                    available_services: [
+                      {
+                        total_currency: "GBP",
+                        total_amount: "11.20",
+                        passenger_id: "pas_0000AUXtjPGOFpXaMEJ1KZ",
+                        id: "ase_0000AUXto7heOrGD8mNG58",
+                      },
+                    ],
+                  },
+                ],
+              },
+              {
+                id: "sec_0000AUXto7tLhMcNj3qbJu",
+                elements: [
+                  {
+                    type: "seat",
+                    seat_characteristics: null,
+                    name: "Standard Seats",
+                    id: "ele_0000AUXto7tLhMcNj3qbJv",
+                    disclosures: [],
+                    designator: "35D",
+                    available_services: [
+                      {
+                        total_currency: "GBP",
+                        total_amount: "11.20",
+                        passenger_id: "pas_0000AUXtjPGOFpXaMEJ1KZ",
+                        id: "ase_0000AUXto7heOrGD8mNG59",
+                      },
+                    ],
+                  },
+                  {
+                    type: "seat",
+                    seat_characteristics: null,
+                    name: "Standard Seats",
+                    id: "ele_0000AUXto7tLhMcNj3qbJw",
+                    disclosures: [],
+                    designator: "35E",
+                    available_services: [
+                      {
+                        total_currency: "GBP",
+                        total_amount: "10.64",
+                        passenger_id: "pas_0000AUXtjPGOFpXaMEJ1KZ",
+                        id: "ase_0000AUXto7heOrGD8mNG5B",
+                      },
+                    ],
+                  },
+                  {
+                    type: "seat",
+                    seat_characteristics: null,
+                    name: "Standard Seats",
+                    id: "ele_0000AUXto7tLhMcNj3qbJx",
+                    disclosures: [],
+                    designator: "35G",
+                    available_services: [
+                      {
+                        total_currency: "GBP",
+                        total_amount: "10.64",
+                        passenger_id: "pas_0000AUXtjPGOFpXaMEJ1KZ",
+                        id: "ase_0000AUXto7heOrGD8mNG5C",
+                      },
+                    ],
+                  },
+                  {
+                    type: "seat",
+                    seat_characteristics: null,
+                    name: "Standard Seats",
+                    id: "ele_0000AUXto7tLhMcNj3qbJy",
+                    disclosures: [],
+                    designator: "35H",
+                    available_services: [
+                      {
+                        total_currency: "GBP",
+                        total_amount: "11.20",
+                        passenger_id: "pas_0000AUXtjPGOFpXaMEJ1KZ",
+                        id: "ase_0000AUXto7heOrGD8mNG5D",
+                      },
+                    ],
+                  },
+                ],
+              },
+              {
+                id: "sec_0000AUXto7tLhMcNj3qbJz",
+                elements: [
+                  {
+                    type: "seat",
+                    seat_characteristics: null,
+                    name: "Standard Seats",
+                    id: "ele_0000AUXto7tLhMcNj3qbK0",
+                    disclosures: [],
+                    designator: "35J",
+                    available_services: [
+                      {
+                        total_currency: "GBP",
+                        total_amount: "11.20",
+                        passenger_id: "pas_0000AUXtjPGOFpXaMEJ1KZ",
+                        id: "ase_0000AUXto7heOrGD8mNG5F",
+                      },
+                    ],
+                  },
+                  {
+                    type: "seat",
+                    seat_characteristics: null,
+                    name: "Standard Seats",
+                    id: "ele_0000AUXto7tLhMcNj3qbK1",
+                    disclosures: [],
+                    designator: "35K",
+                    available_services: [
+                      {
+                        total_currency: "GBP",
+                        total_amount: "10.64",
+                        passenger_id: "pas_0000AUXtjPGOFpXaMEJ1KZ",
+                        id: "ase_0000AUXto7heOrGD8mNG5G",
+                      },
+                    ],
+                  },
+                  {
+                    type: "seat",
+                    seat_characteristics: null,
+                    name: "Standard Seats",
+                    id: "ele_0000AUXto7tLhMcNj3qbK2",
+                    disclosures: [],
+                    designator: "35L",
+                    available_services: [
+                      {
+                        total_currency: "GBP",
+                        total_amount: "11.20",
+                        passenger_id: "pas_0000AUXtjPGOFpXaMEJ1KZ",
+                        id: "ase_0000AUXto7heOrGD8mNG5H",
+                      },
+                    ],
+                  },
+                ],
+              },
+            ],
+            id: "row_0000AUXto7tLhMcNj3qbJo",
+          },
+          {
+            sections: [
+              {
+                id: "sec_0000AUXto7tLhMcNj3qbK4",
+                elements: [
+                  {
+                    type: "seat",
+                    seat_characteristics: null,
+                    name: "Standard Seats",
+                    id: "ele_0000AUXto7tLhMcNj3qbK5",
+                    disclosures: [],
+                    designator: "36A",
+                    available_services: [
+                      {
+                        total_currency: "GBP",
+                        total_amount: "11.20",
+                        passenger_id: "pas_0000AUXtjPGOFpXaMEJ1KZ",
+                        id: "ase_0000AUXto7heOrGD8mNG5I",
+                      },
+                    ],
+                  },
+                  {
+                    type: "empty",
+                    seat_characteristics: null,
+                    name: null,
+                    id: "ele_0000AUXto7tLhMcNj3qbK7",
+                    disclosures: null,
+                    designator: null,
+                    available_services: [],
+                  },
+                  {
+                    type: "seat",
+                    seat_characteristics: null,
+                    name: "Standard Seats",
+                    id: "ele_0000AUXto7thg2txkA0sro",
+                    disclosures: [],
+                    designator: "36C",
+                    available_services: [
+                      {
+                        total_currency: "GBP",
+                        total_amount: "11.20",
+                        passenger_id: "pas_0000AUXtjPGOFpXaMEJ1KZ",
+                        id: "ase_0000AUXto7heOrGD8mNG5J",
+                      },
+                    ],
+                  },
+                ],
+              },
+              {
+                id: "sec_0000AUXto7thg2txkA0srr",
+                elements: [
+                  {
+                    type: "seat",
+                    seat_characteristics: null,
+                    name: "Standard Seats",
+                    id: "ele_0000AUXto7thg2txkA0sru",
+                    disclosures: [],
+                    designator: "36D",
+                    available_services: [
+                      {
+                        total_currency: "GBP",
+                        total_amount: "11.20",
+                        passenger_id: "pas_0000AUXtjPGOFpXaMEJ1KZ",
+                        id: "ase_0000AUXto7heOrGD8mNG5L",
+                      },
+                    ],
+                  },
+                  {
+                    type: "seat",
+                    seat_characteristics: null,
+                    name: "Standard Seats",
+                    id: "ele_0000AUXto7thg2txkA0srw",
+                    disclosures: [],
+                    designator: "36E",
+                    available_services: [
+                      {
+                        total_currency: "GBP",
+                        total_amount: "10.64",
+                        passenger_id: "pas_0000AUXtjPGOFpXaMEJ1KZ",
+                        id: "ase_0000AUXto7heOrGD8mNG5N",
+                      },
+                    ],
+                  },
+                  {
+                    type: "seat",
+                    seat_characteristics: null,
+                    name: "Standard Seats",
+                    id: "ele_0000AUXto7u3ejBXlGBAQ5",
+                    disclosures: [],
+                    designator: "36G",
+                    available_services: [
+                      {
+                        total_currency: "GBP",
+                        total_amount: "10.64",
+                        passenger_id: "pas_0000AUXtjPGOFpXaMEJ1KZ",
+                        id: "ase_0000AUXto7heOrGD8mNG5O",
+                      },
+                    ],
+                  },
+                  {
+                    type: "seat",
+                    seat_characteristics: null,
+                    name: "Standard Seats",
+                    id: "ele_0000AUXto7u3ejBXlGBAQ6",
+                    disclosures: [],
+                    designator: "36H",
+                    available_services: [
+                      {
+                        total_currency: "GBP",
+                        total_amount: "11.20",
+                        passenger_id: "pas_0000AUXtjPGOFpXaMEJ1KZ",
+                        id: "ase_0000AUXto7heOrGD8mNG5P",
+                      },
+                    ],
+                  },
+                ],
+              },
+              {
+                id: "sec_0000AUXto7u3ejBXlGBAQ7",
+                elements: [
+                  {
+                    type: "seat",
+                    seat_characteristics: null,
+                    name: "Standard Seats",
+                    id: "ele_0000AUXto7u3ejBXlGBAQ8",
+                    disclosures: [],
+                    designator: "36J",
+                    available_services: [
+                      {
+                        total_currency: "GBP",
+                        total_amount: "11.20",
+                        passenger_id: "pas_0000AUXtjPGOFpXaMEJ1KZ",
+                        id: "ase_0000AUXto7heOrGD8mNG5Q",
+                      },
+                    ],
+                  },
+                  {
+                    type: "empty",
+                    seat_characteristics: null,
+                    name: null,
+                    id: "ele_0000AUXto7u3ejBXlGBAQ9",
+                    disclosures: null,
+                    designator: null,
+                    available_services: [],
+                  },
+                  {
+                    type: "seat",
+                    seat_characteristics: null,
+                    name: "Standard Seats",
+                    id: "ele_0000AUXto7u3ejBXlGBAQA",
+                    disclosures: [],
+                    designator: "36L",
+                    available_services: [
+                      {
+                        total_currency: "GBP",
+                        total_amount: "11.20",
+                        passenger_id: "pas_0000AUXtjPGOFpXaMEJ1KZ",
+                        id: "ase_0000AUXto7heOrGD8mNG5S",
+                      },
+                    ],
+                  },
+                ],
+              },
+            ],
+            id: "row_0000AUXto7tLhMcNj3qbK3",
+          },
+          {
+            sections: [
+              {
+                id: "sec_0000AUXto7u3ejBXlGBAQC",
+                elements: [
+                  {
+                    type: "seat",
+                    seat_characteristics: null,
+                    name: "Standard Seats",
+                    id: "ele_0000AUXto7u3ejBXlGBAQD",
+                    disclosures: [],
+                    designator: "37A",
+                    available_services: [
+                      {
+                        total_currency: "GBP",
+                        total_amount: "11.20",
+                        passenger_id: "pas_0000AUXtjPGOFpXaMEJ1KZ",
+                        id: "ase_0000AUXto7i0NXXn9sXXdI",
+                      },
+                    ],
+                  },
+                  {
+                    type: "empty",
+                    seat_characteristics: null,
+                    name: null,
+                    id: "ele_0000AUXto7u3ejBXlGBAQE",
+                    disclosures: null,
+                    designator: null,
+                    available_services: [],
+                  },
+                  {
+                    type: "seat",
+                    seat_characteristics: null,
+                    name: "Standard Seats",
+                    id: "ele_0000AUXto7u3ejBXlGBAQG",
+                    disclosures: [],
+                    designator: "37C",
+                    available_services: [
+                      {
+                        total_currency: "GBP",
+                        total_amount: "11.20",
+                        passenger_id: "pas_0000AUXtjPGOFpXaMEJ1KZ",
+                        id: "ase_0000AUXto7i0NXXn9sXXdJ",
+                      },
+                    ],
+                  },
+                ],
+              },
+              {
+                id: "sec_0000AUXto7uPdPT7mMLRyK",
+                elements: [
+                  {
+                    type: "seat",
+                    seat_characteristics: null,
+                    name: "Standard Seats",
+                    id: "ele_0000AUXto7uPdPT7mMLRyM",
+                    disclosures: [],
+                    designator: "37D",
+                    available_services: [
+                      {
+                        total_currency: "GBP",
+                        total_amount: "11.20",
+                        passenger_id: "pas_0000AUXtjPGOFpXaMEJ1KZ",
+                        id: "ase_0000AUXto7i0NXXn9sXXdK",
+                      },
+                    ],
+                  },
+                  {
+                    type: "seat",
+                    seat_characteristics: null,
+                    name: "Standard Seats",
+                    id: "ele_0000AUXto7uPdPT7mMLRyN",
+                    disclosures: [],
+                    designator: "37E",
+                    available_services: [
+                      {
+                        total_currency: "GBP",
+                        total_amount: "10.64",
+                        passenger_id: "pas_0000AUXtjPGOFpXaMEJ1KZ",
+                        id: "ase_0000AUXto7i0NXXn9sXXdL",
+                      },
+                    ],
+                  },
+                  {
+                    type: "seat",
+                    seat_characteristics: null,
+                    name: "Standard Seats",
+                    id: "ele_0000AUXto7uPdPT7mMLRyP",
+                    disclosures: [],
+                    designator: "37G",
+                    available_services: [
+                      {
+                        total_currency: "GBP",
+                        total_amount: "10.64",
+                        passenger_id: "pas_0000AUXtjPGOFpXaMEJ1KZ",
+                        id: "ase_0000AUXto7i0NXXn9sXXdM",
+                      },
+                    ],
+                  },
+                  {
+                    type: "seat",
+                    seat_characteristics: null,
+                    name: "Standard Seats",
+                    id: "ele_0000AUXto7uPdPT7mMLRyR",
+                    disclosures: [],
+                    designator: "37H",
+                    available_services: [
+                      {
+                        total_currency: "GBP",
+                        total_amount: "11.20",
+                        passenger_id: "pas_0000AUXtjPGOFpXaMEJ1KZ",
+                        id: "ase_0000AUXto7i0NXXn9sXXdN",
+                      },
+                    ],
+                  },
+                ],
+              },
+              {
+                id: "sec_0000AUXto7uPdPT7mMLRyS",
+                elements: [
+                  {
+                    type: "seat",
+                    seat_characteristics: null,
+                    name: "Standard Seats",
+                    id: "ele_0000AUXto7uPdPT7mMLRyT",
+                    disclosures: [],
+                    designator: "37J",
+                    available_services: [
+                      {
+                        total_currency: "GBP",
+                        total_amount: "11.20",
+                        passenger_id: "pas_0000AUXtjPGOFpXaMEJ1KZ",
+                        id: "ase_0000AUXto7i0NXXn9sXXdO",
+                      },
+                    ],
+                  },
+                  {
+                    type: "empty",
+                    seat_characteristics: null,
+                    name: null,
+                    id: "ele_0000AUXto7ulc5khnSVjWb",
+                    disclosures: null,
+                    designator: null,
+                    available_services: [],
+                  },
+                  {
+                    type: "seat",
+                    seat_characteristics: null,
+                    name: "Standard Seats",
+                    id: "ele_0000AUXto7ulc5khnSVjWc",
+                    disclosures: [],
+                    designator: "37L",
+                    available_services: [
+                      {
+                        total_currency: "GBP",
+                        total_amount: "11.20",
+                        passenger_id: "pas_0000AUXtjPGOFpXaMEJ1KZ",
+                        id: "ase_0000AUXto7i0NXXn9sXXdP",
+                      },
+                    ],
+                  },
+                ],
+              },
+            ],
+            id: "row_0000AUXto7u3ejBXlGBAQB",
+          },
+          {
+            sections: [
+              {
+                id: "sec_0000AUXto7ulc5khnSVjWe",
+                elements: [
+                  {
+                    type: "seat",
+                    seat_characteristics: null,
+                    name: "Standard Seats",
+                    id: "ele_0000AUXto7ulc5khnSVjWg",
+                    disclosures: [],
+                    designator: "38A",
+                    available_services: [
+                      {
+                        total_currency: "GBP",
+                        total_amount: "11.20",
+                        passenger_id: "pas_0000AUXtjPGOFpXaMEJ1KZ",
+                        id: "ase_0000AUXto7i0NXXn9sXXdQ",
+                      },
+                    ],
+                  },
+                  {
+                    type: "empty",
+                    seat_characteristics: null,
+                    name: null,
+                    id: "ele_0000AUXto7ulc5khnSVjWh",
+                    disclosures: null,
+                    designator: null,
+                    available_services: [],
+                  },
+                  {
+                    type: "seat",
+                    seat_characteristics: null,
+                    name: "Standard Seats",
+                    id: "ele_0000AUXto7ulc5khnSVjWi",
+                    disclosures: [],
+                    designator: "38C",
+                    available_services: [
+                      {
+                        total_currency: "GBP",
+                        total_amount: "11.20",
+                        passenger_id: "pas_0000AUXtjPGOFpXaMEJ1KZ",
+                        id: "ase_0000AUXto7i0NXXn9sXXdR",
+                      },
+                    ],
+                  },
+                ],
+              },
+              {
+                id: "sec_0000AUXto7ulc5khnSVjWj",
+                elements: [
+                  {
+                    type: "seat",
+                    seat_characteristics: null,
+                    name: "Standard Seats",
+                    id: "ele_0000AUXto7ulc5khnSVjWk",
+                    disclosures: [],
+                    designator: "38D",
+                    available_services: [
+                      {
+                        total_currency: "GBP",
+                        total_amount: "11.20",
+                        passenger_id: "pas_0000AUXtjPGOFpXaMEJ1KZ",
+                        id: "ase_0000AUXto7i0NXXn9sXXdS",
+                      },
+                    ],
+                  },
+                  {
+                    type: "seat",
+                    seat_characteristics: null,
+                    name: "Standard Seats",
+                    id: "ele_0000AUXto7ulc5khnSVjWl",
+                    disclosures: [],
+                    designator: "38E",
+                    available_services: [
+                      {
+                        total_currency: "GBP",
+                        total_amount: "10.64",
+                        passenger_id: "pas_0000AUXtjPGOFpXaMEJ1KZ",
+                        id: "ase_0000AUXto7i0NXXn9sXXdT",
+                      },
+                    ],
+                  },
+                  {
+                    type: "seat",
+                    seat_characteristics: null,
+                    name: "Standard Seats",
+                    id: "ele_0000AUXto7ulc5khnSVjWm",
+                    disclosures: [],
+                    designator: "38G",
+                    available_services: [
+                      {
+                        total_currency: "GBP",
+                        total_amount: "10.64",
+                        passenger_id: "pas_0000AUXtjPGOFpXaMEJ1KZ",
+                        id: "ase_0000AUXto7i0NXXn9sXXdU",
+                      },
+                    ],
+                  },
+                  {
+                    type: "seat",
+                    seat_characteristics: null,
+                    name: "Standard Seats",
+                    id: "ele_0000AUXto7ulc5khnSVjWn",
+                    disclosures: [],
+                    designator: "38H",
+                    available_services: [
+                      {
+                        total_currency: "GBP",
+                        total_amount: "11.20",
+                        passenger_id: "pas_0000AUXtjPGOFpXaMEJ1KZ",
+                        id: "ase_0000AUXto7i0NXXn9sXXdV",
+                      },
+                    ],
+                  },
+                ],
+              },
+              {
+                id: "sec_0000AUXto7ulc5khnSVjWo",
+                elements: [
+                  {
+                    type: "seat",
+                    seat_characteristics: null,
+                    name: "Standard Seats",
+                    id: "ele_0000AUXto7ulc5khnSVjWp",
+                    disclosures: [],
+                    designator: "38J",
+                    available_services: [
+                      {
+                        total_currency: "GBP",
+                        total_amount: "11.20",
+                        passenger_id: "pas_0000AUXtjPGOFpXaMEJ1KZ",
+                        id: "ase_0000AUXto7i0NXXn9sXXdW",
+                      },
+                    ],
+                  },
+                  {
+                    type: "empty",
+                    seat_characteristics: null,
+                    name: null,
+                    id: "ele_0000AUXto7ulc5khnSVjWq",
+                    disclosures: null,
+                    designator: null,
+                    available_services: [],
+                  },
+                  {
+                    type: "seat",
+                    seat_characteristics: null,
+                    name: "Standard Seats",
+                    id: "ele_0000AUXto7ulc5khnSVjWr",
+                    disclosures: [],
+                    designator: "38L",
+                    available_services: [
+                      {
+                        total_currency: "GBP",
+                        total_amount: "11.20",
+                        passenger_id: "pas_0000AUXtjPGOFpXaMEJ1KZ",
+                        id: "ase_0000AUXto7i0NXXn9sXXdX",
+                      },
+                    ],
+                  },
+                ],
+              },
+            ],
+            id: "row_0000AUXto7ulc5khnSVjWd",
+          },
+          {
+            sections: [
+              {
+                id: "sec_0000AUXto7ulc5khnSVjWt",
+                elements: [
+                  {
+                    type: "lavatory",
+                    seat_characteristics: null,
+                    name: null,
+                    id: "ele_0000AUXto7ulc5khnSVjWu",
+                    disclosures: null,
+                    designator: null,
+                    available_services: [],
+                  },
+                  {
+                    type: "empty",
+                    seat_characteristics: null,
+                    name: null,
+                    id: "ele_0000AUXto7ulc5khnSVjWv",
+                    disclosures: null,
+                    designator: null,
+                    available_services: [],
+                  },
+                  {
+                    type: "empty",
+                    seat_characteristics: null,
+                    name: null,
+                    id: "ele_0000AUXto7ulc5khnSVjWw",
+                    disclosures: null,
+                    designator: null,
+                    available_services: [],
+                  },
+                ],
+              },
+              {
+                id: "sec_0000AUXto7ulc5khnSVjWx",
+                elements: [
+                  {
+                    type: "seat",
+                    seat_characteristics: null,
+                    name: "Standard Seats",
+                    id: "ele_0000AUXto7ulc5khnSVjWy",
+                    disclosures: [],
+                    designator: "39D",
+                    available_services: [],
+                  },
+                  {
+                    type: "seat",
+                    seat_characteristics: null,
+                    name: "Standard Seats",
+                    id: "ele_0000AUXto7ulc5khnSVjWz",
+                    disclosures: [],
+                    designator: "39E",
+                    available_services: [],
+                  },
+                  {
+                    type: "seat",
+                    seat_characteristics: null,
+                    name: "Standard Seats",
+                    id: "ele_0000AUXto7ulc5khnSVjX0",
+                    disclosures: [],
+                    designator: "39G",
+                    available_services: [],
+                  },
+                  {
+                    type: "seat",
+                    seat_characteristics: null,
+                    name: "Standard Seats",
+                    id: "ele_0000AUXto7ulc5khnSVjX1",
+                    disclosures: [],
+                    designator: "39H",
+                    available_services: [],
+                  },
+                ],
+              },
+              {
+                id: "sec_0000AUXto7ulc5khnSVjX2",
+                elements: [
+                  {
+                    type: "empty",
+                    seat_characteristics: null,
+                    name: null,
+                    id: "ele_0000AUXto7ulc5khnSVjX3",
+                    disclosures: null,
+                    designator: null,
+                    available_services: [],
+                  },
+                  {
+                    type: "empty",
+                    seat_characteristics: null,
+                    name: null,
+                    id: "ele_0000AUXto7ulc5khnSVjX4",
+                    disclosures: null,
+                    designator: null,
+                    available_services: [],
+                  },
+                  {
+                    type: "lavatory",
+                    seat_characteristics: null,
+                    name: null,
+                    id: "ele_0000AUXto7ulc5khnSVjX5",
+                    disclosures: null,
+                    designator: null,
+                    available_services: [],
+                  },
+                ],
+              },
+            ],
+            id: "row_0000AUXto7ulc5khnSVjWs",
+          },
+          {
+            sections: [
+              {
+                id: "sec_0000AUXto7ulc5khnSVjX8",
+                elements: [
+                  {
+                    type: "empty",
+                    seat_characteristics: null,
+                    name: null,
+                    id: "ele_0000AUXto7ulc5khnSVjX9",
+                    disclosures: null,
+                    designator: null,
+                    available_services: [],
+                  },
+                  {
+                    type: "empty",
+                    seat_characteristics: null,
+                    name: null,
+                    id: "ele_0000AUXto7ulc5khnSVjXA",
+                    disclosures: null,
+                    designator: null,
+                    available_services: [],
+                  },
+                  {
+                    type: "empty",
+                    seat_characteristics: null,
+                    name: null,
+                    id: "ele_0000AUXto7ulc5khnSVjXB",
+                    disclosures: null,
+                    designator: null,
+                    available_services: [],
+                  },
+                ],
+              },
+              {
+                id: "sec_0000AUXto7ulc5khnSVjXC",
+                elements: [
+                  {
+                    type: "seat",
+                    seat_characteristics: null,
+                    name: "Standard Seats",
+                    id: "ele_0000AUXto7ulc5khnSVjXE",
+                    disclosures: [],
+                    designator: "40D",
+                    available_services: [],
+                  },
+                  {
+                    type: "seat",
+                    seat_characteristics: null,
+                    name: "Standard Seats",
+                    id: "ele_0000AUXto7v7am2HoYg14q",
+                    disclosures: [],
+                    designator: "40E",
+                    available_services: [],
+                  },
+                  {
+                    type: "seat",
+                    seat_characteristics: null,
+                    name: "Standard Seats",
+                    id: "ele_0000AUXto7v7am2HoYg14s",
+                    disclosures: [],
+                    designator: "40G",
+                    available_services: [],
+                  },
+                  {
+                    type: "seat",
+                    seat_characteristics: null,
+                    name: "Standard Seats",
+                    id: "ele_0000AUXto7v7am2HoYg14t",
+                    disclosures: [],
+                    designator: "40H",
+                    available_services: [],
+                  },
+                ],
+              },
+              {
+                id: "sec_0000AUXto7v7am2HoYg14v",
+                elements: [
+                  {
+                    type: "empty",
+                    seat_characteristics: null,
+                    name: null,
+                    id: "ele_0000AUXto7v7am2HoYg14w",
+                    disclosures: null,
+                    designator: null,
+                    available_services: [],
+                  },
+                  {
+                    type: "empty",
+                    seat_characteristics: null,
+                    name: null,
+                    id: "ele_0000AUXto7v7am2HoYg14x",
+                    disclosures: null,
+                    designator: null,
+                    available_services: [],
+                  },
+                  {
+                    type: "empty",
+                    seat_characteristics: null,
+                    name: null,
+                    id: "ele_0000AUXto7v7am2HoYg14y",
+                    disclosures: null,
+                    designator: null,
+                    available_services: [],
+                  },
+                ],
+              },
+            ],
+            id: "row_0000AUXto7ulc5khnSVjX7",
+          },
+          {
+            sections: [
+              {
+                id: "sec_0000AUXto7v7am2HoYg150",
+                elements: [
+                  {
+                    type: "exit_row",
+                    seat_characteristics: null,
+                    name: null,
+                    id: "ele_0000AUXto7v7am2HoYg152",
+                    disclosures: null,
+                    designator: null,
+                    available_services: [],
+                  },
+                ],
+              },
+              {
+                id: "sec_0000AUXto7v7am2HoYg154",
+                elements: [],
+              },
+              {
+                id: "sec_0000AUXto7v7am2HoYg155",
+                elements: [
+                  {
+                    type: "exit_row",
+                    seat_characteristics: null,
+                    name: null,
+                    id: "ele_0000AUXto7v7am2HoYg156",
+                    disclosures: null,
+                    designator: null,
+                    available_services: [],
+                  },
+                ],
+              },
+            ],
+            id: "row_0000AUXto7v7am2HoYg14z",
+          },
+          {
+            sections: [
+              {
+                id: "sec_0000AUXto7v7am2HoYg158",
+                elements: [
+                  {
+                    type: "galley",
+                    seat_characteristics: null,
+                    name: null,
+                    id: "ele_0000AUXto7v7am2HoYg159",
+                    disclosures: null,
+                    designator: null,
+                    available_services: [],
+                  },
+                ],
+              },
+              {
+                id: "sec_0000AUXto7v7am2HoYg15B",
+                elements: [
+                  {
+                    type: "galley",
+                    seat_characteristics: null,
+                    name: null,
+                    id: "ele_0000AUXto7v7am2HoYg15C",
+                    disclosures: null,
+                    designator: null,
+                    available_services: [],
+                  },
+                ],
+              },
+              {
+                id: "sec_0000AUXto7v7am2HoYg15D",
+                elements: [
+                  {
+                    type: "galley",
+                    seat_characteristics: null,
+                    name: null,
+                    id: "ele_0000AUXto7vTZSJrpeqId6",
+                    disclosures: null,
+                    designator: null,
+                    available_services: [],
+                  },
+                ],
+              },
+            ],
+            id: "row_0000AUXto7v7am2HoYg157",
+          },
+        ],
+        deck: 0,
+        cabin_class: "economy",
+        aisles: 2,
+      },
+    ],
+  },
+];

--- a/src/lib/retrieveSeatMaps.ts
+++ b/src/lib/retrieveSeatMaps.ts
@@ -2,12 +2,12 @@ import { SeatMap } from "src/types/SeatMap";
 import { captureErrorInSentry } from "./captureErrorInSentry";
 import { fetchFromMockSeatMaps } from "./fetchFromMocks";
 import { isMockOfferId } from "./isMockOfferId";
-import { retrieveSeatMapFromDuffelAPI } from "./retrieveSeatMapFromDuffelAPI";
+import { retrieveSeatMapsFromDuffelAPI } from "./retrieveSeatMapsFromDuffelAPI";
 
-export async function retrieveSeatMap(
+export async function retrieveSeatMaps(
   offer_id: string,
   client_key: string,
-  onSeatMapReady: (seatMap: SeatMap) => void,
+  onSeatMapReady: (seatMaps: SeatMap[]) => void,
   onError: (error: string) => void,
   setIsLoading: (isLoading: boolean) => void
 ) {
@@ -28,7 +28,7 @@ export async function retrieveSeatMap(
   }
 
   try {
-    const data = await retrieveSeatMapFromDuffelAPI(offer_id, client_key);
+    const data = await retrieveSeatMapsFromDuffelAPI(offer_id, client_key);
     onSeatMapReady(data);
   } catch (error) {
     let message = "An unknown error occurred while retrieving the offer.";

--- a/src/lib/retrieveSeatMapsFromDuffelAPI.ts
+++ b/src/lib/retrieveSeatMapsFromDuffelAPI.ts
@@ -1,6 +1,6 @@
 import { fetchFromDuffelAPI } from "./fetchFromDuffelAPI";
 
-export async function retrieveSeatMapFromDuffelAPI(
+export async function retrieveSeatMapsFromDuffelAPI(
   offer_id: string,
   client_key: string
 ) {

--- a/src/lib/useSeatSelectionContext.tsx
+++ b/src/lib/useSeatSelectionContext.tsx
@@ -1,0 +1,83 @@
+import { createContext, useContext } from "react";
+import {
+  SeatMap,
+  SeatMapCabinRowSectionAvailableService,
+  SeatMapCabinRowSectionElementSeat,
+} from "src/types/SeatMap";
+import { Offer } from "src/types/Offer";
+
+export const sizes = {
+  default: {
+    element: 32,
+    icon: 24,
+    spacing: 8,
+  },
+  small: {
+    element: 26,
+    icon: 16,
+    spacing: 6,
+  },
+};
+
+export type Size = keyof typeof sizes;
+
+const noop = () => ({});
+
+export interface SeatSelectionPassenger {
+  id: string;
+  name?: string | null;
+}
+
+export type SeatSelectionContextInterface = {
+  [segmentId: string]: SeatSelectionForSegment;
+};
+
+export type SeatSelectionForSegment = {
+  [passengerId: string]: SeatInformation | null;
+};
+export type SeatInformation = {
+  designator: string;
+  service: SeatMapCabinRowSectionAvailableService;
+};
+
+export interface CurrentSeat {
+  seat: SeatMapCabinRowSectionElementSeat | null;
+  service: SeatMapCabinRowSectionAvailableService | undefined;
+}
+
+export interface ExtendedSeatInfo {
+  segment: string;
+  seat: SeatMapCabinRowSectionElementSeat;
+  service: SeatMapCabinRowSectionAvailableService;
+}
+
+export interface SeatSelectionContextValue {
+  offer: Offer;
+  seatMaps: SeatMap[];
+  seatSelection: SeatSelectionContextInterface;
+  size: Size;
+  // TODO: get rid of currentSeat and setCurrentSeat as this can (and should be) derived from `seatSelection` value.
+  currentSeat: CurrentSeat;
+  setCurrentSeat: (seat: CurrentSeat) => void;
+  onSelectSeat: (seat: SeatInformation | null) => void;
+  setIsLoading: (isLoading: boolean) => void;
+  extendedSeatInfo: ExtendedSeatInfo[];
+  setExtendedSeatInfo: (seat: ExtendedSeatInfo[]) => void;
+  currency: string;
+}
+
+export const SeatSelectionContext = createContext<SeatSelectionContextValue>({
+  offer: {} as Offer,
+  seatMaps: [],
+  seatSelection: {} as SeatSelectionContextInterface,
+  size: "default",
+  currentSeat: {} as CurrentSeat,
+  setCurrentSeat: noop,
+  onSelectSeat: noop,
+  setIsLoading: noop,
+  extendedSeatInfo: [],
+  setExtendedSeatInfo: noop,
+  currency: "",
+});
+
+export const useSeatSelectionContext = () => useContext(SeatSelectionContext);

--- a/src/styles/components/Amenity.css
+++ b/src/styles/components/Amenity.css
@@ -1,0 +1,23 @@
+.map-element--amenity {
+  width: 100%;
+  height: var(--SPACING-LG-1);
+  color: var(--GREY-600);
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  margin-bottom: var(--SPACING-SM-1);
+}
+
+@media only screen and (min-width: 768px) {
+  .map-element--amenity {
+    width: 100%;
+    height: var(--SPACING-LG-3);
+    font-size: var(--FONT-SIZES-C2);
+  }
+}
+
+.map-element--wrapped {
+  background-color: var(--GREY-100);
+  border-radius: 8px;
+  border: 2px solid var(--GREY-200);
+}

--- a/src/styles/components/Legend.css
+++ b/src/styles/components/Legend.css
@@ -1,0 +1,58 @@
+.seat-map__legend {
+  width: calc(100% + var(--SPACING-MD-3));
+  min-height: fit-content;
+  margin: calc(var(--SPACING-SM-1) * -1) calc(var(--SPACING-SM-2) * -1);
+  display: flex;
+  flex-wrap: wrap;
+  align-items: center;
+  justify-content: center;
+  line-height: var(--SPACING-MD-3);
+  font-size: var(--FONT-SIZES-C2);
+  font-weight: 400;
+}
+
+.seat-map__legend-item {
+  display: flex;
+  align-items: center;
+  text-transform: capitalize;
+  margin: var(--SPACING-SM-1) var(--SPACING-SM-2);
+  color: var(--GREY-700);
+}
+
+.seat-map__legend-item--symbol .ff-icon {
+  margin-right: var(--SPACING-XS-3);
+}
+
+.seat-map__legend-seat {
+  width: var(--SPACING-MD-1);
+  height: var(--SPACING-MD-1);
+  border-radius: 5px;
+  border: 2px solid var(--GREY-400);
+  color: var(--GREY-400);
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  margin-right: var(--SPACING-SM-1);
+}
+
+.seat-map__legend-seat--fee-payable {
+  background-color: rgba(var(--ACCENT), var(--ACCENT-LIGHT-100));
+  border: 2px solid rgba(var(--ACCENT), var(--ACCENT-LIGHT-200));
+}
+
+.seat-map__legend-seat--fee-payable-indicator {
+  position: relative;
+  top: var(--SPACING-XS-2);
+  left: var(--SPACING-XS-2);
+  color: rgba(var(--ACCENT), var(--ACCENT-LIGHT-300));
+}
+
+.seat-map__legend-seat--included {
+  background-color: rgba(var(--ACCENT), var(--ACCENT-LIGHT-100));
+  border: 2px solid rgba(var(--ACCENT), var(--ACCENT-LIGHT-200));
+}
+
+.seat-map__legend-seat--selected {
+  background-color: rgba(var(--ACCENT), var(--ACCENT-LIGHT-1000));
+  border: 2px solid rgba(var(--ACCENT), var(--ACCENT-LIGHT-1000));
+}

--- a/src/styles/components/LoadingState.css
+++ b/src/styles/components/LoadingState.css
@@ -1,0 +1,81 @@
+.loading-state__container {
+  display: flex;
+  flex-direction: column;
+  align-content: center;
+  align-items: center;
+  text-align: center;
+  justify-content: center;
+  font-family: var(--FONT-FAMILY);
+  height: calc(100vh - var(--SPACING-XL-3));
+  width: var(--SPACING-XL-3);
+  margin: 0 auto;
+  line-height: var(--SPACING-MD-1);
+}
+
+.loading-state__message {
+  font-size: var(--FONT-SIZES-C3);
+  text-transform: uppercase;
+  color: var(--GREY-400);
+  letter-spacing: 0.02rem;
+}
+
+.loading-state__progress-indicator {
+  height: var(--SPACING-XS-2);
+  margin: var(--SPACING-SM-3) 0;
+  border-radius: 999px;
+  width: calc(100% - var(--SPACING-SM-1));
+  background-color: rgba(var(--ACCENT), var(--ACCENT-LIGHT-100));
+  position: relative;
+  transition: var(--TRANSITIONS-CUBIC-BEZIER);
+}
+
+.loading-state__progress-indicator--status {
+  display: block;
+  height: 100%;
+  border-radius: 999px;
+  background-color: rgba(var(--ACCENT), var(--ACCENT-LIGHT-1000));
+  position: relative;
+  animation: fillstatus 1s linear;
+}
+
+@keyframes fillstatus {
+  0% {
+    width: 0;
+  }
+  70% {
+    width: 100%;
+  }
+  80% {
+    opacity: 1;
+    width: 100%;
+  }
+  100% {
+    opacity: 0;
+    width: 100%;
+  }
+}
+
+.loading-state__segment {
+  display: flex;
+  flex-direction: row;
+  margin: var(--SPACING-XS-2) 0;
+  color: var(--GREY-400);
+  text-transform: uppercase;
+}
+
+.loading-state__segment--origin,
+.loading-state__segment--destination {
+  font-weight: 600;
+  font-size: var(--FONT-SIZES-C1);
+  color: var(--GREY-900);
+  padding: 0 var(--SPACING-SM-1);
+  text-transform: uppercase;
+}
+
+.loading-state__segment__duration {
+  color: var(--GREY-400);
+  font-size: var(--FONT-SIZES-C3);
+  letter-spacing: 0.02rem;
+  margin: var(--SPACING-XS-2) 0;
+  text-transform: uppercase;
+}

--- a/src/styles/components/PassengerSelect.css
+++ b/src/styles/components/PassengerSelect.css
@@ -80,3 +80,14 @@
     inset;
   background-color: rgba(var(--ACCENT), var(--ACCENT-LIGHT-100));
 }
+
+.passenger-selection-segment {
+  margin: var(--SPACING-LG-1) 0 0;
+  padding: 0 0 var(--SPACING-LG-1);
+  border-bottom: 1px solid var(--GREY-200);
+  font-family: var(--FONT-FAMILY);
+}
+
+.passenger-selection-segment:first-child {
+  margin-top: 0;
+}

--- a/src/styles/components/PassengersLayout.css
+++ b/src/styles/components/PassengersLayout.css
@@ -1,0 +1,90 @@
+.layout {
+  --LAYOUT-BOX-SHADOW: 0px 0px 0px 1px rgba(var(--BLACK), 0.05),
+    0px 4px 24px rgba(var(--BLACK), 0.08);
+  display: flex;
+  flex-direction: column;
+  width: 100%;
+  height: 100%;
+  padding: 0;
+  position: relative;
+}
+
+.layout__container {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  flex-grow: 1;
+  border-bottom: 1px solid rgba(59, 64, 86, 0.1);
+  height: calc(100% - 177px);
+  overflow: auto;
+}
+
+.layout__aside {
+  display: none;
+  padding-top: var(--SPACING-LG-1);
+}
+
+.layout__main-content {
+  width: 100%;
+  height: 100%;
+  display: flex;
+  justify-content: space-between;
+  flex-direction: column;
+}
+
+.layout__mobile-info {
+  align-self: center;
+  position: absolute;
+  bottom: 187px;
+  width: calc(100% - 20px);
+  padding: var(--SPACING-XS-3);
+  margin-bottom: var(--SPACING-SM-2);
+  height: auto;
+  border-radius: 8px;
+  z-index: 100;
+  box-shadow: var(--LAYOUT-BOX-SHADOW);
+}
+
+.layout__confirmation {
+  padding: var(--SPACING-MD-3);
+  box-shadow: var(--LAYOUT-BOX-SHADOW);
+  position: sticky;
+  bottom: 0;
+  background-color: rgb(var(--WHITE));
+}
+
+@media screen and (min-width: 768px) {
+  .layout {
+    overflow: hidden;
+  }
+
+  .layout__container {
+    height: auto;
+    padding: 0;
+    flex-direction: row;
+    align-items: initial;
+    max-height: calc(100vh - 115px);
+  }
+
+  .layout__confirmation {
+    padding: var(--SPACING-LG-1);
+    box-shadow: none;
+  }
+
+  .layout__aside {
+    overflow: auto;
+    border-right: 1px solid var(--GREY-200);
+    display: flex;
+    flex-direction: column;
+    position: sticky;
+    top: 0;
+    flex: 1 0 auto;
+    min-width: 415px;
+  }
+
+  .layout__main-content {
+    height: auto;
+    align-items: center;
+    overflow: auto;
+  }
+}

--- a/src/styles/components/Row.css
+++ b/src/styles/components/Row.css
@@ -1,0 +1,79 @@
+.map-element--exit {
+  color: var(--GREY-400);
+  width: 100%;
+  height: var(--SPACING-LG-3);
+  display: flex;
+  justify-content: flex-start;
+  align-items: center;
+}
+
+.map-element--exit--right {
+  justify-content: flex-end;
+}
+
+.map-element--empty {
+  min-width: var(--SPACING-LG-2);
+  height: var(--SPACING-LG-2);
+}
+
+@media only screen and (min-width: 768px) {
+  .map-element--empty {
+    min-width: var(--SPACING-LG-3);
+    height: var(--SPACING-LG-3);
+  }
+}
+
+.map-element + .map-element {
+  margin-left: var(--SPACING-XS-2);
+}
+
+@media only screen and (min-width: 768px) {
+  .map-element + .map-element {
+    margin-left: var(--SPACING-SM-1);
+  }
+}
+
+.map-section {
+  display: flex;
+  justify-content: center;
+  padding: var(--SPACING-XS-1) 0;
+}
+
+@media only screen and (min-width: 768px) {
+  .map-section {
+    padding: var(--SPACING-XS-2) 0;
+  }
+}
+
+.map-section--left {
+  border-left: 2px solid var(--GREY-200);
+  padding-left: var(--SPACING-SM-3);
+}
+
+.map-section--left.map-section--wing {
+  box-shadow: -19px 0px 0px 0px var(--GREY-200);
+}
+
+.map-section--right {
+  border-right: 2px solid var(--GREY-200);
+  padding-right: var(--SPACING-SM-3);
+}
+
+.map-section--right.map-section--wing {
+  box-shadow: 19px 0px 0px 0px var(--GREY-200);
+}
+
+.map-section__aisle {
+  display: flex;
+  justify-content: center;
+  color: var(--GREY-600);
+  font-size: var(--FONT-SIZES-C3);
+  line-height: var(--SPACING-MD-2);
+}
+
+@media only screen and (min-width: 768px) {
+  .map-section__aisle {
+    font-size: var(--FONT-SIZES-C2);
+    line-height: var(--SPACING-MD-3);
+  }
+}

--- a/src/styles/components/Seat.css
+++ b/src/styles/components/Seat.css
@@ -1,0 +1,72 @@
+.map-element__seat {
+  appearance: none;
+  outline: none;
+  cursor: default;
+  width: var(--SPACING-LG-2);
+  height: var(--SPACING-LG-2);
+  border-radius: 8px;
+  border: 2px solid var(--GREY-200);
+  box-sizing: border-box;
+  color: var(--GREY-600);
+  background-color: var(--GREY-100);
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  line-height: var(--SPACING-MD-3);
+  text-transform: uppercase;
+  font-weight: bold;
+  font-size: var(--FONT-SIZES-C3);
+  text-align: left;
+  position: relative;
+}
+
+@media only screen and (min-width: 768px) {
+  .map-element__seat {
+    width: var(--SPACING-LG-3);
+    height: var(--SPACING-LG-3);
+    font-size: var(--FONT-SIZES-C2);
+  }
+}
+
+.map-element--available {
+  border: 2px solid rgba(var(--ACCENT), var(--ACCENT-LIGHT-200));
+  background-color: rgba(var(--ACCENT), var(--ACCENT-LIGHT-100));
+  color: rgba(var(--ACCENT), var(--ACCENT-LIGHT-300));
+}
+
+.map-element--fee-payable {
+  position: absolute;
+  top: 22px;
+  left: 22px;
+  color: rgba(var(--ACCENT), var(--ACCENT-LIGHT-300));
+}
+
+@media only screen and (min-width: 768px) {
+  .map-element--fee-payable {
+    top: 26px;
+    left: 26px;
+  }
+}
+
+@media (hover: hover) and (pointer: fine) {
+  .map-element--actionable:hover {
+    cursor: pointer;
+  }
+
+  .map-element--actionable:not(.map-element--selected):hover {
+    background-color: rgba(var(--ACCENT), var(--ACCENT-LIGHT-200));
+    color: rgba(var(--ACCENT), var(--ACCENT-LIGHT-1000));
+    transition: var(--TRANSITIONS-CUBIC-BEZIER);
+  }
+
+  .map-element--fee-payable {
+    color: rgba(var(--ACCENT), var(--ACCENT-LIGHT-1000));
+    transition: var(--TRANSITIONS-CUBIC-BEZIER);
+  }
+}
+
+.map-element--selected {
+  background-color: rgba(var(--ACCENT), var(--ACCENT-LIGHT-1000));
+  border: 2px solid rgba(var(--ACCENT), var(--ACCENT-LIGHT-1000));
+  color: rgba(var(--WHITE), 1);
+}

--- a/src/styles/components/SeatInfo.css
+++ b/src/styles/components/SeatInfo.css
@@ -1,0 +1,34 @@
+.seat-info {
+  background-color: rgb(var(--WHITE));
+  padding: var(--SPACING-SM-3);
+  padding-bottom: var(--SPACING-SM-3);
+}
+
+.seat-info__details {
+  font-size: var(--FONT-SIZES-C1);
+  color: var(--GREY-900);
+  font-weight: normal;
+  text-transform: none;
+  display: flex;
+  justify-content: space-between;
+}
+
+.seat-info__details > span {
+  flex-grow: 1;
+  margin: 0 var(--SPACING-SM-1);
+}
+
+.seat-info__disclosure {
+  font-size: var(--FONT-SIZES-C3);
+  color: var(--GREY-600);
+  line-height: 150%;
+  text-transform: none;
+  font-weight: normal;
+  margin-top: var(--SPACING-SM-1);
+}
+
+.seat-info__details + .seat-info__disclosure {
+  padding-top: var(--SPACING-SM-3);
+  border-top: 1px solid var(--GREY-200);
+  margin-top: var(--SPACING-SM-3);
+}

--- a/src/styles/components/SeatMap.css
+++ b/src/styles/components/SeatMap.css
@@ -1,0 +1,40 @@
+.seat-map {
+  background-color: rgba(var(--WHITE), 1);
+  padding: var(--SPACING-SM-3);
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  width: fit-content;
+  min-height: 100%;
+}
+
+@media only screen and (min-width: 768px) {
+  .seat-map {
+    padding: var(--SPACING-LG-1) var(--SPACING-SM-3) var(--SPACING-SM-3);
+  }
+}
+
+.seat-map__legend-container {
+  margin-bottom: var(--SPACING-MD-3);
+  width: fit-content;
+}
+
+.seat-map__map-container {
+  display: grid;
+  grid-template-columns: repeat(var(--CABIN-AISLES), auto var(--SPACING-LG-1)) auto;
+  grid-column-gap: var(--SPACING-XS-2);
+  align-items: center;
+  width: min-content;
+  margin: 0 var(--SPACING-SM-2);
+}
+
+@media only screen and (min-width: 768px) {
+  .seat-map__map-container {
+    grid-template-columns:
+      repeat(var(--CABIN-AISLES), auto var(--SPACING-LG-2))
+      auto;
+    grid-column-gap: var(--SPACING-SM-2);
+    margin: 0;
+    padding-bottom: var(--SPACING-LG-1);
+  }
+}

--- a/src/styles/components/SeatSelect.css
+++ b/src/styles/components/SeatSelect.css
@@ -1,0 +1,92 @@
+.seat-selection {
+  --SEAT-SELECTION-BOX-SHADOW: 0px 0px 0px 1px rgba(var(--BLACK), 0.05),
+    0px 4px 24px rgba(var(--BLACK), 0.08);
+  background-color: rgb(var(--WHITE));
+  display: flex;
+  flex-direction: column;
+  width: 100%;
+  height: 100%;
+  padding: 0;
+  position: relative;
+}
+
+.seat-selection__content {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  flex-grow: 1;
+  border-bottom: 1px solid rgba(59, 64, 86, 0.1);
+  height: calc(100% - 177px);
+  overflow: auto;
+}
+
+.seat-selection__content-child--passengers {
+  display: none;
+  padding-top: var(--SPACING-LG-1);
+}
+
+.seat-selection__content-child--map {
+  width: 100%;
+  height: 100%;
+  display: flex;
+  justify-content: space-between;
+  flex-direction: column;
+}
+
+.seat-selection__mobile-seat-info {
+  align-self: center;
+  position: absolute;
+  bottom: 187px;
+  width: calc(100% - 20px);
+  padding: var(--SPACING-XS-3);
+  margin-bottom: var(--SPACING-SM-2);
+  height: auto;
+  background-color: white;
+  border-radius: 8px;
+  z-index: 100;
+  box-shadow: var(--SEAT-SELECTION-BOX-SHADOW);
+}
+
+.seat-selection__confirmation {
+  padding: var(--SPACING-MD-3);
+  box-shadow: var(--SEAT-SELECTION-BOX-SHADOW);
+  position: sticky;
+  bottom: 0;
+  background-color: rgb(var(--WHITE));
+}
+
+@media screen and (min-width: 768px) {
+  .seat-selection__content {
+    height: auto;
+    padding: 0;
+    flex-direction: row;
+    align-items: initial;
+    max-height: calc(100vh - 115px);
+  }
+
+  .seat-selection__confirmation {
+    padding: var(--SPACING-LG-1);
+    box-shadow: none;
+  }
+
+  .seat-selection__content-child--passengers {
+    overflow: auto;
+    border-right: 1px solid var(--GREY-200);
+    display: flex;
+    flex-direction: column;
+    position: sticky;
+    top: 0;
+    flex: 1 0 auto;
+    min-width: 415px;
+  }
+
+  .seat-selection__content-child--passengers > div:not(.passenger-selection) {
+    margin-left: var(--SPACING-LG-1);
+  }
+
+  .seat-selection__content-child--map {
+    height: auto;
+    align-items: center;
+    overflow: auto;
+  }
+}

--- a/src/styles/components/Tabs.css
+++ b/src/styles/components/Tabs.css
@@ -1,0 +1,49 @@
+.seat-map__tab-select {
+  width: 100%;
+  max-width: 400px;
+  display: flex;
+  text-align: center;
+  min-height: var(--SPACING-LG-1);
+  margin-bottom: var(--SPACING-MD-3);
+  border: 2px solid var(--GREY-200);
+  border-radius: 3px;
+  background-color: var(--GREY-200);
+}
+
+.seat-map__tab-select-option {
+  appearance: none;
+  outline: none;
+  margin: 0;
+  border: none;
+  padding: var(--SPACING-XS-2) var(--SPACING-SM-3);
+  font-weight: 600;
+  font-size: var(--FONT-SIZES-C2);
+  width: 100%;
+  color: var(--GREY-900);
+  background-color: var(--GREY-200);
+  cursor: pointer;
+  border-radius: 3px;
+}
+
+.seat-map__tab-select-option:hover,
+.seat-map__tab-select-option:focus,
+.seat-map__tab-select-option:active {
+  color: rgba(var(--ACCENT), var(--ACCENT-LIGHT-1000));
+  background-color: rgba(var(--ACCENT), var(--ACCENT-LIGHT-200));
+  transition: var(--TRANSITIONS-CUBIC-BEZIER);
+}
+
+.seat-map__tab-select-option--selected {
+  color: var(--GREY-900);
+  background-color: rgba(var(--WHITE), 1);
+  box-shadow: 0px 0px 0px 1px rgba(var(--BLACK), 0.05),
+    0px 2px 12px rgba(var(--BLACK), 0.08);
+}
+
+.seat-map__tab-select-option:first-child {
+  margin-right: 1px;
+}
+
+.seat-map__tab-select-option:last-child {
+  margin-left: 1px;
+}

--- a/src/styles/global.css
+++ b/src/styles/global.css
@@ -6,16 +6,26 @@
 @import "./transitions.css";
 @import "./typography.css";
 
+@import "./components/Amenity.css";
 @import "./components/BaggageDisplay.css";
 @import "./components/Button.css";
 @import "./components/Card.css";
 @import "./components/Counter.css";
+@import "./components/Legend.css";
 @import "./components/Loader.css";
+@import "./components/LoadingState.css";
 @import "./components/Modal.css";
 @import "./components/PassengerSelect.css";
+@import "./components/PassengersLayout.css";
+@import "./components/Row.css";
+@import "./components/Seat.css";
+@import "./components/SeatInfo.css";
+@import "./components/SeatMap.css";
+@import "./components/SeatSelect.css";
 @import "./components/Segment.css";
 @import "./components/SelectionSegment.css";
 @import "./components/Summary.css";
+@import "./components/Tabs.css";
 
 .duffel-components {
   --BUTTON-RADIUS: 5px;


### PR DESCRIPTION
__what__

This PR ports over the seat selection components to this repo. I'll follow up this PR with a way to create and save examples for offers and seat selection ([jira](https://duffel.atlassian.net/browse/FLIN-3131)). For now, the styles, component and most of the data flow should be ready. the bit missing is surfacing selected service from seat map to duffel checkout and vice versa([jira](https://duffel.atlassian.net/browse/FLIN-3132)). Here's a preview of where it's at so far:

https://user-images.githubusercontent.com/2934495/231396863-c145d5b8-b876-46a0-a84b-dfc2e02ec1c0.mov

