### PR TITLE
Log update

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -35,5 +35,14 @@ module.exports = {
     "react/react-in-jsx-scope": 0,
     "react/prop-types": 0,
     "react-hooks/exhaustive-deps": 0,
+    "no-console": ["error", { allow: ["warn", "error"] }],
+    "no-restricted-syntax": [
+      "error",
+      {
+        selector: "CallExpression[callee.object.name='console']",
+        message:
+          "Prefer 'log' or 'logGroup' from 'src/lib/logging.ts' instead of 'console'.",
+      },
+    ],
   },
 };

--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -35,7 +35,6 @@ module.exports = {
     "react/react-in-jsx-scope": 0,
     "react/prop-types": 0,
     "react-hooks/exhaustive-deps": 0,
-    "no-console": ["error", { allow: ["warn", "error"] }],
     "no-restricted-syntax": [
       "error",
       {

--- a/config/esbuild.cdn.config.js
+++ b/config/esbuild.cdn.config.js
@@ -6,6 +6,7 @@ const esbuildCopyStaticFiles = require("esbuild-copy-static-files");
 
 dotenv.config({ path: ".env.build" });
 if (process.env.SENTRY_AUTH_TOKEN === undefined) {
+  // eslint-disable-next-line
   console.error(
     "'process.env.SENTRY_AUTH_TOKEN' is required but missing." +
       "Make sure it's included in your .env.build file."

--- a/config/esbuild.cdn.config.js
+++ b/config/esbuild.cdn.config.js
@@ -38,7 +38,7 @@ esbuild
         include: "./cdn-dist",
         authToken: process.env.SENTRY_AUTH_TOKEN,
         logLevel: "info",
-        release: `cdn-${VERSION}`,
+        release: VERSION,
       }),
       esbuildCopyStaticFiles({
         src: "src/fixtures",

--- a/config/esbuild.dev.config.js
+++ b/config/esbuild.dev.config.js
@@ -39,7 +39,8 @@ const COMPONENT_CDN = process.env.COMPONENT_CDN.startsWith("http://localhost:")
     servedir: "cdn-dist",
     port: 8000,
   });
-
-  console.log(`\n🐄 Serving component on http://${host}:${port}`);
   await esbuildContext.watch();
+
+  // eslint-disable-next-line
+  console.log(`\n🐄 Serving component on http://${host}:${port}`);
 })();

--- a/config/esbuild.react.config.js
+++ b/config/esbuild.react.config.js
@@ -35,7 +35,7 @@ esbuild
         include: `./react-dist`,
         authToken: process.env.SENTRY_AUTH_TOKEN,
         logLevel: "info",
-        release: `react-${VERSION}`,
+        release: VERSION,
       }),
     ],
   })

--- a/scripts/generate-fixture.ts
+++ b/scripts/generate-fixture.ts
@@ -10,6 +10,9 @@ const DUFFEL_API_TOKEN = process.env.DUFFEL_API_TOKEN || "";
 const DUFFEL_API_URL = process.env.DUFFEL_API_URL || "";
 const VERBOSE = process.env.VERBOSE === "true";
 
+// eslint-disable-next-line
+const log = console.log;
+
 if (DUFFEL_API_URL.includes("localhost"))
   process.env.NODE_TLS_REJECT_UNAUTHORIZED = "0";
 
@@ -89,7 +92,8 @@ const main = async () => {
     const sliceInput = new Array<[string, string]>(sliceCount);
     for (let i = 0; i < sliceCount; i++) {
       let origin = sliceInput[i - 1]?.[0];
-      console.log(`\nSlice #${i + 1}`);
+
+      log(`\nSlice #${i + 1}`);
       const { value } = await prompts({
         type: "text",
         name: "value",
@@ -108,7 +112,7 @@ const main = async () => {
     }
 
     // ask how many adults
-    console.log(`\n`);
+    log(`\n`);
     const { adultCount } = await prompts({
       type: "number",
       name: "adultCount",
@@ -117,7 +121,7 @@ const main = async () => {
     });
 
     // ask for requested sources
-    console.log(`\n`);
+    log(`\n`);
     const { requestedSources } = await prompts({
       type: "text",
       name: "requestedSources",
@@ -135,7 +139,7 @@ const main = async () => {
       const airlines = new Set(
         offerRequest.offers.map((offer) => offer.owner.iata_code)
       );
-      console.log(
+      log(
         `Received ${withPlural(
           offerRequest.offers.length,
           "offer",
@@ -147,7 +151,7 @@ const main = async () => {
             "airlines"
           )}(${Array.from(airlines.values()).join(",")})`
       );
-      console.log(
+      log(
         `Search completed, offer request ID: ${offerRequest.id}.\nUsing first offer to get services: ${offerRequest.offers[0].id}\n`
       );
     }
@@ -183,10 +187,11 @@ const main = async () => {
       JSON.stringify(seatMaps, null, 2)
     );
 
-    console.log(`\n🐄 Fixtures saved for ${firstOffer.id}`);
-    console.log(`  ↳ /src/fixtures/offer/${firstOffer.id}.json`);
-    console.log(`  ↳ /src/fixtures/seat-maps/${firstOffer.id}.json\n`);
+    log(`\n🐄 Fixtures saved for ${firstOffer.id}`);
+    log(`  ↳ /src/fixtures/offer/${firstOffer.id}.json`);
+    log(`  ↳ /src/fixtures/seat-maps/${firstOffer.id}.json\n`);
   } catch (err) {
+    // eslint-disable-next-line
     console.error(err);
     process.exit(1);
   }

--- a/src/components/DuffelAncillaries.tsx
+++ b/src/components/DuffelAncillaries.tsx
@@ -186,7 +186,7 @@ export const DuffelAncillaries: React.FC<DuffelAncillariesProps> = (props) => {
           ? props.offer_id
           : props.offer.id,
         !isPropsWithOfferIdForFixture ? props.client_key : null,
-        setError,
+        () => updateSeatMaps([]),
         setIsSeatMapLoading,
         updateSeatMaps
       );

--- a/src/components/DuffelAncillaries.tsx
+++ b/src/components/DuffelAncillaries.tsx
@@ -3,7 +3,7 @@ import { createPriceFormatters } from "@lib/createPriceFormatters";
 import { formatAvailableServices } from "@lib/formatAvailableServices";
 import { formatSeatMaps } from "@lib/formatSeatMaps";
 import { isPayloadComplete } from "@lib/isPayloadComplete";
-import { LogContext, initializeLogger } from "@lib/logging";
+import { initializeLogger, logGroup } from "@lib/logging";
 import { offerIsExpired } from "@lib/offerIsExpired";
 import { retrieveOffer } from "@lib/retrieveOffer";
 import { retrieveSeatMaps } from "@lib/retrieveSeatMaps";
@@ -33,9 +33,9 @@ const COMPONENT_CDN = process.env.COMPONENT_CDN || "";
 const hrefToComponentStyles = `${COMPONENT_CDN}/global.css`;
 
 export const DuffelAncillaries: React.FC<DuffelAncillariesProps> = (props) => {
-  const logger = initializeLogger(props.debug || false);
+  initializeLogger(props.debug || false);
 
-  logger.logGroup("Properties passed into the component:", props);
+  logGroup("Properties passed into the component:", props);
 
   if (!areDuffelAncillariesPropsValid(props)) {
     throw new Error(
@@ -235,7 +235,7 @@ export const DuffelAncillaries: React.FC<DuffelAncillariesProps> = (props) => {
         cancel_for_any_reason_services: cfarSelectedServices,
       };
 
-      logger.logGroup("Payload ready", {
+      logGroup("Payload ready", {
         "Order creation payload": createOrderPayload,
         "Services metadata": metadata,
       });
@@ -284,63 +284,61 @@ export const DuffelAncillaries: React.FC<DuffelAncillariesProps> = (props) => {
     error,
   };
 
-  logger.logGroup("Component's internal state:", state);
+  logGroup("Component's internal state:", state);
 
   return (
     <>
       <link rel="stylesheet" href={hrefToComponentStyles}></link>
 
-      <LogContext.Provider value={logger}>
-        <div className="duffel-components" style={duffelComponentsStyle}>
-          <ErrorBoundary>
-            {error && (
-              <FetchOfferErrorState
-                height={nonIdealStateHeight}
-                message={error}
-              />
-            )}
+      <div className="duffel-components" style={duffelComponentsStyle}>
+        <ErrorBoundary>
+          {error && (
+            <FetchOfferErrorState
+              height={nonIdealStateHeight}
+              message={error}
+            />
+          )}
 
-            {!error &&
-              props.services.map((ancillaryName) => {
-                if (ancillaryName === "bags")
-                  return (
-                    <BaggageSelectionCard
-                      key="bags"
-                      isLoading={isOfferLoading}
-                      offer={offer}
-                      passengers={passengers}
-                      selectedServices={baggageSelectedServices}
-                      setSelectedServices={setBaggageSelectedServices}
-                    />
-                  );
+          {!error &&
+            props.services.map((ancillaryName) => {
+              if (ancillaryName === "bags")
+                return (
+                  <BaggageSelectionCard
+                    key="bags"
+                    isLoading={isOfferLoading}
+                    offer={offer}
+                    passengers={passengers}
+                    selectedServices={baggageSelectedServices}
+                    setSelectedServices={setBaggageSelectedServices}
+                  />
+                );
 
-                if (ancillaryName === "seats")
-                  return (
-                    <SeatSelectionCard
-                      key="seats"
-                      isLoading={isOfferLoading || isSeatMapLoading}
-                      seatMaps={seatMaps}
-                      offer={offer}
-                      passengers={passengers}
-                      selectedServices={seatSelectedServices}
-                      setSelectedServices={setSeatSelectedServices}
-                    />
-                  );
+              if (ancillaryName === "seats")
+                return (
+                  <SeatSelectionCard
+                    key="seats"
+                    isLoading={isOfferLoading || isSeatMapLoading}
+                    seatMaps={seatMaps}
+                    offer={offer}
+                    passengers={passengers}
+                    selectedServices={seatSelectedServices}
+                    setSelectedServices={setSeatSelectedServices}
+                  />
+                );
 
-                if (ancillaryName === "cancel_for_any_reason")
-                  return (
-                    <CfarSelectionCard
-                      key="cancel_for_any_reason"
-                      isLoading={isOfferLoading}
-                      offer={offer}
-                      selectedServices={cfarSelectedServices}
-                      setSelectedServices={setCfarSelectedServices}
-                    />
-                  );
-              })}
-          </ErrorBoundary>
-        </div>
-      </LogContext.Provider>
+              if (ancillaryName === "cancel_for_any_reason")
+                return (
+                  <CfarSelectionCard
+                    key="cancel_for_any_reason"
+                    isLoading={isOfferLoading}
+                    offer={offer}
+                    selectedServices={cfarSelectedServices}
+                    setSelectedServices={setCfarSelectedServices}
+                  />
+                );
+            })}
+        </ErrorBoundary>
+      </div>
     </>
   );
 };

--- a/src/components/ErrorBoundary.tsx
+++ b/src/components/ErrorBoundary.tsx
@@ -13,9 +13,9 @@ export class ErrorBoundary extends React.Component<{
     return { hasError: true };
   }
 
-  componentDidCatch(error: Error, context: Record<any, any>) {
+  componentDidCatch(error: Error) {
     // You can also log the error to an error reporting service
-    captureErrorInSentry(error, context);
+    captureErrorInSentry(error);
   }
 
   render() {

--- a/src/components/Icon.tsx
+++ b/src/components/Icon.tsx
@@ -1,3 +1,4 @@
+import { log } from "@lib/logging";
 import * as React from "react";
 
 /* eslint-disable react/no-unknown-property */
@@ -109,7 +110,7 @@ export type IconName = keyof typeof ICON_MAP;
 
 const getIconPath = (name: IconName) => {
   if (!(name in ICON_MAP)) {
-    console.warn(`The icon "${name}" is missing from ICON_MAP`);
+    log(`The icon "${name}" is missing from ICON_MAP`);
     return null;
   }
   return ICON_MAP[name];

--- a/src/examples/full-stack/server.mjs
+++ b/src/examples/full-stack/server.mjs
@@ -154,4 +154,5 @@ http
   })
   .listen(6262);
 
+// eslint-disable-next-line
 console.log(`\n🐄 Serving example on http://localhost:6262`);

--- a/src/examples/just-typescript/src/index.ts
+++ b/src/examples/just-typescript/src/index.ts
@@ -29,6 +29,7 @@ window.onload = () => {
     ],
   });
   onDuffelAncillariesPayloadReady((data, metadata) => {
+    /* eslint-disable */
     console.table(data);
     console.table(metadata);
   });

--- a/src/examples/react-app/src/index.tsx
+++ b/src/examples/react-app/src/index.tsx
@@ -31,6 +31,7 @@ const App: React.FC = () => (
           born_on: "1942-10-17",
         },
       ]}
+      // eslint-disable-next-line
       onPayloadReady={console.log}
     />
   </>

--- a/src/lib/captureErrorInSentry.ts
+++ b/src/lib/captureErrorInSentry.ts
@@ -1,8 +1,5 @@
 import * as Sentry from "@sentry/browser";
 
-/* eslint-disable-next-line @typescript-eslint/no-var-requires */
-const PACKAGE_DOT_JSON = require("../../package.json");
-
 let hasSentryInitiated = false;
 function initiateSentry() {
   Sentry.init({
@@ -13,7 +10,7 @@ function initiateSentry() {
      * this value to allow Sentry to resolve the correct source maps when
      * processing events.
      */
-    release: `${PACKAGE_DOT_JSON.name}@${PACKAGE_DOT_JSON.version}`,
+    release: process.env.COMPONENT_VERSION,
 
     /**
      * List of integrations that should be installed after SDK was initialized.
@@ -36,25 +33,10 @@ function initiateSentry() {
   hasSentryInitiated = true;
 }
 
-export const captureErrorInSentry = (
-  error: Error,
-  context?: Record<string, any>
-) => {
+export const captureErrorInSentry = (error: Error) => {
   if (!hasSentryInitiated) {
     initiateSentry();
   }
-
-  Sentry.configureScope((scope) => {
-    if (error.message) {
-      scope.setFingerprint([error.message]);
-    }
-
-    if (context) {
-      Object.entries(context).forEach(([key, value]) =>
-        scope.setExtra(key, value)
-      );
-    }
-  });
 
   return Sentry.captureException(error);
 };

--- a/src/lib/fetchFromDuffelAPI.ts
+++ b/src/lib/fetchFromDuffelAPI.ts
@@ -1,3 +1,12 @@
+import { logGroup } from "./logging";
+
+export interface ErrorResponse extends Response {
+  data: { meta: any; errors: any[] };
+}
+export const isErrorResponse = (response: any): response is ErrorResponse => {
+  return "data" in response && Array.isArray(response.data.errors);
+};
+
 const DUFFEL_API_URL = process.env.DUFFEL_API_URL;
 const COMPONENT_VERSION = process.env.COMPONENT_VERSION;
 
@@ -7,9 +16,11 @@ export async function fetchFromDuffelAPI(
   method = "GET",
   body?: string
 ) {
-  const response = await fetch(
-    `${DUFFEL_API_URL}/ancillaries-component/${path}`,
-    {
+  logGroup("Making request to the Duffel API", { path, method });
+  const fullUrl = `${DUFFEL_API_URL}/ancillaries-component/${path}`;
+  let response: Response | null = null;
+  try {
+    response = await fetch(fullUrl, {
       method,
       body,
       headers: {
@@ -17,8 +28,27 @@ export async function fetchFromDuffelAPI(
         Authorization: `Bearer ${withClientKey}`,
         "User-Agent": `Duffel/ancillaries-component@${COMPONENT_VERSION}`,
       },
-    }
-  );
+    });
+  } catch (error) {
+    logGroup("Failed to make request to the Duffel API", { error });
+    throw error;
+  }
 
-  return await response.json();
+  const data = await response.json();
+  if (Array.isArray(data.errors)) {
+    logGroup("Request to the Duffel API failed", {
+      operation: `${method} ${fullUrl}`,
+      method,
+      request_id: data?.meta?.request_id,
+      errors: data.errors,
+      status: response.status,
+    });
+    throw { ...response, data };
+  } else {
+    logGroup("Request to the Duffel succeeded", {
+      request_id: data?.meta?.request_id,
+    });
+  }
+
+  return data;
 }

--- a/src/lib/formatDate.ts
+++ b/src/lib/formatDate.ts
@@ -5,10 +5,9 @@ export const formatDateString = (dateString: string) => {
   if (!isNaN(date.valueOf())) return formatDate(date);
   else {
     captureErrorInSentry(
-      new Error("formatDateString attempted to parse an invalid date string"),
-      {
-        dateString,
-      }
+      new Error(
+        `formatDateString attempted to parse an invalid date string: ${dateString}`
+      )
     );
   }
 };

--- a/src/lib/getBaggageServiceDescription.ts
+++ b/src/lib/getBaggageServiceDescription.ts
@@ -6,7 +6,7 @@ export const getBaggageServiceDescription = (
 ) => {
   if (!metadata) {
     captureErrorInSentry(
-      new Error("getBaggageServiceDescription was not given any metadata"),
+      new Error("getBaggageServiceDescription was not given any metadata")
     );
     return null;
   }
@@ -18,7 +18,7 @@ export const getBaggageServiceDescription = (
     !metadata.maximum_depth_cm
   ) {
     captureErrorInSentry(
-      new Error("getBaggageServiceDescription metadata doesn't have any data"),
+      new Error("getBaggageServiceDescription metadata doesn't have any data")
     );
     return null;
   }

--- a/src/lib/getBaggageServiceDescription.ts
+++ b/src/lib/getBaggageServiceDescription.ts
@@ -7,7 +7,6 @@ export const getBaggageServiceDescription = (
   if (!metadata) {
     captureErrorInSentry(
       new Error("getBaggageServiceDescription was not given any metadata"),
-      { metadata }
     );
     return null;
   }
@@ -20,7 +19,6 @@ export const getBaggageServiceDescription = (
   ) {
     captureErrorInSentry(
       new Error("getBaggageServiceDescription metadata doesn't have any data"),
-      { metadata }
     );
     return null;
   }

--- a/src/lib/getTotalAmountForServices.ts
+++ b/src/lib/getTotalAmountForServices.ts
@@ -37,7 +37,7 @@ export const getTotalAmountForServicesWithPriceMap = (
       } else {
         captureErrorInSentry(
           new Error(
-            `The service id provided could not be found in neither the offer nor the seat maps. Service id: ${id}`
+            `The service id (${id}) provided could not be found in neither the offer nor the seat maps.`
           )
         );
       }

--- a/src/lib/logging.ts
+++ b/src/lib/logging.ts
@@ -35,7 +35,7 @@ const shouldLog = () => localStorage.getItem(LOCAL_STORAGE_KEY) === "true";
  * log('This is a log message')
  * logGroup('These messages will be grouped together', ['This is a log message', 'This is another log message'])
  */
-export const initializeLogger = (debugMode: boolean): void => {
+const initializeLogger = (debugMode: boolean): void => {
   storeLoggerState(debugMode);
   if (debugMode && !LOG_INITIALISED) {
     // eslint-disable-next-line
@@ -56,7 +56,7 @@ export const initializeLogger = (debugMode: boolean): void => {
  * Log a message to the console. Messages will be prefixed with "[Duffel Ancillaries]".
  * @param message The message to print to the console.
  */
-export const log = (message: any) => {
+const log = (message: any) => {
   if (shouldLog()) {
     // eslint-disable-next-line
     console.info(MESSAGE_PREFIX, message);
@@ -73,21 +73,18 @@ export const log = (message: any) => {
  * @param groupName The name of the group of messages. This will be prefixed with "[Duffel Ancillaries]".
  * @param messages An array of messages to print to the console, inside the group.
  */
-export function logGroup(groupName: string, messages: any[]): void;
+function logGroup(groupName: string, messages: any[]): void;
 
 /**
  * Log a series of messages to the console inside a collapsible group.
  * @param groupName The name of the group of messages. This will be prefixed with "[Duffel Ancillaries]".
  * @param object An object to print to the console, inside the group.
  */
-export function logGroup(
-  groupName: string,
-  object: { [key: string]: any }
-): void;
+function logGroup(groupName: string, object: { [key: string]: any }): void;
 
 // Overloaded function implementation.
 // https://www.typescriptlang.org/docs/handbook/2/functions.html#function-overloads
-export function logGroup(
+function logGroup(
   groupName: string,
   messagesOrObject: any[] | { [key: string]: any }
 ): void {
@@ -119,3 +116,5 @@ export function logGroup(
     });
   }
 }
+
+export { initializeLogger, logGroup, log };

--- a/src/lib/logging.ts
+++ b/src/lib/logging.ts
@@ -2,9 +2,11 @@ import * as Sentry from "@sentry/browser";
 
 const MESSAGE_PREFIX = "[Duffel Ancillaries] ";
 const LOCAL_STORAGE_KEY = "duffel-ancillaries-logger-state";
+let LOG_INITIALISED = false;
 
-const storeLoggerState = (shouldLog: boolean) =>
+const storeLoggerState = (shouldLog: boolean) => {
   localStorage.setItem(LOCAL_STORAGE_KEY, shouldLog.toString());
+};
 
 const shouldLog = () => localStorage.getItem(LOCAL_STORAGE_KEY) === "true";
 
@@ -35,11 +37,19 @@ const shouldLog = () => localStorage.getItem(LOCAL_STORAGE_KEY) === "true";
  */
 export const initializeLogger = (debugMode: boolean): void => {
   storeLoggerState(debugMode);
-  if (debugMode) {
-    log(
-      `\n\nDebug mode is enabled. Information about your setup will be printed to the console.\n\nIf you do not want to enable debug mode (for example in a production environment), pass "debug: false" when initializing this component.\n\nLearn more about the Ancillaries component:\nhttp://duffel.com/docs/guides/ancillaries-component`
+  if (debugMode && !LOG_INITIALISED) {
+    // eslint-disable-next-line
+    console.info(
+      MESSAGE_PREFIX,
+      `\n\nDebug mode is enabled. Information about your setup will be printed to the console.
+    
+    If you do not want to enable debug mode (for example in a production environment), pass "debug: false" when initializing this component.
+    
+    Learn more about the Ancillaries component:
+    http://duffel.com/docs/guides/ancillaries-component`
     );
   }
+  LOG_INITIALISED = true;
 };
 
 /**
@@ -52,8 +62,7 @@ export const log = (message: any) => {
     console.info(MESSAGE_PREFIX, message);
   } else {
     Sentry.addBreadcrumb({
-      category: "Log message",
-      level: "info",
+      category: "log",
       message,
     });
   }
@@ -104,9 +113,9 @@ export function logGroup(
     console.groupEnd();
   } else {
     Sentry.addBreadcrumb({
-      category: `Log grouop: ${groupName}`,
-      level: "info",
-      data: transformedMessagesOrObject,
+      category: "log.group",
+      message: groupName,
+      data: messagesOrObject,
     });
   }
 }

--- a/src/lib/logging.ts
+++ b/src/lib/logging.ts
@@ -1,4 +1,12 @@
-import { createContext, useContext } from "react";
+import * as Sentry from "@sentry/browser";
+
+const MESSAGE_PREFIX = "[Duffel Ancillaries] ";
+const LOCAL_STORAGE_KEY = "duffel-ancillaries-logger-state";
+
+const storeLoggerState = (shouldLog: boolean) =>
+  localStorage.setItem(LOCAL_STORAGE_KEY, shouldLog.toString());
+
+const shouldLog = () => localStorage.getItem(LOCAL_STORAGE_KEY) === "true";
 
 /**
  * The functions in this file are used to enable logging.
@@ -25,36 +33,30 @@ import { createContext, useContext } from "react";
  * log('This is a log message')
  * logGroup('These messages will be grouped together', ['This is a log message', 'This is another log message'])
  */
-
-const initializeLogger = (debugMode: boolean) => {
+export const initializeLogger = (debugMode: boolean): void => {
+  storeLoggerState(debugMode);
   if (debugMode) {
     log(
       `\n\nDebug mode is enabled. Information about your setup will be printed to the console.\n\nIf you do not want to enable debug mode (for example in a production environment), pass "debug: false" when initializing this component.\n\nLearn more about the Ancillaries component:\nhttp://duffel.com/docs/guides/ancillaries-component`
     );
   }
-
-  // We return functions that do nothing because it allows consumers
-  // of this function to not have to check if the logger is enabled or not.
-  // If we returned undefined, consumers would have to do something like:
-  // if (log) { log('message') }
-  //
-  // eslint-disable-next-line @typescript-eslint/no-empty-function
-  const noop = () => {};
-
-  return {
-    log: debugMode ? log : noop,
-    logGroup: debugMode ? logGroup : noop,
-  };
 };
-
-const MESSAGE_PREFIX = "[Duffel Ancillaries] ";
 
 /**
  * Log a message to the console. Messages will be prefixed with "[Duffel Ancillaries]".
  * @param message The message to print to the console.
  */
-const log = (message: any) => {
-  console.log(MESSAGE_PREFIX, message);
+export const log = (message: any) => {
+  if (shouldLog()) {
+    // eslint-disable-next-line
+    console.info(MESSAGE_PREFIX, message);
+  } else {
+    Sentry.addBreadcrumb({
+      category: "Log message",
+      level: "info",
+      message,
+    });
+  }
 };
 
 /**
@@ -62,23 +64,24 @@ const log = (message: any) => {
  * @param groupName The name of the group of messages. This will be prefixed with "[Duffel Ancillaries]".
  * @param messages An array of messages to print to the console, inside the group.
  */
-function logGroup(groupName: string, messages: any[]): void;
+export function logGroup(groupName: string, messages: any[]): void;
 
 /**
  * Log a series of messages to the console inside a collapsible group.
  * @param groupName The name of the group of messages. This will be prefixed with "[Duffel Ancillaries]".
  * @param object An object to print to the console, inside the group.
  */
-function logGroup(groupName: string, object: { [key: string]: any }): void;
+export function logGroup(
+  groupName: string,
+  object: { [key: string]: any }
+): void;
 
 // Overloaded function implementation.
 // https://www.typescriptlang.org/docs/handbook/2/functions.html#function-overloads
-function logGroup(
+export function logGroup(
   groupName: string,
   messagesOrObject: any[] | { [key: string]: any }
 ): void {
-  console.groupCollapsed(MESSAGE_PREFIX, groupName);
-
   let transformedMessagesOrObject = [];
   if (Array.isArray(messagesOrObject)) {
     transformedMessagesOrObject = messagesOrObject;
@@ -87,14 +90,23 @@ function logGroup(
       ([key, value]) => ({ property: key, value })
     );
   }
-  transformedMessagesOrObject.forEach((message) => {
-    console.log(message);
-  });
 
-  console.groupEnd();
+  if (shouldLog()) {
+    // eslint-disable-next-line
+    console.groupCollapsed(MESSAGE_PREFIX, groupName);
+
+    transformedMessagesOrObject.forEach((message) => {
+      // eslint-disable-next-line
+      console.info(message);
+    });
+
+    // eslint-disable-next-line
+    console.groupEnd();
+  } else {
+    Sentry.addBreadcrumb({
+      category: `Log grouop: ${groupName}`,
+      level: "info",
+      data: transformedMessagesOrObject,
+    });
+  }
 }
-
-const LogContext = createContext(initializeLogger(false));
-const useLog = () => useContext(LogContext);
-
-export { LogContext, initializeLogger, useLog };

--- a/src/tests/lib/logging.test.tsx
+++ b/src/tests/lib/logging.test.tsx
@@ -1,27 +1,27 @@
-import { initializeLogger } from "@lib/logging";
+import { initializeLogger, log, logGroup } from "../../lib/logging";
 
 const consoleSpies = {
-  log: jest.spyOn(console, "log"),
+  log: jest.spyOn(console, "info"),
   groupCollapsed: jest.spyOn(console, "groupCollapsed"),
   groupEnd: jest.spyOn(console, "groupEnd"),
 };
 
 describe("initializeLogger", () => {
   it("should return functions that do nothing when debugMode is false", () => {
-    const logger = initializeLogger(false);
-    logger.log("This should not be logged");
+    initializeLogger(false);
+    log("This should not be logged");
     expect(consoleSpies.log).not.toHaveBeenCalled();
   });
 
   it("should return functions that log a message when debugMode is true", () => {
-    const logger = initializeLogger(true);
-    logger.log("This should be logged");
+    initializeLogger(true);
+    log("This should be logged");
 
     // Twice because initializeLogger logs a message when it's called,
     // and then the message we're testing.
     expect(consoleSpies.log).toHaveBeenCalledTimes(2);
 
-    logger.logGroup("This should be logged", ["one", "two"]);
+    logGroup("This should be logged", ["one", "two"]);
     expect(consoleSpies.groupCollapsed).toHaveBeenCalledTimes(1);
     expect(consoleSpies.groupEnd).toHaveBeenCalledTimes(1);
 

--- a/src/tests/lib/logging.test.tsx
+++ b/src/tests/lib/logging.test.tsx
@@ -6,7 +6,7 @@ const consoleSpies = {
   groupEnd: jest.spyOn(console, "groupEnd"),
 };
 
-describe("initializeLogger", () => {
+describe("logging", () => {
   it("should return functions that do nothing when debugMode is false", () => {
     initializeLogger(false);
     log("This should not be logged");
@@ -17,16 +17,16 @@ describe("initializeLogger", () => {
     initializeLogger(true);
     log("This should be logged");
 
-    // Twice because initializeLogger logs a message when it's called,
-    // and then the message we're testing.
-    expect(consoleSpies.log).toHaveBeenCalledTimes(2);
+    // Once because initializeLogger was initialised on the test above
+    // And so, the initialisation message would not show up twice.
+    expect(consoleSpies.log).toHaveBeenCalledTimes(1);
 
     logGroup("This should be logged", ["one", "two"]);
     expect(consoleSpies.groupCollapsed).toHaveBeenCalledTimes(1);
     expect(consoleSpies.groupEnd).toHaveBeenCalledTimes(1);
 
-    // Four times: once for the initializeLogger message, once for the
-    // earlier message, and twice for the array passed to logGroup.
-    expect(consoleSpies.log).toHaveBeenCalledTimes(4);
+    // once for the call to `log` above and then
+    // twice for the array passed to logGroup
+    expect(consoleSpies.log).toHaveBeenCalledTimes(3);
   });
 });


### PR DESCRIPTION
__what__

We have gotten a couple of Sentries that were hard to gather information about. It takes too much time to go into GCP to check logs and even in that case it, the entries from platform might not be informative to help us debug the issue. With this change we introduce Sentry breadcrumbs to our logs to give use more visibility into what the component tried to do prior to failing:

<img width="1189" alt="Screenshot 2023-06-15 at 3 38 11 PM" src="https://github.com/duffelhq/duffel-components/assets/2934495/60940645-cac3-4169-9318-a7934acbf1b0">
