### PR TITLE
Fixes broken release step on CI

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -45,6 +45,9 @@ jobs:
           GIT_AUTHOR_EMAIL: duffel-bot-read-write@duffel.com
           GIT_COMMITTER_NAME: duffel-bot
           GIT_COMMITTER_EMAIL: duffel-bot-read-write@duffel.com
+          DUFFEL_API_URL: https://api.duffel.com
+          COMPONENT_CDN: https://assets.duffel.com/components
+          SENTRY_AUTH_TOKEN: ${{ secrets.SENTRY_AUTH_TOKEN }}
         run: yarn release
 
       - name: Get version from package.json after release step


### PR DESCRIPTION
__what__

This adds missing env variables to the release step. They will be used to build the component.