### PR TITLE
[UXP-3063] Fix ancillaries being added to offer without hitting confirm

### DIFF
--- a/src/components/DuffelAncillaries/bags/BaggageSelectionCard.tsx
+++ b/src/components/DuffelAncillaries/bags/BaggageSelectionCard.tsx
@@ -86,7 +86,12 @@ export const BaggageSelectionCard: React.FC<BaggageSelectionCardProps> = ({
         offer={offer}
         passengers={passengers}
         onClose={(newSelectedServices) => {
-          setSelectedServices(newSelectedServices);
+          // We need to do a deep copy here because otherwise the modal changing the quantity
+          // will affect the selected services regardless of whether it's saved or not
+          const newSelectedServicesDeepCopy = JSON.parse(
+            JSON.stringify(newSelectedServices)
+          );
+          setSelectedServices(newSelectedServicesDeepCopy);
           setIsOpen(false);
         }}
         selectedServices={selectedServices}

--- a/src/components/DuffelAncillaries/bags/BaggageSelectionModal.tsx
+++ b/src/components/DuffelAncillaries/bags/BaggageSelectionModal.tsx
@@ -48,7 +48,7 @@ export const BaggageSelectionModal: React.FC<BaggageSelectionModalProps> = ({
   }
 
   return (
-    <Modal isOpen={isOpen} onClose={() => onClose(selectedServicesState)}>
+    <Modal isOpen={isOpen} onClose={() => onClose(selectedServices)}>
       <BaggageSelectionModalHeader
         segmentCount={segments.length}
         currentSegment={currentSegment}

--- a/src/components/DuffelAncillaries/seats/SeatSelectionModal.tsx
+++ b/src/components/DuffelAncillaries/seats/SeatSelectionModal.tsx
@@ -100,7 +100,7 @@ export const SeatSelectionModal: React.FC<SeatSelectionModalProps> = ({
     getCurrencyForSeatMaps(seatMaps) ?? offer.total_currency;
 
   return (
-    <Modal isOpen={isOpen} onClose={() => onClose(selectedServicesState)}>
+    <Modal isOpen={isOpen} onClose={() => onClose(selectedServices)}>
       <SeatSelectionModalHeader
         segmentAndPassengerPermutationsCount={
           segmentAndPassengerPermutations.length


### PR DESCRIPTION
Ancillaries were being added to offer without hitting confirm. This is because we were saving the newly selected state `onClose`, i.e. even if the user clicked the cancel button. I've set it so that unless they clicked Confirm, we revert to the old state on the offer. There was then another issue where the `quantity` of the baggage was still getting updated (e.g. set to 0) , because we were referencing the same object, so I've done a deep copy instead to make sure we don't accidentally update it.