### PR TITLE
[No Jira] Enhance Renovate config

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -1,0 +1,16 @@
+{
+  "$schema": "https://docs.renovatebot.com/renovate-schema.json",
+  "extends": [
+    "config:base",
+    "schedule:earlyMondays",
+    ":combinePatchMinorReleases"
+  ],
+  "labels": ["dependencies"],
+  "enabledManagers": ["github-actions", "npm"],
+  "packageRules": [
+    {
+      "matchPackagePrefixes": ["@types", "eslint", "jest", "prettier"],
+      "automerge": true
+    }
+  ]
+}

--- a/renovate.json
+++ b/renovate.json
@@ -1,4 +1,0 @@
-{
-  "$schema": "https://docs.renovatebot.com/renovate-schema.json",
-  "extends": ["config:base"]
-}


### PR DESCRIPTION
This PR:

* Moves `renovate.json` to `.github/` to match other repos
* Changes the Renovate config to match settings on other repos (running on early Monday, combining patch and minor releases, and auto merging safe dependencies)