### PR TITLE
[No Jira] Use non-zero indexed passengers for seats

### DIFF
--- a/src/components/seats/SeatSelectionModal.tsx
+++ b/src/components/seats/SeatSelectionModal.tsx
@@ -60,7 +60,7 @@ export const SeatSelectionModal: React.FC<SeatSelectionModalProps> = ({
   const currentPassengerName = getPassengerName(
     currentPassenger,
     offer.passengers[currentPassengerIndex],
-    currentPassengerIndex
+    currentPassengerIndex + 1
   );
 
   const onSeatToggle = (seatServiceToToggle: CreateOrderPayloadService) => {


### PR DESCRIPTION
This fixes a bug where unnamed passengers said "Passenger 0" on the seat selection modal.