### PR TITLE
Sets package version to current one to force new push

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@duffel/components",
-  "version": "3.0.0-canary",
+  "version": "2.7.20",
   "private": true,
   "license": "MIT",
   "main": "index.js",


### PR DESCRIPTION
__what__

with the latest push to main, the ["Release" workflow](https://github.com/duffelhq/duffel-components/actions/runs/5219530365/jobs/9421469596) ran successfully but semantic-release evaluated that "There are no relevant changes, so no new version is released." 

This update includes a breaking change comment and returns package json to the current release version on npm to force (and verify) that semantic release will create a major bump to v3.0.0 
