### PR TITLE
Adds missing branches config

### DIFF
--- a/package.json
+++ b/package.json
@@ -125,5 +125,10 @@
     ],
     "@semantic-release/npm",
     "@semantic-release/github"
-  ]
+  ],
+  "release": {
+    "branches": [
+      "main"
+    ]
+  }
 }


### PR DESCRIPTION
__what__

By default, semantic-releases expects releases to happen on the `master` branch. Since we didn't have a config on package json to specify otherwise, the release workflow failed. This PR fixes that. 