### PR TITLE
Increase spacing below selected seat

### DIFF
--- a/src/styles/components/SeatInfo.css
+++ b/src/styles/components/SeatInfo.css
@@ -1,5 +1,5 @@
 .seat-info {
-  --INFO-CARD-MARGIN: 10px;
+  --INFO-CARD-MARGIN: 20px;
   background-color: rgb(var(--WHITE));
   padding: 24px;
   padding-bottom: 24px;


### PR DESCRIPTION
We were missing a bit of spacing between selected seat components.
View on Jira:

Before:
<img width="675" alt="Screenshot 2023-07-13 at 12 16 02" src="https://github.com/duffelhq/duffel-components/assets/1416759/fe98ef89-372b-4d44-889a-af452de1a7d0">


After:
<img width="691" alt="Screenshot 2023-07-13 at 12 15 51" src="https://github.com/duffelhq/duffel-components/assets/1416759/47364858-4467-4574-9ce3-25668f7836d9">
