### PR TITLE
[No Jira] Only set timeout for offers that expire in less than a day

### DIFF
--- a/src/components/DuffelAncillaries.tsx
+++ b/src/components/DuffelAncillaries.tsx
@@ -93,7 +93,14 @@ export const DuffelAncillaries: React.FC<DuffelAncillariesProps> = (props) => {
       setError(expiryErrorMessage);
     } else {
       const msUntilExpiry = new Date(offer.expires_at).getTime() - Date.now();
-      setTimeout(() => setError(expiryErrorMessage), msUntilExpiry);
+
+      // Only show the expiry error message if the offer expires in less than a day,
+      // to prevent buffer overflows when showing offers for fixtures, which expire in
+      // years.
+      const milisecondsInOneDay = 1000 * 60 * 60 * 24;
+      if (msUntilExpiry < milisecondsInOneDay) {
+        setTimeout(() => setError(expiryErrorMessage), msUntilExpiry);
+      }
     }
   };
 


### PR DESCRIPTION
The fixture offers have 20 years of expiry on them. This was causing a buffer overflow because `setTimeout` has a maximum value of 2^32 (about 24 days). I've added a check so that the timeout is only set if it expires in less than a day, which was an arbitrary number but it felt like a good one.