### PR TITLE
Fixup: changes how we set the offer state on the hook

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "duffel-components",
-  "version": "0.1.0",
+  "version": "0.1.1",
   "private": true,
   "license": "MIT",
   "main": "index.js",

--- a/src/components/DuffelAncillaries.tsx
+++ b/src/components/DuffelAncillaries.tsx
@@ -62,9 +62,7 @@ export const DuffelAncillaries: React.FC<DuffelAncillariesProps> = (props) => {
     React.useState<CreateOrderPayloadPassengers>(props.passengers);
 
   const [offer, setOffer] = React.useState<Offer | undefined>(
-    isPropsWithOfferAndSeatMaps && isPropsWithOfferAndClientKey
-      ? props.offer
-      : undefined
+    (props as any).offer
   );
 
   const [isOfferLoading, setIsOfferLoading] = React.useState(
@@ -132,6 +130,15 @@ export const DuffelAncillaries: React.FC<DuffelAncillariesProps> = (props) => {
         setIsSeatMapLoading,
         setSeatMaps
       );
+    }
+
+    if (isPropsWithOfferAndClientKey) {
+      setOffer(props.offer);
+    }
+
+    if (isPropsWithOfferAndSeatMaps) {
+      setOffer(props.offer);
+      setSeatMaps(props.seat_maps);
     }
   }, [
     // `as any` is needed here because the list


### PR DESCRIPTION
__what__

When integrating with Links we learned the offer state was not updated after mount even if the props changes. This PR fixes that for both getting the offer and seat maps states. 