### PR TITLE
[UXP-3053] fix: cleaner interface when only one way flight

### DIFF
--- a/.storybook/__snapshots__/Storyshots.test.js.snap
+++ b/.storybook/__snapshots__/Storyshots.test.js.snap
@@ -569,21 +569,11 @@ exports[`Storyshots DuffelAncillaries All Services 1`] = `
           <div
             style={
               {
-                "columnGap": "12px",
                 "display": "grid",
-                "gridTemplateColumns": "repeat(2, 1fr)",
                 "marginTop": "16px",
               }
             }
           >
-            <button
-              className="button button--outlined button--48"
-              disabled={true}
-              onClick={[Function]}
-              type="button"
-            >
-              Back
-            </button>
             <button
               className="button button--primary button--48"
               data-testid="confirm-selection-for-baggage"
@@ -7270,21 +7260,11 @@ exports[`Storyshots DuffelAncillaries Expired Offer 1`] = `
           <div
             style={
               {
-                "columnGap": "12px",
                 "display": "grid",
-                "gridTemplateColumns": "repeat(2, 1fr)",
                 "marginTop": "16px",
               }
             }
           >
-            <button
-              className="button button--outlined button--48"
-              disabled={true}
-              onClick={[Function]}
-              type="button"
-            >
-              Back
-            </button>
             <button
               className="button button--primary button--48"
               data-testid="confirm-selection-for-baggage"
@@ -13971,21 +13951,11 @@ exports[`Storyshots DuffelAncillaries Just Bags 1`] = `
           <div
             style={
               {
-                "columnGap": "12px",
                 "display": "grid",
-                "gridTemplateColumns": "repeat(2, 1fr)",
                 "marginTop": "16px",
               }
             }
           >
-            <button
-              className="button button--outlined button--48"
-              disabled={true}
-              onClick={[Function]}
-              type="button"
-            >
-              Back
-            </button>
             <button
               className="button button--primary button--48"
               data-testid="confirm-selection-for-baggage"
@@ -20714,21 +20684,11 @@ exports[`Storyshots DuffelAncillaries Markup 1`] = `
           <div
             style={
               {
-                "columnGap": "12px",
                 "display": "grid",
-                "gridTemplateColumns": "repeat(2, 1fr)",
                 "marginTop": "16px",
               }
             }
           >
-            <button
-              className="button button--outlined button--48"
-              disabled={true}
-              onClick={[Function]}
-              type="button"
-            >
-              Back
-            </button>
             <button
               className="button button--primary button--48"
               data-testid="confirm-selection-for-baggage"
@@ -27415,21 +27375,11 @@ exports[`Storyshots DuffelAncillaries Markup Using Price Formatters 1`] = `
           <div
             style={
               {
-                "columnGap": "12px",
                 "display": "grid",
-                "gridTemplateColumns": "repeat(2, 1fr)",
                 "marginTop": "16px",
               }
             }
           >
-            <button
-              className="button button--outlined button--48"
-              disabled={true}
-              onClick={[Function]}
-              type="button"
-            >
-              Back
-            </button>
             <button
               className="button button--primary button--48"
               data-testid="confirm-selection-for-baggage"
@@ -34116,21 +34066,11 @@ exports[`Storyshots DuffelAncillaries Markup Using Price Formatters With Custom 
           <div
             style={
               {
-                "columnGap": "12px",
                 "display": "grid",
-                "gridTemplateColumns": "repeat(2, 1fr)",
                 "marginTop": "16px",
               }
             }
           >
-            <button
-              className="button button--outlined button--48"
-              disabled={true}
-              onClick={[Function]}
-              type="button"
-            >
-              Back
-            </button>
             <button
               className="button button--primary button--48"
               data-testid="confirm-selection-for-baggage"
@@ -40471,6 +40411,6387 @@ exports[`Storyshots DuffelAncillaries Markup Using Price Formatters With Custom 
 ]
 `;
 
+exports[`Storyshots DuffelAncillaries One Way One Passenger Offer 1`] = `
+[
+  <link
+    href="/global.css"
+    rel="stylesheet"
+  />,
+  <div
+    className="duffel-components"
+    style={
+      {
+        "display": "flex",
+        "flexDirection": "column",
+        "rowGap": "12px",
+        "width": "100%",
+      }
+    }
+  >
+    <button
+      className="ancillary-card"
+      disabled={false}
+      onClick={[Function]}
+      style={
+        {
+          "background": "transparent",
+          "border": "solid 1px rgba(226, 226, 232, 1)",
+          "borderRadius": "8px",
+          "boxSizing": "border-box",
+          "color": "var(--GREY-900)",
+          "cursor": "pointer",
+          "display": "flex",
+          "flexDirection": "column",
+          "flexWrap": "wrap",
+          "fontSize": "16px",
+          "fontWeight": "400",
+          "justifyContent": "space-between",
+          "letterSpacing": "0em",
+          "lineHeight": "24px",
+          "padding": "20px",
+          "rowGap": "4px",
+          "transition": "border-color 0.3s var(--TRANSITION-CUBIC-BEZIER) background-color 0.3s var(--TRANSITION-CUBIC-BEZIER)",
+          "width": "100%",
+        }
+      }
+      title="Select extra baggage"
+    >
+      <div
+        style={
+          {
+            "alignItems": "flex-start",
+            "columnGap": "12px",
+            "display": "flex",
+            "marginBlock": "0",
+            "marginTop": "2px",
+            "textAlign": "start",
+            "width": "100%",
+          }
+        }
+      >
+        <div>
+          <svg
+            aria-label="cabin_bag"
+            data-testid="cabin_bag"
+            height={24}
+            style={
+              {
+                "display": "block",
+                "fill": "currentColor",
+              }
+            }
+            viewBox="0 0 24 24"
+            width={24}
+          >
+            <path
+              d="M7.3077 20.5C6.81058 20.5 6.38502 20.323 6.03102 19.969C5.67701 19.615 5.5 19.1894 5.5 18.6923V8.25007C5.5 7.76417 5.67019 7.35103 6.01057 7.01065C6.35096 6.67027 6.7641 6.50007 7.25 6.50007H9.25V3.6924C9.25 3.43631 9.33622 3.22166 9.50865 3.04842C9.68108 2.87519 9.89773 2.78857 10.1586 2.78857H13.8414C14.1022 2.78857 14.3189 2.87519 14.4913 3.04842C14.6637 3.22166 14.75 3.43631 14.75 3.6924V6.50007H16.6922C17.1894 6.50007 17.6149 6.67708 17.9689 7.0311C18.3229 7.3851 18.5 7.81066 18.5 8.30777V18.6923C18.5 19.1894 18.3229 19.615 17.9689 19.969C17.6149 20.323 17.1894 20.5 16.6922 20.5C16.6922 20.7507 16.6074 20.9608 16.4377 21.1303C16.2681 21.2999 16.0578 21.3846 15.807 21.3846C15.5561 21.3846 15.3461 21.2999 15.1769 21.1303C15.0077 20.9608 14.923 20.7507 14.923 20.5H9.0769C9.0769 20.7513 8.99206 20.9615 8.82237 21.1308C8.65271 21.3 8.44246 21.3846 8.19162 21.3846C7.94079 21.3846 7.73076 21.2999 7.56153 21.1303C7.39231 20.9608 7.3077 20.7507 7.3077 20.5ZM10.4423 6.50007H13.5577V3.98085H10.4423V6.50007ZM7.3077 19H16.6922C16.782 19 16.8557 18.9712 16.9134 18.9135C16.9711 18.8558 17 18.7821 17 18.6923V8.30777C17 8.21802 16.9711 8.1443 16.9134 8.0866C16.8557 8.0289 16.782 8.00005 16.6922 8.00005H7.3077C7.21795 8.00005 7.14423 8.0289 7.08652 8.0866C7.02882 8.1443 6.99997 8.21802 6.99997 8.30777V18.6923C6.99997 18.7821 7.02882 18.8558 7.08652 18.9135C7.14423 18.9712 7.21795 19 7.3077 19ZM8.15382 17.1539C8.15382 17.3261 8.21009 17.4685 8.32262 17.5811C8.43514 17.6937 8.57744 17.75 8.74952 17.75C8.92161 17.75 9.06407 17.6937 9.1769 17.5811C9.28972 17.4685 9.34613 17.3261 9.34613 17.1539V9.8462C9.34613 9.67398 9.28986 9.53157 9.17732 9.41897C9.06481 9.30637 8.92251 9.25007 8.75043 9.25007C8.57834 9.25007 8.43588 9.30637 8.32305 9.41897C8.21023 9.53157 8.15382 9.67398 8.15382 9.8462V17.1539ZM11.4038 17.1539C11.4038 17.3261 11.4601 17.4685 11.5726 17.5811C11.6851 17.6937 11.8274 17.75 11.9995 17.75C12.1716 17.75 12.3141 17.6937 12.4269 17.5811C12.5397 17.4685 12.5961 17.3261 12.5961 17.1539V9.8462C12.5961 9.67398 12.5399 9.53157 12.4273 9.41897C12.3148 9.30637 12.1725 9.25007 12.0004 9.25007C11.8283 9.25007 11.6859 9.30637 11.5731 9.41897C11.4602 9.53157 11.4038 9.67398 11.4038 9.8462V17.1539ZM14.6538 17.1539C14.6538 17.3261 14.7101 17.4685 14.8226 17.5811C14.9351 17.6937 15.0774 17.75 15.2495 17.75C15.4216 17.75 15.5641 17.6937 15.6769 17.5811C15.7897 17.4685 15.8461 17.3261 15.8461 17.1539V9.8462C15.8461 9.67398 15.7899 9.53157 15.6773 9.41897C15.5648 9.30637 15.4225 9.25007 15.2504 9.25007C15.0783 9.25007 14.9359 9.30637 14.823 9.41897C14.7102 9.53157 14.6538 9.67398 14.6538 9.8462V17.1539Z"
+            />
+          </svg>
+        </div>
+        <div
+          style={
+            {
+              "alignItems": "start",
+              "display": "flex",
+              "justifyContent": "space-between",
+              "width": "100%",
+            }
+          }
+        >
+          <p
+            className="p1--semibold"
+            style={
+              {
+                "marginBlock": "0",
+              }
+            }
+          >
+            Extra baggage
+          </p>
+          <div
+            className="ancillary-card__children"
+          >
+            <svg
+              aria-label="expand_content"
+              className="ancillary-card__expand-icon"
+              data-testid="expand_content"
+              height={24}
+              style={
+                {
+                  "display": "block",
+                  "fill": "currentColor",
+                }
+              }
+              viewBox="0 0 24 24"
+              width={24}
+            >
+              <path
+                d="M5 19V13H7V17H11V19H5ZM17 11V7H13V5H19V11H17Z"
+              />
+            </svg>
+          </div>
+        </div>
+      </div>
+      <p
+        className="p1--regular"
+        style={
+          {
+            "color": "var(--GREY-600)",
+            "marginBlock": "0",
+            "marginLeft": "34px",
+            "textAlign": "start",
+          }
+        }
+      >
+        Add any extra baggage you need for your trip
+      </p>
+    </button>
+    <div
+      className="modal"
+      style={
+        {
+          "opacity": 0,
+        }
+      }
+    >
+      <div
+        className="modal--content"
+        role="presentation"
+      >
+        <div
+          style={
+            {
+              "padding": "24px 24px 16px",
+            }
+          }
+        >
+          <h2
+            className="h3--semibold"
+            style={{}}
+          >
+            Flight to 
+            LAX
+            <span
+              className="p2--regular"
+              style={
+                {
+                  "color": "var(--GREY-600)",
+                  "marginLeft": "8px",
+                }
+              }
+            >
+              Apr 21, 2023
+            </span>
+          </h2>
+        </div>
+        <div
+          className="modal-body"
+        >
+          <div
+            style={
+              {
+                "marginTop": "24px",
+              }
+            }
+          >
+            <h3
+              className="p1--semibold"
+              style={
+                {
+                  "margin": 0,
+                }
+              }
+            >
+              Dorothy Green
+            </h3>
+            <div
+              className="p2--regular"
+              style={
+                {
+                  "backgroundColor": " var(--GREEN-100)",
+                  "borderRadius": "6px",
+                  "color": " var(--GREEN-300)",
+                  "marginBlock": "8px",
+                  "padding": "8px 12px",
+                }
+              }
+            >
+              1 cabin bag and 1 checked bag
+               included with ticket
+            </div>
+            <div
+              style={
+                {
+                  "display": "flex",
+                  "flexDirection": "column",
+                  "rowGap": "8px",
+                }
+              }
+            />
+            <p
+              style={
+                {
+                  "color": "var(--GREY-700)",
+                  "margin": 0,
+                }
+              }
+            >
+              Extra baggage is not available for this passenger on this flight
+            </p>
+          </div>
+        </div>
+        <div
+          style={
+            {
+              "padding": "16px 24px 24px",
+            }
+          }
+        >
+          <div
+            className="flex--space-between"
+          >
+            <div>
+              Price for 
+              0 extra bags
+            </div>
+            <div
+              className="h3--semibold"
+              data-testid="baggage-total-amount-label"
+            >
+              + 
+              £0.00
+            </div>
+          </div>
+          <div
+            style={
+              {
+                "display": "grid",
+                "marginTop": "16px",
+              }
+            }
+          >
+            <button
+              className="button button--primary button--48"
+              data-testid="confirm-selection-for-baggage"
+              onClick={[Function]}
+              type="button"
+            >
+              Confirm
+            </button>
+          </div>
+        </div>
+        <button
+          className="icon-button icon-button--primary modal--close-button"
+          onClick={[Function]}
+          title="Close modal"
+          type="button"
+        >
+          <svg
+            aria-label="close"
+            data-testid="close"
+            height={24}
+            style={
+              {
+                "display": "block",
+                "fill": "currentColor",
+              }
+            }
+            viewBox="0 0 24 24"
+            width={24}
+          >
+            <path
+              d="M18.3 5.71c-.39-.39-1.02-.39-1.41 0L12 10.59 7.11 5.7c-.39-.39-1.02-.39-1.41 0-.39.39-.39 1.02 0 1.41L10.59 12 5.7 16.89c-.39.39-.39 1.02 0 1.41.39.39 1.02.39 1.41 0L12 13.41l4.89 4.89c.39.39 1.02.39 1.41 0 .39-.39.39-1.02 0-1.41L13.41 12l4.89-4.89c.38-.38.38-1.02 0-1.4z"
+            />
+          </svg>
+        </button>
+      </div>
+    </div>
+    <button
+      className="ancillary-card"
+      disabled={false}
+      onClick={[Function]}
+      style={
+        {
+          "background": "transparent",
+          "border": "solid 1px rgba(226, 226, 232, 1)",
+          "borderRadius": "8px",
+          "boxSizing": "border-box",
+          "color": "var(--GREY-900)",
+          "cursor": "pointer",
+          "display": "flex",
+          "flexDirection": "column",
+          "flexWrap": "wrap",
+          "fontSize": "16px",
+          "fontWeight": "400",
+          "justifyContent": "space-between",
+          "letterSpacing": "0em",
+          "lineHeight": "24px",
+          "padding": "20px",
+          "rowGap": "4px",
+          "transition": "border-color 0.3s var(--TRANSITION-CUBIC-BEZIER) background-color 0.3s var(--TRANSITION-CUBIC-BEZIER)",
+          "width": "100%",
+        }
+      }
+      title="Select seats"
+    >
+      <div
+        style={
+          {
+            "alignItems": "flex-start",
+            "columnGap": "12px",
+            "display": "flex",
+            "marginBlock": "0",
+            "marginTop": "2px",
+            "textAlign": "start",
+            "width": "100%",
+          }
+        }
+      >
+        <div>
+          <svg
+            aria-label="flight_class"
+            data-testid="flight_class"
+            height={24}
+            style={
+              {
+                "display": "block",
+                "fill": "currentColor",
+              }
+            }
+            viewBox="0 0 24 24"
+            width={24}
+          >
+            <path
+              d="M14.2596 12.5C13.7737 12.5 13.3606 12.3298 13.0202 11.9894C12.6798 11.649 12.5096 11.2359 12.5096 10.75V6.25C12.5096 5.7641 12.6798 5.35096 13.0202 5.01058C13.3606 4.67019 13.7737 4.5 14.2596 4.5H15.75C16.2359 4.5 16.649 4.67019 16.9894 5.01058C17.3298 5.35096 17.5 5.7641 17.5 6.25V10.75C17.5 11.2359 17.3298 11.649 16.9894 11.9894C16.649 12.3298 16.2359 12.5 15.75 12.5H14.2596ZM14.2596 11H15.75C15.8205 11 15.8798 10.9759 15.9278 10.9279C15.9759 10.8798 16 10.8205 16 10.75V6.25C16 6.17948 15.9759 6.12018 15.9278 6.0721C15.8798 6.02402 15.8205 5.99998 15.75 5.99998H14.2596C14.1891 5.99998 14.1298 6.02402 14.0817 6.0721C14.0336 6.12018 14.0096 6.17948 14.0096 6.25V10.75C14.0096 10.8205 14.0336 10.8798 14.0817 10.9279C14.1298 10.9759 14.1891 11 14.2596 11ZM9.5673 17.5C9.21345 17.5 8.89678 17.398 8.6173 17.1942C8.33782 16.9903 8.14423 16.7198 8.03655 16.3827L5.5 8.02883V4.5H6.99997V7.99998L9.49997 16H17.7596V17.5H9.5673ZM8.25 20.5V19H17.75V20.5H8.25ZM14.2596 5.99998H16H14.0096H14.2596Z"
+            />
+          </svg>
+        </div>
+        <div
+          style={
+            {
+              "alignItems": "start",
+              "display": "flex",
+              "justifyContent": "space-between",
+              "width": "100%",
+            }
+          }
+        >
+          <p
+            className="p1--semibold"
+            style={
+              {
+                "marginBlock": "0",
+              }
+            }
+          >
+            Seat selection
+          </p>
+          <div
+            className="ancillary-card__children"
+          >
+            <svg
+              aria-label="expand_content"
+              className="ancillary-card__expand-icon"
+              data-testid="expand_content"
+              height={24}
+              style={
+                {
+                  "display": "block",
+                  "fill": "currentColor",
+                }
+              }
+              viewBox="0 0 24 24"
+              width={24}
+            >
+              <path
+                d="M5 19V13H7V17H11V19H5ZM17 11V7H13V5H19V11H17Z"
+              />
+            </svg>
+          </div>
+        </div>
+      </div>
+      <p
+        className="p1--regular"
+        style={
+          {
+            "color": "var(--GREY-600)",
+            "marginBlock": "0",
+            "marginLeft": "34px",
+            "textAlign": "start",
+          }
+        }
+      >
+        Specify where on the plane you’d like to sit
+      </p>
+    </button>
+    <div
+      className="modal"
+      style={
+        {
+          "opacity": 0,
+        }
+      }
+    >
+      <div
+        className="modal--content"
+        role="presentation"
+      >
+        <div
+          style={
+            {
+              "padding": "24px 24px 16px",
+            }
+          }
+        >
+          <h2
+            className="h3--semibold"
+            style={{}}
+          >
+            Flight to 
+            LAX
+            <span
+              className="p2--regular"
+              style={
+                {
+                  "color": "var(--GREY-600)",
+                  "marginLeft": "8px",
+                }
+              }
+            >
+              Apr 21, 2023
+            </span>
+          </h2>
+          <p
+            className="h3--semibold"
+            style={
+              {
+                "color": "var(--GREY-600)",
+                "marginBlock": "0 4px",
+              }
+            }
+          >
+            Dorothy Green
+          </p>
+        </div>
+        <div
+          className="modal-body"
+        >
+          <div
+            className="seat-map seat-map--wings"
+          >
+            <div
+              className="seat-map__legend-container"
+            >
+              <div
+                className="seat-map__legend"
+              >
+                <span
+                  className="seat-map__legend-item"
+                >
+                  <span
+                    aria-label="Additional cost for seat"
+                    className="seat-map__legend-seat seat-map__legend-seat--fee-payable"
+                  >
+                    <svg
+                      aria-label="seat_paid_indicator"
+                      className="seat-map__legend-seat--fee-payable-indicator"
+                      data-testid="seat_paid_indicator"
+                      height={12}
+                      style={
+                        {
+                          "display": "block",
+                          "fill": "currentColor",
+                        }
+                      }
+                      viewBox="0 0 24 24"
+                      width={12}
+                    >
+                      <path
+                        d="M11.7686 0.731368C12.7766 -0.276576 14.5 0.437294 14.5 1.86274V10.8C14.5 12.5673 13.0673 14 11.3 14H2.36274C0.937294 14 0.223427 12.2766 1.23137 11.2686L11.7686 0.731368Z"
+                      />
+                    </svg>
+                  </span>
+                  Additional Cost
+                </span>
+                <span
+                  className="seat-map__legend-item"
+                >
+                  <span
+                    aria-label="Included seat"
+                    className="seat-map__legend-seat seat-map__legend-seat--included"
+                  />
+                  Included
+                </span>
+                <span
+                  className="seat-map__legend-item"
+                >
+                  <span
+                    aria-label="Selected seat"
+                    className="seat-map__legend-seat seat-map__legend-seat--selected"
+                  />
+                  Selected
+                </span>
+                <span
+                  className="seat-map__legend-item"
+                >
+                  <span
+                    aria-label="Unavailable seat"
+                    className="seat-map__legend-seat"
+                  >
+                    <svg
+                      aria-label="close"
+                      data-testid="close"
+                      height={14}
+                      style={
+                        {
+                          "display": "block",
+                          "fill": "currentColor",
+                        }
+                      }
+                      viewBox="0 0 24 24"
+                      width={14}
+                    >
+                      <path
+                        d="M18.3 5.71c-.39-.39-1.02-.39-1.41 0L12 10.59 7.11 5.7c-.39-.39-1.02-.39-1.41 0-.39.39-.39 1.02 0 1.41L10.59 12 5.7 16.89c-.39.39-.39 1.02 0 1.41.39.39 1.02.39 1.41 0L12 13.41l4.89 4.89c.39.39 1.02.39 1.41 0 .39-.39.39-1.02 0-1.41L13.41 12l4.89-4.89c.38-.38.38-1.02 0-1.4z"
+                      />
+                    </svg>
+                  </span>
+                  Unavailable
+                </span>
+                <span
+                  className="seat-map__legend-item seat-map__legend-item--symbol"
+                >
+                  <svg
+                    aria-label="bassinet"
+                    data-testid="bassinet"
+                    height={20}
+                    style={
+                      {
+                        "display": "block",
+                        "fill": "currentColor",
+                      }
+                    }
+                    viewBox="0 0 24 24"
+                    width={20}
+                  >
+                    <path
+                      d="M19 12C19 14.1217 18.1571 16.1566 16.6569 17.6569C15.1566 19.1571 13.1217 20 11 20C8.87827 20 6.84344 19.1571 5.34315 17.6569C3.84286 16.1566 3 14.1217 3 12L11 12H19Z"
+                    />
+                    <path
+                      d="M16.1347 5.86529L11 11V4C12.0506 4 13.0909 4.20693 14.0615 4.60896C14.8136 4.92052 15.5125 5.34451 16.1347 5.86529ZM16.8602 6.55405L12.4142 11H18.9373C18.8482 10.293 18.6649 9.59962 18.391 8.93853C18.0264 8.05823 17.5077 7.25087 16.8602 6.55405Z"
+                    />
+                  </svg>
+                  bassinet
+                </span>
+                <span
+                  className="seat-map__legend-item seat-map__legend-item--symbol"
+                >
+                  <svg
+                    aria-label="lavatory"
+                    data-testid="lavatory"
+                    height={20}
+                    style={
+                      {
+                        "display": "block",
+                        "fill": "currentColor",
+                      }
+                    }
+                    viewBox="0 0 24 24"
+                    width={20}
+                  >
+                    <path
+                      d="M5.5 22v-7.5H4V9c0-1.1.9-2 2-2h3c1.1 0 2 .9 2 2v5.5H9.5V22h-4zM18 22v-6h3l-2.54-7.63C18.18 7.55 17.42 7 16.56 7h-.12c-.86 0-1.63.55-1.9 1.37L12 16h3v6h3zM7.5 6c1.11 0 2-.89 2-2s-.89-2-2-2-2 .89-2 2 .89 2 2 2zm9 0c1.11 0 2-.89 2-2s-.89-2-2-2-2 .89-2 2 .89 2 2 2z"
+                    />
+                  </svg>
+                  lavatory
+                </span>
+                <span
+                  className="seat-map__legend-item seat-map__legend-item--symbol"
+                >
+                  <svg
+                    aria-label="exit_row"
+                    data-testid="exit_row"
+                    height={20}
+                    style={
+                      {
+                        "display": "block",
+                        "fill": "currentColor",
+                      }
+                    }
+                    viewBox="0 0 24 24"
+                    width={20}
+                  >
+                    <path
+                      d="M20 11H6.83001L9.71001 8.12001C10.1 7.73001 10.1 7.10001 9.71001 6.71001C9.32001 6.32001 8.69001 6.32001 8.30001 6.71001L3.71001 11.3C3.32001 11.69 3.32001 12.32 3.71001 12.71L8.30001 17.3C8.69001 17.69 9.32001 17.69 9.71001 17.3C10.1 16.91 10.1 16.28 9.71001 15.89L6.83001 13H20C20.55 13 21 12.55 21 12C21 11.45 20.55 11 20 11Z"
+                    />
+                  </svg>
+                  exit
+                </span>
+                <span
+                  className="seat-map__legend-item seat-map__legend-item--symbol"
+                >
+                  <svg
+                    aria-label="galley"
+                    data-testid="galley"
+                    height={20}
+                    style={
+                      {
+                        "display": "block",
+                        "fill": "currentColor",
+                      }
+                    }
+                    viewBox="0 0 24 24"
+                    width={20}
+                  >
+                    <path
+                      d="M20 3H4v10c0 2.21 1.79 4 4 4h6c2.21 0 4-1.79 4-4v-3h2c1.11 0 2-.9 2-2V5c0-1.11-.89-2-2-2zm0 5h-2V5h2v3zM4 19h16v2H4z"
+                    />
+                  </svg>
+                  galley
+                </span>
+              </div>
+            </div>
+            <div
+              className="seat-map__map-container"
+              style={
+                {
+                  "--CABIN-AISLES": 2,
+                }
+              }
+            >
+              <div
+                className="map-section map-section--left map-section--wing"
+              >
+                <div
+                  className="map-element map-element--empty"
+                />
+                <div
+                  aria-label="bassinet"
+                  className="map-element map-element--amenity"
+                >
+                  <svg
+                    aria-label="bassinet"
+                    data-testid="bassinet"
+                    height={16}
+                    style={
+                      {
+                        "display": "block",
+                        "fill": "currentColor",
+                      }
+                    }
+                    viewBox="0 0 24 24"
+                    width={16}
+                  >
+                    <path
+                      d="M19 12C19 14.1217 18.1571 16.1566 16.6569 17.6569C15.1566 19.1571 13.1217 20 11 20C8.87827 20 6.84344 19.1571 5.34315 17.6569C3.84286 16.1566 3 14.1217 3 12L11 12H19Z"
+                    />
+                    <path
+                      d="M16.1347 5.86529L11 11V4C12.0506 4 13.0909 4.20693 14.0615 4.60896C14.8136 4.92052 15.5125 5.34451 16.1347 5.86529ZM16.8602 6.55405L12.4142 11H18.9373C18.8482 10.293 18.6649 9.59962 18.391 8.93853C18.0264 8.05823 17.5077 7.25087 16.8602 6.55405Z"
+                    />
+                  </svg>
+                </div>
+              </div>
+              <span
+                className="map-section__aisle"
+              />
+              <div
+                className="map-section map-section--wing"
+              >
+                <div
+                  className="map-element map-element--empty"
+                />
+                <div
+                  aria-label="bassinet"
+                  className="map-element map-element--amenity"
+                >
+                  <svg
+                    aria-label="bassinet"
+                    data-testid="bassinet"
+                    height={16}
+                    style={
+                      {
+                        "display": "block",
+                        "fill": "currentColor",
+                      }
+                    }
+                    viewBox="0 0 24 24"
+                    width={16}
+                  >
+                    <path
+                      d="M19 12C19 14.1217 18.1571 16.1566 16.6569 17.6569C15.1566 19.1571 13.1217 20 11 20C8.87827 20 6.84344 19.1571 5.34315 17.6569C3.84286 16.1566 3 14.1217 3 12L11 12H19Z"
+                    />
+                    <path
+                      d="M16.1347 5.86529L11 11V4C12.0506 4 13.0909 4.20693 14.0615 4.60896C14.8136 4.92052 15.5125 5.34451 16.1347 5.86529ZM16.8602 6.55405L12.4142 11H18.9373C18.8482 10.293 18.6649 9.59962 18.391 8.93853C18.0264 8.05823 17.5077 7.25087 16.8602 6.55405Z"
+                    />
+                  </svg>
+                </div>
+                <div
+                  className="map-element map-element--empty"
+                />
+              </div>
+              <span
+                className="map-section__aisle"
+              />
+              <div
+                className="map-section map-section--right map-section--wing"
+              >
+                <div
+                  aria-label="bassinet"
+                  className="map-element map-element--amenity"
+                >
+                  <svg
+                    aria-label="bassinet"
+                    data-testid="bassinet"
+                    height={16}
+                    style={
+                      {
+                        "display": "block",
+                        "fill": "currentColor",
+                      }
+                    }
+                    viewBox="0 0 24 24"
+                    width={16}
+                  >
+                    <path
+                      d="M19 12C19 14.1217 18.1571 16.1566 16.6569 17.6569C15.1566 19.1571 13.1217 20 11 20C8.87827 20 6.84344 19.1571 5.34315 17.6569C3.84286 16.1566 3 14.1217 3 12L11 12H19Z"
+                    />
+                    <path
+                      d="M16.1347 5.86529L11 11V4C12.0506 4 13.0909 4.20693 14.0615 4.60896C14.8136 4.92052 15.5125 5.34451 16.1347 5.86529ZM16.8602 6.55405L12.4142 11H18.9373C18.8482 10.293 18.6649 9.59962 18.391 8.93853C18.0264 8.05823 17.5077 7.25087 16.8602 6.55405Z"
+                    />
+                  </svg>
+                </div>
+                <div
+                  className="map-element map-element--empty"
+                />
+              </div>
+              <div
+                className="map-section map-section--left map-section--wing"
+              >
+                <span
+                  aria-label="28A Seat Unavailable"
+                  className="map-element map-element__seat"
+                >
+                  <svg
+                    aria-label="close"
+                    data-testid="close"
+                    height={14}
+                    style={
+                      {
+                        "display": "block",
+                        "fill": "currentColor",
+                      }
+                    }
+                    viewBox="0 0 24 24"
+                    width={14}
+                  >
+                    <path
+                      d="M18.3 5.71c-.39-.39-1.02-.39-1.41 0L12 10.59 7.11 5.7c-.39-.39-1.02-.39-1.41 0-.39.39-.39 1.02 0 1.41L10.59 12 5.7 16.89c-.39.39-.39 1.02 0 1.41.39.39 1.02.39 1.41 0L12 13.41l4.89 4.89c.39.39 1.02.39 1.41 0 .39-.39.39-1.02 0-1.41L13.41 12l4.89-4.89c.38-.38.38-1.02 0-1.4z"
+                    />
+                  </svg>
+                </span>
+                <button
+                  aria-label="28C Seat £20.00"
+                  className="map-element map-element__seat map-element--available map-element--actionable"
+                  data-testid="seat-28C"
+                  id="28C"
+                  onClick={[Function]}
+                >
+                  <svg
+                    aria-label="seat_paid_indicator"
+                    className="map-element--fee-payable"
+                    data-testid="seat_paid_indicator"
+                    height={16}
+                    style={
+                      {
+                        "display": "block",
+                        "fill": "currentColor",
+                      }
+                    }
+                    viewBox="0 0 24 24"
+                    width={16}
+                  >
+                    <path
+                      d="M11.7686 0.731368C12.7766 -0.276576 14.5 0.437294 14.5 1.86274V10.8C14.5 12.5673 13.0673 14 11.3 14H2.36274C0.937294 14 0.223427 12.2766 1.23137 11.2686L11.7686 0.731368Z"
+                    />
+                  </svg>
+                  C
+                </button>
+              </div>
+              <span
+                className="map-section__aisle"
+              >
+                28
+              </span>
+              <div
+                className="map-section map-section--wing"
+              >
+                <span
+                  aria-label="28D Seat Unavailable"
+                  className="map-element map-element__seat"
+                >
+                  <svg
+                    aria-label="close"
+                    data-testid="close"
+                    height={14}
+                    style={
+                      {
+                        "display": "block",
+                        "fill": "currentColor",
+                      }
+                    }
+                    viewBox="0 0 24 24"
+                    width={14}
+                  >
+                    <path
+                      d="M18.3 5.71c-.39-.39-1.02-.39-1.41 0L12 10.59 7.11 5.7c-.39-.39-1.02-.39-1.41 0-.39.39-.39 1.02 0 1.41L10.59 12 5.7 16.89c-.39.39-.39 1.02 0 1.41.39.39 1.02.39 1.41 0L12 13.41l4.89 4.89c.39.39 1.02.39 1.41 0 .39-.39.39-1.02 0-1.41L13.41 12l4.89-4.89c.38-.38.38-1.02 0-1.4z"
+                    />
+                  </svg>
+                </span>
+                <button
+                  aria-label="28E Seat £20.00"
+                  className="map-element map-element__seat map-element--available map-element--actionable"
+                  data-testid="seat-28E"
+                  id="28E"
+                  onClick={[Function]}
+                >
+                  <svg
+                    aria-label="seat_paid_indicator"
+                    className="map-element--fee-payable"
+                    data-testid="seat_paid_indicator"
+                    height={16}
+                    style={
+                      {
+                        "display": "block",
+                        "fill": "currentColor",
+                      }
+                    }
+                    viewBox="0 0 24 24"
+                    width={16}
+                  >
+                    <path
+                      d="M11.7686 0.731368C12.7766 -0.276576 14.5 0.437294 14.5 1.86274V10.8C14.5 12.5673 13.0673 14 11.3 14H2.36274C0.937294 14 0.223427 12.2766 1.23137 11.2686L11.7686 0.731368Z"
+                    />
+                  </svg>
+                  E
+                </button>
+                <button
+                  aria-label="28F Seat £20.00"
+                  className="map-element map-element__seat map-element--available map-element--actionable"
+                  data-testid="seat-28F"
+                  id="28F"
+                  onClick={[Function]}
+                >
+                  <svg
+                    aria-label="seat_paid_indicator"
+                    className="map-element--fee-payable"
+                    data-testid="seat_paid_indicator"
+                    height={16}
+                    style={
+                      {
+                        "display": "block",
+                        "fill": "currentColor",
+                      }
+                    }
+                    viewBox="0 0 24 24"
+                    width={16}
+                  >
+                    <path
+                      d="M11.7686 0.731368C12.7766 -0.276576 14.5 0.437294 14.5 1.86274V10.8C14.5 12.5673 13.0673 14 11.3 14H2.36274C0.937294 14 0.223427 12.2766 1.23137 11.2686L11.7686 0.731368Z"
+                    />
+                  </svg>
+                  F
+                </button>
+              </div>
+              <span
+                className="map-section__aisle"
+              >
+                28
+              </span>
+              <div
+                className="map-section map-section--right map-section--wing"
+              >
+                <span
+                  aria-label="28J Seat Unavailable"
+                  className="map-element map-element__seat"
+                >
+                  <svg
+                    aria-label="close"
+                    data-testid="close"
+                    height={14}
+                    style={
+                      {
+                        "display": "block",
+                        "fill": "currentColor",
+                      }
+                    }
+                    viewBox="0 0 24 24"
+                    width={14}
+                  >
+                    <path
+                      d="M18.3 5.71c-.39-.39-1.02-.39-1.41 0L12 10.59 7.11 5.7c-.39-.39-1.02-.39-1.41 0-.39.39-.39 1.02 0 1.41L10.59 12 5.7 16.89c-.39.39-.39 1.02 0 1.41.39.39 1.02.39 1.41 0L12 13.41l4.89 4.89c.39.39 1.02.39 1.41 0 .39-.39.39-1.02 0-1.41L13.41 12l4.89-4.89c.38-.38.38-1.02 0-1.4z"
+                    />
+                  </svg>
+                </span>
+                <span
+                  aria-label="28K Seat Unavailable"
+                  className="map-element map-element__seat"
+                >
+                  <svg
+                    aria-label="close"
+                    data-testid="close"
+                    height={14}
+                    style={
+                      {
+                        "display": "block",
+                        "fill": "currentColor",
+                      }
+                    }
+                    viewBox="0 0 24 24"
+                    width={14}
+                  >
+                    <path
+                      d="M18.3 5.71c-.39-.39-1.02-.39-1.41 0L12 10.59 7.11 5.7c-.39-.39-1.02-.39-1.41 0-.39.39-.39 1.02 0 1.41L10.59 12 5.7 16.89c-.39.39-.39 1.02 0 1.41.39.39 1.02.39 1.41 0L12 13.41l4.89 4.89c.39.39 1.02.39 1.41 0 .39-.39.39-1.02 0-1.41L13.41 12l4.89-4.89c.38-.38.38-1.02 0-1.4z"
+                    />
+                  </svg>
+                </span>
+              </div>
+              <div
+                className="map-section map-section--left"
+              >
+                <span
+                  aria-label="29A Seat Unavailable"
+                  className="map-element map-element__seat"
+                >
+                  <svg
+                    aria-label="close"
+                    data-testid="close"
+                    height={14}
+                    style={
+                      {
+                        "display": "block",
+                        "fill": "currentColor",
+                      }
+                    }
+                    viewBox="0 0 24 24"
+                    width={14}
+                  >
+                    <path
+                      d="M18.3 5.71c-.39-.39-1.02-.39-1.41 0L12 10.59 7.11 5.7c-.39-.39-1.02-.39-1.41 0-.39.39-.39 1.02 0 1.41L10.59 12 5.7 16.89c-.39.39-.39 1.02 0 1.41.39.39 1.02.39 1.41 0L12 13.41l4.89 4.89c.39.39 1.02.39 1.41 0 .39-.39.39-1.02 0-1.41L13.41 12l4.89-4.89c.38-.38.38-1.02 0-1.4z"
+                    />
+                  </svg>
+                </span>
+                <button
+                  aria-label="29B Seat £20.00"
+                  className="map-element map-element__seat map-element--available map-element--actionable"
+                  data-testid="seat-29B"
+                  id="29B"
+                  onClick={[Function]}
+                >
+                  <svg
+                    aria-label="seat_paid_indicator"
+                    className="map-element--fee-payable"
+                    data-testid="seat_paid_indicator"
+                    height={16}
+                    style={
+                      {
+                        "display": "block",
+                        "fill": "currentColor",
+                      }
+                    }
+                    viewBox="0 0 24 24"
+                    width={16}
+                  >
+                    <path
+                      d="M11.7686 0.731368C12.7766 -0.276576 14.5 0.437294 14.5 1.86274V10.8C14.5 12.5673 13.0673 14 11.3 14H2.36274C0.937294 14 0.223427 12.2766 1.23137 11.2686L11.7686 0.731368Z"
+                    />
+                  </svg>
+                  B
+                </button>
+                <span
+                  aria-label="29C Seat Unavailable"
+                  className="map-element map-element__seat"
+                >
+                  <svg
+                    aria-label="close"
+                    data-testid="close"
+                    height={14}
+                    style={
+                      {
+                        "display": "block",
+                        "fill": "currentColor",
+                      }
+                    }
+                    viewBox="0 0 24 24"
+                    width={14}
+                  >
+                    <path
+                      d="M18.3 5.71c-.39-.39-1.02-.39-1.41 0L12 10.59 7.11 5.7c-.39-.39-1.02-.39-1.41 0-.39.39-.39 1.02 0 1.41L10.59 12 5.7 16.89c-.39.39-.39 1.02 0 1.41.39.39 1.02.39 1.41 0L12 13.41l4.89 4.89c.39.39 1.02.39 1.41 0 .39-.39.39-1.02 0-1.41L13.41 12l4.89-4.89c.38-.38.38-1.02 0-1.4z"
+                    />
+                  </svg>
+                </span>
+              </div>
+              <span
+                className="map-section__aisle"
+              >
+                29
+              </span>
+              <div
+                className="map-section"
+              >
+                <span
+                  aria-label="29D Seat Unavailable"
+                  className="map-element map-element__seat"
+                >
+                  <svg
+                    aria-label="close"
+                    data-testid="close"
+                    height={14}
+                    style={
+                      {
+                        "display": "block",
+                        "fill": "currentColor",
+                      }
+                    }
+                    viewBox="0 0 24 24"
+                    width={14}
+                  >
+                    <path
+                      d="M18.3 5.71c-.39-.39-1.02-.39-1.41 0L12 10.59 7.11 5.7c-.39-.39-1.02-.39-1.41 0-.39.39-.39 1.02 0 1.41L10.59 12 5.7 16.89c-.39.39-.39 1.02 0 1.41.39.39 1.02.39 1.41 0L12 13.41l4.89 4.89c.39.39 1.02.39 1.41 0 .39-.39.39-1.02 0-1.41L13.41 12l4.89-4.89c.38-.38.38-1.02 0-1.4z"
+                    />
+                  </svg>
+                </span>
+                <span
+                  aria-label="29E Seat Unavailable"
+                  className="map-element map-element__seat"
+                >
+                  <svg
+                    aria-label="close"
+                    data-testid="close"
+                    height={14}
+                    style={
+                      {
+                        "display": "block",
+                        "fill": "currentColor",
+                      }
+                    }
+                    viewBox="0 0 24 24"
+                    width={14}
+                  >
+                    <path
+                      d="M18.3 5.71c-.39-.39-1.02-.39-1.41 0L12 10.59 7.11 5.7c-.39-.39-1.02-.39-1.41 0-.39.39-.39 1.02 0 1.41L10.59 12 5.7 16.89c-.39.39-.39 1.02 0 1.41.39.39 1.02.39 1.41 0L12 13.41l4.89 4.89c.39.39 1.02.39 1.41 0 .39-.39.39-1.02 0-1.41L13.41 12l4.89-4.89c.38-.38.38-1.02 0-1.4z"
+                    />
+                  </svg>
+                </span>
+                <span
+                  aria-label="29F Seat Unavailable"
+                  className="map-element map-element__seat"
+                >
+                  <svg
+                    aria-label="close"
+                    data-testid="close"
+                    height={14}
+                    style={
+                      {
+                        "display": "block",
+                        "fill": "currentColor",
+                      }
+                    }
+                    viewBox="0 0 24 24"
+                    width={14}
+                  >
+                    <path
+                      d="M18.3 5.71c-.39-.39-1.02-.39-1.41 0L12 10.59 7.11 5.7c-.39-.39-1.02-.39-1.41 0-.39.39-.39 1.02 0 1.41L10.59 12 5.7 16.89c-.39.39-.39 1.02 0 1.41.39.39 1.02.39 1.41 0L12 13.41l4.89 4.89c.39.39 1.02.39 1.41 0 .39-.39.39-1.02 0-1.41L13.41 12l4.89-4.89c.38-.38.38-1.02 0-1.4z"
+                    />
+                  </svg>
+                </span>
+              </div>
+              <span
+                className="map-section__aisle"
+              >
+                29
+              </span>
+              <div
+                className="map-section map-section--right"
+              >
+                <span
+                  aria-label="29H Seat Unavailable"
+                  className="map-element map-element__seat"
+                >
+                  <svg
+                    aria-label="close"
+                    data-testid="close"
+                    height={14}
+                    style={
+                      {
+                        "display": "block",
+                        "fill": "currentColor",
+                      }
+                    }
+                    viewBox="0 0 24 24"
+                    width={14}
+                  >
+                    <path
+                      d="M18.3 5.71c-.39-.39-1.02-.39-1.41 0L12 10.59 7.11 5.7c-.39-.39-1.02-.39-1.41 0-.39.39-.39 1.02 0 1.41L10.59 12 5.7 16.89c-.39.39-.39 1.02 0 1.41.39.39 1.02.39 1.41 0L12 13.41l4.89 4.89c.39.39 1.02.39 1.41 0 .39-.39.39-1.02 0-1.41L13.41 12l4.89-4.89c.38-.38.38-1.02 0-1.4z"
+                    />
+                  </svg>
+                </span>
+                <span
+                  aria-label="29J Seat Unavailable"
+                  className="map-element map-element__seat"
+                >
+                  <svg
+                    aria-label="close"
+                    data-testid="close"
+                    height={14}
+                    style={
+                      {
+                        "display": "block",
+                        "fill": "currentColor",
+                      }
+                    }
+                    viewBox="0 0 24 24"
+                    width={14}
+                  >
+                    <path
+                      d="M18.3 5.71c-.39-.39-1.02-.39-1.41 0L12 10.59 7.11 5.7c-.39-.39-1.02-.39-1.41 0-.39.39-.39 1.02 0 1.41L10.59 12 5.7 16.89c-.39.39-.39 1.02 0 1.41.39.39 1.02.39 1.41 0L12 13.41l4.89 4.89c.39.39 1.02.39 1.41 0 .39-.39.39-1.02 0-1.41L13.41 12l4.89-4.89c.38-.38.38-1.02 0-1.4z"
+                    />
+                  </svg>
+                </span>
+                <span
+                  aria-label="29K Seat Unavailable"
+                  className="map-element map-element__seat"
+                >
+                  <svg
+                    aria-label="close"
+                    data-testid="close"
+                    height={14}
+                    style={
+                      {
+                        "display": "block",
+                        "fill": "currentColor",
+                      }
+                    }
+                    viewBox="0 0 24 24"
+                    width={14}
+                  >
+                    <path
+                      d="M18.3 5.71c-.39-.39-1.02-.39-1.41 0L12 10.59 7.11 5.7c-.39-.39-1.02-.39-1.41 0-.39.39-.39 1.02 0 1.41L10.59 12 5.7 16.89c-.39.39-.39 1.02 0 1.41.39.39 1.02.39 1.41 0L12 13.41l4.89 4.89c.39.39 1.02.39 1.41 0 .39-.39.39-1.02 0-1.41L13.41 12l4.89-4.89c.38-.38.38-1.02 0-1.4z"
+                    />
+                  </svg>
+                </span>
+              </div>
+              <div
+                className="map-section map-section--left"
+              >
+                <span
+                  aria-label="30A Seat Unavailable"
+                  className="map-element map-element__seat"
+                >
+                  <svg
+                    aria-label="close"
+                    data-testid="close"
+                    height={14}
+                    style={
+                      {
+                        "display": "block",
+                        "fill": "currentColor",
+                      }
+                    }
+                    viewBox="0 0 24 24"
+                    width={14}
+                  >
+                    <path
+                      d="M18.3 5.71c-.39-.39-1.02-.39-1.41 0L12 10.59 7.11 5.7c-.39-.39-1.02-.39-1.41 0-.39.39-.39 1.02 0 1.41L10.59 12 5.7 16.89c-.39.39-.39 1.02 0 1.41.39.39 1.02.39 1.41 0L12 13.41l4.89 4.89c.39.39 1.02.39 1.41 0 .39-.39.39-1.02 0-1.41L13.41 12l4.89-4.89c.38-.38.38-1.02 0-1.4z"
+                    />
+                  </svg>
+                </span>
+                <span
+                  aria-label="30B Seat Unavailable"
+                  className="map-element map-element__seat"
+                >
+                  <svg
+                    aria-label="close"
+                    data-testid="close"
+                    height={14}
+                    style={
+                      {
+                        "display": "block",
+                        "fill": "currentColor",
+                      }
+                    }
+                    viewBox="0 0 24 24"
+                    width={14}
+                  >
+                    <path
+                      d="M18.3 5.71c-.39-.39-1.02-.39-1.41 0L12 10.59 7.11 5.7c-.39-.39-1.02-.39-1.41 0-.39.39-.39 1.02 0 1.41L10.59 12 5.7 16.89c-.39.39-.39 1.02 0 1.41.39.39 1.02.39 1.41 0L12 13.41l4.89 4.89c.39.39 1.02.39 1.41 0 .39-.39.39-1.02 0-1.41L13.41 12l4.89-4.89c.38-.38.38-1.02 0-1.4z"
+                    />
+                  </svg>
+                </span>
+                <span
+                  aria-label="30C Seat Unavailable"
+                  className="map-element map-element__seat"
+                >
+                  <svg
+                    aria-label="close"
+                    data-testid="close"
+                    height={14}
+                    style={
+                      {
+                        "display": "block",
+                        "fill": "currentColor",
+                      }
+                    }
+                    viewBox="0 0 24 24"
+                    width={14}
+                  >
+                    <path
+                      d="M18.3 5.71c-.39-.39-1.02-.39-1.41 0L12 10.59 7.11 5.7c-.39-.39-1.02-.39-1.41 0-.39.39-.39 1.02 0 1.41L10.59 12 5.7 16.89c-.39.39-.39 1.02 0 1.41.39.39 1.02.39 1.41 0L12 13.41l4.89 4.89c.39.39 1.02.39 1.41 0 .39-.39.39-1.02 0-1.41L13.41 12l4.89-4.89c.38-.38.38-1.02 0-1.4z"
+                    />
+                  </svg>
+                </span>
+              </div>
+              <span
+                className="map-section__aisle"
+              >
+                30
+              </span>
+              <div
+                className="map-section"
+              >
+                <span
+                  aria-label="30D Seat Unavailable"
+                  className="map-element map-element__seat"
+                >
+                  <svg
+                    aria-label="close"
+                    data-testid="close"
+                    height={14}
+                    style={
+                      {
+                        "display": "block",
+                        "fill": "currentColor",
+                      }
+                    }
+                    viewBox="0 0 24 24"
+                    width={14}
+                  >
+                    <path
+                      d="M18.3 5.71c-.39-.39-1.02-.39-1.41 0L12 10.59 7.11 5.7c-.39-.39-1.02-.39-1.41 0-.39.39-.39 1.02 0 1.41L10.59 12 5.7 16.89c-.39.39-.39 1.02 0 1.41.39.39 1.02.39 1.41 0L12 13.41l4.89 4.89c.39.39 1.02.39 1.41 0 .39-.39.39-1.02 0-1.41L13.41 12l4.89-4.89c.38-.38.38-1.02 0-1.4z"
+                    />
+                  </svg>
+                </span>
+                <span
+                  aria-label="30E Seat Unavailable"
+                  className="map-element map-element__seat"
+                >
+                  <svg
+                    aria-label="close"
+                    data-testid="close"
+                    height={14}
+                    style={
+                      {
+                        "display": "block",
+                        "fill": "currentColor",
+                      }
+                    }
+                    viewBox="0 0 24 24"
+                    width={14}
+                  >
+                    <path
+                      d="M18.3 5.71c-.39-.39-1.02-.39-1.41 0L12 10.59 7.11 5.7c-.39-.39-1.02-.39-1.41 0-.39.39-.39 1.02 0 1.41L10.59 12 5.7 16.89c-.39.39-.39 1.02 0 1.41.39.39 1.02.39 1.41 0L12 13.41l4.89 4.89c.39.39 1.02.39 1.41 0 .39-.39.39-1.02 0-1.41L13.41 12l4.89-4.89c.38-.38.38-1.02 0-1.4z"
+                    />
+                  </svg>
+                </span>
+                <span
+                  aria-label="30F Seat Unavailable"
+                  className="map-element map-element__seat"
+                >
+                  <svg
+                    aria-label="close"
+                    data-testid="close"
+                    height={14}
+                    style={
+                      {
+                        "display": "block",
+                        "fill": "currentColor",
+                      }
+                    }
+                    viewBox="0 0 24 24"
+                    width={14}
+                  >
+                    <path
+                      d="M18.3 5.71c-.39-.39-1.02-.39-1.41 0L12 10.59 7.11 5.7c-.39-.39-1.02-.39-1.41 0-.39.39-.39 1.02 0 1.41L10.59 12 5.7 16.89c-.39.39-.39 1.02 0 1.41.39.39 1.02.39 1.41 0L12 13.41l4.89 4.89c.39.39 1.02.39 1.41 0 .39-.39.39-1.02 0-1.41L13.41 12l4.89-4.89c.38-.38.38-1.02 0-1.4z"
+                    />
+                  </svg>
+                </span>
+              </div>
+              <span
+                className="map-section__aisle"
+              >
+                30
+              </span>
+              <div
+                className="map-section map-section--right"
+              >
+                <button
+                  aria-label="30H Seat £20.00"
+                  className="map-element map-element__seat map-element--available map-element--actionable"
+                  data-testid="seat-30H"
+                  id="30H"
+                  onClick={[Function]}
+                >
+                  <svg
+                    aria-label="seat_paid_indicator"
+                    className="map-element--fee-payable"
+                    data-testid="seat_paid_indicator"
+                    height={16}
+                    style={
+                      {
+                        "display": "block",
+                        "fill": "currentColor",
+                      }
+                    }
+                    viewBox="0 0 24 24"
+                    width={16}
+                  >
+                    <path
+                      d="M11.7686 0.731368C12.7766 -0.276576 14.5 0.437294 14.5 1.86274V10.8C14.5 12.5673 13.0673 14 11.3 14H2.36274C0.937294 14 0.223427 12.2766 1.23137 11.2686L11.7686 0.731368Z"
+                    />
+                  </svg>
+                  H
+                </button>
+                <button
+                  aria-label="30J Seat £20.00"
+                  className="map-element map-element__seat map-element--available map-element--actionable"
+                  data-testid="seat-30J"
+                  id="30J"
+                  onClick={[Function]}
+                >
+                  <svg
+                    aria-label="seat_paid_indicator"
+                    className="map-element--fee-payable"
+                    data-testid="seat_paid_indicator"
+                    height={16}
+                    style={
+                      {
+                        "display": "block",
+                        "fill": "currentColor",
+                      }
+                    }
+                    viewBox="0 0 24 24"
+                    width={16}
+                  >
+                    <path
+                      d="M11.7686 0.731368C12.7766 -0.276576 14.5 0.437294 14.5 1.86274V10.8C14.5 12.5673 13.0673 14 11.3 14H2.36274C0.937294 14 0.223427 12.2766 1.23137 11.2686L11.7686 0.731368Z"
+                    />
+                  </svg>
+                  J
+                </button>
+                <button
+                  aria-label="30K Seat £20.00"
+                  className="map-element map-element__seat map-element--available map-element--actionable"
+                  data-testid="seat-30K"
+                  id="30K"
+                  onClick={[Function]}
+                >
+                  <svg
+                    aria-label="seat_paid_indicator"
+                    className="map-element--fee-payable"
+                    data-testid="seat_paid_indicator"
+                    height={16}
+                    style={
+                      {
+                        "display": "block",
+                        "fill": "currentColor",
+                      }
+                    }
+                    viewBox="0 0 24 24"
+                    width={16}
+                  >
+                    <path
+                      d="M11.7686 0.731368C12.7766 -0.276576 14.5 0.437294 14.5 1.86274V10.8C14.5 12.5673 13.0673 14 11.3 14H2.36274C0.937294 14 0.223427 12.2766 1.23137 11.2686L11.7686 0.731368Z"
+                    />
+                  </svg>
+                  K
+                </button>
+              </div>
+              <div
+                className="map-section map-section--left"
+              >
+                <span
+                  aria-label="31A Seat Unavailable"
+                  className="map-element map-element__seat"
+                >
+                  <svg
+                    aria-label="close"
+                    data-testid="close"
+                    height={14}
+                    style={
+                      {
+                        "display": "block",
+                        "fill": "currentColor",
+                      }
+                    }
+                    viewBox="0 0 24 24"
+                    width={14}
+                  >
+                    <path
+                      d="M18.3 5.71c-.39-.39-1.02-.39-1.41 0L12 10.59 7.11 5.7c-.39-.39-1.02-.39-1.41 0-.39.39-.39 1.02 0 1.41L10.59 12 5.7 16.89c-.39.39-.39 1.02 0 1.41.39.39 1.02.39 1.41 0L12 13.41l4.89 4.89c.39.39 1.02.39 1.41 0 .39-.39.39-1.02 0-1.41L13.41 12l4.89-4.89c.38-.38.38-1.02 0-1.4z"
+                    />
+                  </svg>
+                </span>
+                <button
+                  aria-label="31B Seat £20.00"
+                  className="map-element map-element__seat map-element--available map-element--actionable"
+                  data-testid="seat-31B"
+                  id="31B"
+                  onClick={[Function]}
+                >
+                  <svg
+                    aria-label="seat_paid_indicator"
+                    className="map-element--fee-payable"
+                    data-testid="seat_paid_indicator"
+                    height={16}
+                    style={
+                      {
+                        "display": "block",
+                        "fill": "currentColor",
+                      }
+                    }
+                    viewBox="0 0 24 24"
+                    width={16}
+                  >
+                    <path
+                      d="M11.7686 0.731368C12.7766 -0.276576 14.5 0.437294 14.5 1.86274V10.8C14.5 12.5673 13.0673 14 11.3 14H2.36274C0.937294 14 0.223427 12.2766 1.23137 11.2686L11.7686 0.731368Z"
+                    />
+                  </svg>
+                  B
+                </button>
+                <span
+                  aria-label="31C Seat Unavailable"
+                  className="map-element map-element__seat"
+                >
+                  <svg
+                    aria-label="close"
+                    data-testid="close"
+                    height={14}
+                    style={
+                      {
+                        "display": "block",
+                        "fill": "currentColor",
+                      }
+                    }
+                    viewBox="0 0 24 24"
+                    width={14}
+                  >
+                    <path
+                      d="M18.3 5.71c-.39-.39-1.02-.39-1.41 0L12 10.59 7.11 5.7c-.39-.39-1.02-.39-1.41 0-.39.39-.39 1.02 0 1.41L10.59 12 5.7 16.89c-.39.39-.39 1.02 0 1.41.39.39 1.02.39 1.41 0L12 13.41l4.89 4.89c.39.39 1.02.39 1.41 0 .39-.39.39-1.02 0-1.41L13.41 12l4.89-4.89c.38-.38.38-1.02 0-1.4z"
+                    />
+                  </svg>
+                </span>
+              </div>
+              <span
+                className="map-section__aisle"
+              >
+                31
+              </span>
+              <div
+                className="map-section"
+              >
+                <button
+                  aria-label="31D Seat £20.00"
+                  className="map-element map-element__seat map-element--available map-element--actionable"
+                  data-testid="seat-31D"
+                  id="31D"
+                  onClick={[Function]}
+                >
+                  <svg
+                    aria-label="seat_paid_indicator"
+                    className="map-element--fee-payable"
+                    data-testid="seat_paid_indicator"
+                    height={16}
+                    style={
+                      {
+                        "display": "block",
+                        "fill": "currentColor",
+                      }
+                    }
+                    viewBox="0 0 24 24"
+                    width={16}
+                  >
+                    <path
+                      d="M11.7686 0.731368C12.7766 -0.276576 14.5 0.437294 14.5 1.86274V10.8C14.5 12.5673 13.0673 14 11.3 14H2.36274C0.937294 14 0.223427 12.2766 1.23137 11.2686L11.7686 0.731368Z"
+                    />
+                  </svg>
+                  D
+                </button>
+                <span
+                  aria-label="31E Seat Unavailable"
+                  className="map-element map-element__seat"
+                >
+                  <svg
+                    aria-label="close"
+                    data-testid="close"
+                    height={14}
+                    style={
+                      {
+                        "display": "block",
+                        "fill": "currentColor",
+                      }
+                    }
+                    viewBox="0 0 24 24"
+                    width={14}
+                  >
+                    <path
+                      d="M18.3 5.71c-.39-.39-1.02-.39-1.41 0L12 10.59 7.11 5.7c-.39-.39-1.02-.39-1.41 0-.39.39-.39 1.02 0 1.41L10.59 12 5.7 16.89c-.39.39-.39 1.02 0 1.41.39.39 1.02.39 1.41 0L12 13.41l4.89 4.89c.39.39 1.02.39 1.41 0 .39-.39.39-1.02 0-1.41L13.41 12l4.89-4.89c.38-.38.38-1.02 0-1.4z"
+                    />
+                  </svg>
+                </span>
+                <span
+                  aria-label="31F Seat Unavailable"
+                  className="map-element map-element__seat"
+                >
+                  <svg
+                    aria-label="close"
+                    data-testid="close"
+                    height={14}
+                    style={
+                      {
+                        "display": "block",
+                        "fill": "currentColor",
+                      }
+                    }
+                    viewBox="0 0 24 24"
+                    width={14}
+                  >
+                    <path
+                      d="M18.3 5.71c-.39-.39-1.02-.39-1.41 0L12 10.59 7.11 5.7c-.39-.39-1.02-.39-1.41 0-.39.39-.39 1.02 0 1.41L10.59 12 5.7 16.89c-.39.39-.39 1.02 0 1.41.39.39 1.02.39 1.41 0L12 13.41l4.89 4.89c.39.39 1.02.39 1.41 0 .39-.39.39-1.02 0-1.41L13.41 12l4.89-4.89c.38-.38.38-1.02 0-1.4z"
+                    />
+                  </svg>
+                </span>
+              </div>
+              <span
+                className="map-section__aisle"
+              >
+                31
+              </span>
+              <div
+                className="map-section map-section--right"
+              >
+                <button
+                  aria-label="31H Seat £20.00"
+                  className="map-element map-element__seat map-element--available map-element--actionable"
+                  data-testid="seat-31H"
+                  id="31H"
+                  onClick={[Function]}
+                >
+                  <svg
+                    aria-label="seat_paid_indicator"
+                    className="map-element--fee-payable"
+                    data-testid="seat_paid_indicator"
+                    height={16}
+                    style={
+                      {
+                        "display": "block",
+                        "fill": "currentColor",
+                      }
+                    }
+                    viewBox="0 0 24 24"
+                    width={16}
+                  >
+                    <path
+                      d="M11.7686 0.731368C12.7766 -0.276576 14.5 0.437294 14.5 1.86274V10.8C14.5 12.5673 13.0673 14 11.3 14H2.36274C0.937294 14 0.223427 12.2766 1.23137 11.2686L11.7686 0.731368Z"
+                    />
+                  </svg>
+                  H
+                </button>
+                <span
+                  aria-label="31J Seat Unavailable"
+                  className="map-element map-element__seat"
+                >
+                  <svg
+                    aria-label="close"
+                    data-testid="close"
+                    height={14}
+                    style={
+                      {
+                        "display": "block",
+                        "fill": "currentColor",
+                      }
+                    }
+                    viewBox="0 0 24 24"
+                    width={14}
+                  >
+                    <path
+                      d="M18.3 5.71c-.39-.39-1.02-.39-1.41 0L12 10.59 7.11 5.7c-.39-.39-1.02-.39-1.41 0-.39.39-.39 1.02 0 1.41L10.59 12 5.7 16.89c-.39.39-.39 1.02 0 1.41.39.39 1.02.39 1.41 0L12 13.41l4.89 4.89c.39.39 1.02.39 1.41 0 .39-.39.39-1.02 0-1.41L13.41 12l4.89-4.89c.38-.38.38-1.02 0-1.4z"
+                    />
+                  </svg>
+                </span>
+                <span
+                  aria-label="31K Seat Unavailable"
+                  className="map-element map-element__seat"
+                >
+                  <svg
+                    aria-label="close"
+                    data-testid="close"
+                    height={14}
+                    style={
+                      {
+                        "display": "block",
+                        "fill": "currentColor",
+                      }
+                    }
+                    viewBox="0 0 24 24"
+                    width={14}
+                  >
+                    <path
+                      d="M18.3 5.71c-.39-.39-1.02-.39-1.41 0L12 10.59 7.11 5.7c-.39-.39-1.02-.39-1.41 0-.39.39-.39 1.02 0 1.41L10.59 12 5.7 16.89c-.39.39-.39 1.02 0 1.41.39.39 1.02.39 1.41 0L12 13.41l4.89 4.89c.39.39 1.02.39 1.41 0 .39-.39.39-1.02 0-1.41L13.41 12l4.89-4.89c.38-.38.38-1.02 0-1.4z"
+                    />
+                  </svg>
+                </span>
+              </div>
+              <div
+                className="map-section map-section--left"
+              >
+                <button
+                  aria-label="32A Seat £20.00"
+                  className="map-element map-element__seat map-element--available map-element--actionable"
+                  data-testid="seat-32A"
+                  id="32A"
+                  onClick={[Function]}
+                >
+                  <svg
+                    aria-label="seat_paid_indicator"
+                    className="map-element--fee-payable"
+                    data-testid="seat_paid_indicator"
+                    height={16}
+                    style={
+                      {
+                        "display": "block",
+                        "fill": "currentColor",
+                      }
+                    }
+                    viewBox="0 0 24 24"
+                    width={16}
+                  >
+                    <path
+                      d="M11.7686 0.731368C12.7766 -0.276576 14.5 0.437294 14.5 1.86274V10.8C14.5 12.5673 13.0673 14 11.3 14H2.36274C0.937294 14 0.223427 12.2766 1.23137 11.2686L11.7686 0.731368Z"
+                    />
+                  </svg>
+                  A
+                </button>
+                <span
+                  aria-label="32B Seat Unavailable"
+                  className="map-element map-element__seat"
+                >
+                  <svg
+                    aria-label="close"
+                    data-testid="close"
+                    height={14}
+                    style={
+                      {
+                        "display": "block",
+                        "fill": "currentColor",
+                      }
+                    }
+                    viewBox="0 0 24 24"
+                    width={14}
+                  >
+                    <path
+                      d="M18.3 5.71c-.39-.39-1.02-.39-1.41 0L12 10.59 7.11 5.7c-.39-.39-1.02-.39-1.41 0-.39.39-.39 1.02 0 1.41L10.59 12 5.7 16.89c-.39.39-.39 1.02 0 1.41.39.39 1.02.39 1.41 0L12 13.41l4.89 4.89c.39.39 1.02.39 1.41 0 .39-.39.39-1.02 0-1.41L13.41 12l4.89-4.89c.38-.38.38-1.02 0-1.4z"
+                    />
+                  </svg>
+                </span>
+                <button
+                  aria-label="32C Seat £20.00"
+                  className="map-element map-element__seat map-element--available map-element--actionable"
+                  data-testid="seat-32C"
+                  id="32C"
+                  onClick={[Function]}
+                >
+                  <svg
+                    aria-label="seat_paid_indicator"
+                    className="map-element--fee-payable"
+                    data-testid="seat_paid_indicator"
+                    height={16}
+                    style={
+                      {
+                        "display": "block",
+                        "fill": "currentColor",
+                      }
+                    }
+                    viewBox="0 0 24 24"
+                    width={16}
+                  >
+                    <path
+                      d="M11.7686 0.731368C12.7766 -0.276576 14.5 0.437294 14.5 1.86274V10.8C14.5 12.5673 13.0673 14 11.3 14H2.36274C0.937294 14 0.223427 12.2766 1.23137 11.2686L11.7686 0.731368Z"
+                    />
+                  </svg>
+                  C
+                </button>
+              </div>
+              <span
+                className="map-section__aisle"
+              >
+                32
+              </span>
+              <div
+                className="map-section"
+              >
+                <span
+                  aria-label="32D Seat Unavailable"
+                  className="map-element map-element__seat"
+                >
+                  <svg
+                    aria-label="close"
+                    data-testid="close"
+                    height={14}
+                    style={
+                      {
+                        "display": "block",
+                        "fill": "currentColor",
+                      }
+                    }
+                    viewBox="0 0 24 24"
+                    width={14}
+                  >
+                    <path
+                      d="M18.3 5.71c-.39-.39-1.02-.39-1.41 0L12 10.59 7.11 5.7c-.39-.39-1.02-.39-1.41 0-.39.39-.39 1.02 0 1.41L10.59 12 5.7 16.89c-.39.39-.39 1.02 0 1.41.39.39 1.02.39 1.41 0L12 13.41l4.89 4.89c.39.39 1.02.39 1.41 0 .39-.39.39-1.02 0-1.41L13.41 12l4.89-4.89c.38-.38.38-1.02 0-1.4z"
+                    />
+                  </svg>
+                </span>
+                <span
+                  aria-label="32E Seat Unavailable"
+                  className="map-element map-element__seat"
+                >
+                  <svg
+                    aria-label="close"
+                    data-testid="close"
+                    height={14}
+                    style={
+                      {
+                        "display": "block",
+                        "fill": "currentColor",
+                      }
+                    }
+                    viewBox="0 0 24 24"
+                    width={14}
+                  >
+                    <path
+                      d="M18.3 5.71c-.39-.39-1.02-.39-1.41 0L12 10.59 7.11 5.7c-.39-.39-1.02-.39-1.41 0-.39.39-.39 1.02 0 1.41L10.59 12 5.7 16.89c-.39.39-.39 1.02 0 1.41.39.39 1.02.39 1.41 0L12 13.41l4.89 4.89c.39.39 1.02.39 1.41 0 .39-.39.39-1.02 0-1.41L13.41 12l4.89-4.89c.38-.38.38-1.02 0-1.4z"
+                    />
+                  </svg>
+                </span>
+                <button
+                  aria-label="32F Seat £20.00"
+                  className="map-element map-element__seat map-element--available map-element--actionable"
+                  data-testid="seat-32F"
+                  id="32F"
+                  onClick={[Function]}
+                >
+                  <svg
+                    aria-label="seat_paid_indicator"
+                    className="map-element--fee-payable"
+                    data-testid="seat_paid_indicator"
+                    height={16}
+                    style={
+                      {
+                        "display": "block",
+                        "fill": "currentColor",
+                      }
+                    }
+                    viewBox="0 0 24 24"
+                    width={16}
+                  >
+                    <path
+                      d="M11.7686 0.731368C12.7766 -0.276576 14.5 0.437294 14.5 1.86274V10.8C14.5 12.5673 13.0673 14 11.3 14H2.36274C0.937294 14 0.223427 12.2766 1.23137 11.2686L11.7686 0.731368Z"
+                    />
+                  </svg>
+                  F
+                </button>
+              </div>
+              <span
+                className="map-section__aisle"
+              >
+                32
+              </span>
+              <div
+                className="map-section map-section--right"
+              >
+                <button
+                  aria-label="32H Seat £20.00"
+                  className="map-element map-element__seat map-element--available map-element--actionable"
+                  data-testid="seat-32H"
+                  id="32H"
+                  onClick={[Function]}
+                >
+                  <svg
+                    aria-label="seat_paid_indicator"
+                    className="map-element--fee-payable"
+                    data-testid="seat_paid_indicator"
+                    height={16}
+                    style={
+                      {
+                        "display": "block",
+                        "fill": "currentColor",
+                      }
+                    }
+                    viewBox="0 0 24 24"
+                    width={16}
+                  >
+                    <path
+                      d="M11.7686 0.731368C12.7766 -0.276576 14.5 0.437294 14.5 1.86274V10.8C14.5 12.5673 13.0673 14 11.3 14H2.36274C0.937294 14 0.223427 12.2766 1.23137 11.2686L11.7686 0.731368Z"
+                    />
+                  </svg>
+                  H
+                </button>
+                <button
+                  aria-label="32J Seat £20.00"
+                  className="map-element map-element__seat map-element--available map-element--actionable"
+                  data-testid="seat-32J"
+                  id="32J"
+                  onClick={[Function]}
+                >
+                  <svg
+                    aria-label="seat_paid_indicator"
+                    className="map-element--fee-payable"
+                    data-testid="seat_paid_indicator"
+                    height={16}
+                    style={
+                      {
+                        "display": "block",
+                        "fill": "currentColor",
+                      }
+                    }
+                    viewBox="0 0 24 24"
+                    width={16}
+                  >
+                    <path
+                      d="M11.7686 0.731368C12.7766 -0.276576 14.5 0.437294 14.5 1.86274V10.8C14.5 12.5673 13.0673 14 11.3 14H2.36274C0.937294 14 0.223427 12.2766 1.23137 11.2686L11.7686 0.731368Z"
+                    />
+                  </svg>
+                  J
+                </button>
+                <span
+                  aria-label="32K Seat Unavailable"
+                  className="map-element map-element__seat"
+                >
+                  <svg
+                    aria-label="close"
+                    data-testid="close"
+                    height={14}
+                    style={
+                      {
+                        "display": "block",
+                        "fill": "currentColor",
+                      }
+                    }
+                    viewBox="0 0 24 24"
+                    width={14}
+                  >
+                    <path
+                      d="M18.3 5.71c-.39-.39-1.02-.39-1.41 0L12 10.59 7.11 5.7c-.39-.39-1.02-.39-1.41 0-.39.39-.39 1.02 0 1.41L10.59 12 5.7 16.89c-.39.39-.39 1.02 0 1.41.39.39 1.02.39 1.41 0L12 13.41l4.89 4.89c.39.39 1.02.39 1.41 0 .39-.39.39-1.02 0-1.41L13.41 12l4.89-4.89c.38-.38.38-1.02 0-1.4z"
+                    />
+                  </svg>
+                </span>
+              </div>
+              <div
+                className="map-section map-section--left"
+              >
+                <span
+                  aria-label="33A Seat Unavailable"
+                  className="map-element map-element__seat"
+                >
+                  <svg
+                    aria-label="close"
+                    data-testid="close"
+                    height={14}
+                    style={
+                      {
+                        "display": "block",
+                        "fill": "currentColor",
+                      }
+                    }
+                    viewBox="0 0 24 24"
+                    width={14}
+                  >
+                    <path
+                      d="M18.3 5.71c-.39-.39-1.02-.39-1.41 0L12 10.59 7.11 5.7c-.39-.39-1.02-.39-1.41 0-.39.39-.39 1.02 0 1.41L10.59 12 5.7 16.89c-.39.39-.39 1.02 0 1.41.39.39 1.02.39 1.41 0L12 13.41l4.89 4.89c.39.39 1.02.39 1.41 0 .39-.39.39-1.02 0-1.41L13.41 12l4.89-4.89c.38-.38.38-1.02 0-1.4z"
+                    />
+                  </svg>
+                </span>
+                <span
+                  aria-label="33B Seat Unavailable"
+                  className="map-element map-element__seat"
+                >
+                  <svg
+                    aria-label="close"
+                    data-testid="close"
+                    height={14}
+                    style={
+                      {
+                        "display": "block",
+                        "fill": "currentColor",
+                      }
+                    }
+                    viewBox="0 0 24 24"
+                    width={14}
+                  >
+                    <path
+                      d="M18.3 5.71c-.39-.39-1.02-.39-1.41 0L12 10.59 7.11 5.7c-.39-.39-1.02-.39-1.41 0-.39.39-.39 1.02 0 1.41L10.59 12 5.7 16.89c-.39.39-.39 1.02 0 1.41.39.39 1.02.39 1.41 0L12 13.41l4.89 4.89c.39.39 1.02.39 1.41 0 .39-.39.39-1.02 0-1.41L13.41 12l4.89-4.89c.38-.38.38-1.02 0-1.4z"
+                    />
+                  </svg>
+                </span>
+                <span
+                  aria-label="33C Seat Unavailable"
+                  className="map-element map-element__seat"
+                >
+                  <svg
+                    aria-label="close"
+                    data-testid="close"
+                    height={14}
+                    style={
+                      {
+                        "display": "block",
+                        "fill": "currentColor",
+                      }
+                    }
+                    viewBox="0 0 24 24"
+                    width={14}
+                  >
+                    <path
+                      d="M18.3 5.71c-.39-.39-1.02-.39-1.41 0L12 10.59 7.11 5.7c-.39-.39-1.02-.39-1.41 0-.39.39-.39 1.02 0 1.41L10.59 12 5.7 16.89c-.39.39-.39 1.02 0 1.41.39.39 1.02.39 1.41 0L12 13.41l4.89 4.89c.39.39 1.02.39 1.41 0 .39-.39.39-1.02 0-1.41L13.41 12l4.89-4.89c.38-.38.38-1.02 0-1.4z"
+                    />
+                  </svg>
+                </span>
+              </div>
+              <span
+                className="map-section__aisle"
+              >
+                33
+              </span>
+              <div
+                className="map-section"
+              >
+                <button
+                  aria-label="33D Seat £20.00"
+                  className="map-element map-element__seat map-element--available map-element--actionable"
+                  data-testid="seat-33D"
+                  id="33D"
+                  onClick={[Function]}
+                >
+                  <svg
+                    aria-label="seat_paid_indicator"
+                    className="map-element--fee-payable"
+                    data-testid="seat_paid_indicator"
+                    height={16}
+                    style={
+                      {
+                        "display": "block",
+                        "fill": "currentColor",
+                      }
+                    }
+                    viewBox="0 0 24 24"
+                    width={16}
+                  >
+                    <path
+                      d="M11.7686 0.731368C12.7766 -0.276576 14.5 0.437294 14.5 1.86274V10.8C14.5 12.5673 13.0673 14 11.3 14H2.36274C0.937294 14 0.223427 12.2766 1.23137 11.2686L11.7686 0.731368Z"
+                    />
+                  </svg>
+                  D
+                </button>
+                <span
+                  aria-label="33E Seat Unavailable"
+                  className="map-element map-element__seat"
+                >
+                  <svg
+                    aria-label="close"
+                    data-testid="close"
+                    height={14}
+                    style={
+                      {
+                        "display": "block",
+                        "fill": "currentColor",
+                      }
+                    }
+                    viewBox="0 0 24 24"
+                    width={14}
+                  >
+                    <path
+                      d="M18.3 5.71c-.39-.39-1.02-.39-1.41 0L12 10.59 7.11 5.7c-.39-.39-1.02-.39-1.41 0-.39.39-.39 1.02 0 1.41L10.59 12 5.7 16.89c-.39.39-.39 1.02 0 1.41.39.39 1.02.39 1.41 0L12 13.41l4.89 4.89c.39.39 1.02.39 1.41 0 .39-.39.39-1.02 0-1.41L13.41 12l4.89-4.89c.38-.38.38-1.02 0-1.4z"
+                    />
+                  </svg>
+                </span>
+                <button
+                  aria-label="33F Seat £20.00"
+                  className="map-element map-element__seat map-element--available map-element--actionable"
+                  data-testid="seat-33F"
+                  id="33F"
+                  onClick={[Function]}
+                >
+                  <svg
+                    aria-label="seat_paid_indicator"
+                    className="map-element--fee-payable"
+                    data-testid="seat_paid_indicator"
+                    height={16}
+                    style={
+                      {
+                        "display": "block",
+                        "fill": "currentColor",
+                      }
+                    }
+                    viewBox="0 0 24 24"
+                    width={16}
+                  >
+                    <path
+                      d="M11.7686 0.731368C12.7766 -0.276576 14.5 0.437294 14.5 1.86274V10.8C14.5 12.5673 13.0673 14 11.3 14H2.36274C0.937294 14 0.223427 12.2766 1.23137 11.2686L11.7686 0.731368Z"
+                    />
+                  </svg>
+                  F
+                </button>
+              </div>
+              <span
+                className="map-section__aisle"
+              >
+                33
+              </span>
+              <div
+                className="map-section map-section--right"
+              >
+                <button
+                  aria-label="33H Seat £20.00"
+                  className="map-element map-element__seat map-element--available map-element--actionable"
+                  data-testid="seat-33H"
+                  id="33H"
+                  onClick={[Function]}
+                >
+                  <svg
+                    aria-label="seat_paid_indicator"
+                    className="map-element--fee-payable"
+                    data-testid="seat_paid_indicator"
+                    height={16}
+                    style={
+                      {
+                        "display": "block",
+                        "fill": "currentColor",
+                      }
+                    }
+                    viewBox="0 0 24 24"
+                    width={16}
+                  >
+                    <path
+                      d="M11.7686 0.731368C12.7766 -0.276576 14.5 0.437294 14.5 1.86274V10.8C14.5 12.5673 13.0673 14 11.3 14H2.36274C0.937294 14 0.223427 12.2766 1.23137 11.2686L11.7686 0.731368Z"
+                    />
+                  </svg>
+                  H
+                </button>
+                <button
+                  aria-label="33J Seat £20.00"
+                  className="map-element map-element__seat map-element--available map-element--actionable"
+                  data-testid="seat-33J"
+                  id="33J"
+                  onClick={[Function]}
+                >
+                  <svg
+                    aria-label="seat_paid_indicator"
+                    className="map-element--fee-payable"
+                    data-testid="seat_paid_indicator"
+                    height={16}
+                    style={
+                      {
+                        "display": "block",
+                        "fill": "currentColor",
+                      }
+                    }
+                    viewBox="0 0 24 24"
+                    width={16}
+                  >
+                    <path
+                      d="M11.7686 0.731368C12.7766 -0.276576 14.5 0.437294 14.5 1.86274V10.8C14.5 12.5673 13.0673 14 11.3 14H2.36274C0.937294 14 0.223427 12.2766 1.23137 11.2686L11.7686 0.731368Z"
+                    />
+                  </svg>
+                  J
+                </button>
+                <span
+                  aria-label="33K Seat Unavailable"
+                  className="map-element map-element__seat"
+                >
+                  <svg
+                    aria-label="close"
+                    data-testid="close"
+                    height={14}
+                    style={
+                      {
+                        "display": "block",
+                        "fill": "currentColor",
+                      }
+                    }
+                    viewBox="0 0 24 24"
+                    width={14}
+                  >
+                    <path
+                      d="M18.3 5.71c-.39-.39-1.02-.39-1.41 0L12 10.59 7.11 5.7c-.39-.39-1.02-.39-1.41 0-.39.39-.39 1.02 0 1.41L10.59 12 5.7 16.89c-.39.39-.39 1.02 0 1.41.39.39 1.02.39 1.41 0L12 13.41l4.89 4.89c.39.39 1.02.39 1.41 0 .39-.39.39-1.02 0-1.41L13.41 12l4.89-4.89c.38-.38.38-1.02 0-1.4z"
+                    />
+                  </svg>
+                </span>
+              </div>
+              <div
+                className="map-section map-section--left"
+              >
+                <span
+                  aria-label="34A Seat Unavailable"
+                  className="map-element map-element__seat"
+                >
+                  <svg
+                    aria-label="close"
+                    data-testid="close"
+                    height={14}
+                    style={
+                      {
+                        "display": "block",
+                        "fill": "currentColor",
+                      }
+                    }
+                    viewBox="0 0 24 24"
+                    width={14}
+                  >
+                    <path
+                      d="M18.3 5.71c-.39-.39-1.02-.39-1.41 0L12 10.59 7.11 5.7c-.39-.39-1.02-.39-1.41 0-.39.39-.39 1.02 0 1.41L10.59 12 5.7 16.89c-.39.39-.39 1.02 0 1.41.39.39 1.02.39 1.41 0L12 13.41l4.89 4.89c.39.39 1.02.39 1.41 0 .39-.39.39-1.02 0-1.41L13.41 12l4.89-4.89c.38-.38.38-1.02 0-1.4z"
+                    />
+                  </svg>
+                </span>
+                <span
+                  aria-label="34B Seat Unavailable"
+                  className="map-element map-element__seat"
+                >
+                  <svg
+                    aria-label="close"
+                    data-testid="close"
+                    height={14}
+                    style={
+                      {
+                        "display": "block",
+                        "fill": "currentColor",
+                      }
+                    }
+                    viewBox="0 0 24 24"
+                    width={14}
+                  >
+                    <path
+                      d="M18.3 5.71c-.39-.39-1.02-.39-1.41 0L12 10.59 7.11 5.7c-.39-.39-1.02-.39-1.41 0-.39.39-.39 1.02 0 1.41L10.59 12 5.7 16.89c-.39.39-.39 1.02 0 1.41.39.39 1.02.39 1.41 0L12 13.41l4.89 4.89c.39.39 1.02.39 1.41 0 .39-.39.39-1.02 0-1.41L13.41 12l4.89-4.89c.38-.38.38-1.02 0-1.4z"
+                    />
+                  </svg>
+                </span>
+                <button
+                  aria-label="34C Seat £20.00"
+                  className="map-element map-element__seat map-element--available map-element--actionable"
+                  data-testid="seat-34C"
+                  id="34C"
+                  onClick={[Function]}
+                >
+                  <svg
+                    aria-label="seat_paid_indicator"
+                    className="map-element--fee-payable"
+                    data-testid="seat_paid_indicator"
+                    height={16}
+                    style={
+                      {
+                        "display": "block",
+                        "fill": "currentColor",
+                      }
+                    }
+                    viewBox="0 0 24 24"
+                    width={16}
+                  >
+                    <path
+                      d="M11.7686 0.731368C12.7766 -0.276576 14.5 0.437294 14.5 1.86274V10.8C14.5 12.5673 13.0673 14 11.3 14H2.36274C0.937294 14 0.223427 12.2766 1.23137 11.2686L11.7686 0.731368Z"
+                    />
+                  </svg>
+                  C
+                </button>
+              </div>
+              <span
+                className="map-section__aisle"
+              >
+                34
+              </span>
+              <div
+                className="map-section"
+              >
+                <span
+                  aria-label="34D Seat Unavailable"
+                  className="map-element map-element__seat"
+                >
+                  <svg
+                    aria-label="close"
+                    data-testid="close"
+                    height={14}
+                    style={
+                      {
+                        "display": "block",
+                        "fill": "currentColor",
+                      }
+                    }
+                    viewBox="0 0 24 24"
+                    width={14}
+                  >
+                    <path
+                      d="M18.3 5.71c-.39-.39-1.02-.39-1.41 0L12 10.59 7.11 5.7c-.39-.39-1.02-.39-1.41 0-.39.39-.39 1.02 0 1.41L10.59 12 5.7 16.89c-.39.39-.39 1.02 0 1.41.39.39 1.02.39 1.41 0L12 13.41l4.89 4.89c.39.39 1.02.39 1.41 0 .39-.39.39-1.02 0-1.41L13.41 12l4.89-4.89c.38-.38.38-1.02 0-1.4z"
+                    />
+                  </svg>
+                </span>
+                <button
+                  aria-label="34E Seat £20.00"
+                  className="map-element map-element__seat map-element--available map-element--actionable"
+                  data-testid="seat-34E"
+                  id="34E"
+                  onClick={[Function]}
+                >
+                  <svg
+                    aria-label="seat_paid_indicator"
+                    className="map-element--fee-payable"
+                    data-testid="seat_paid_indicator"
+                    height={16}
+                    style={
+                      {
+                        "display": "block",
+                        "fill": "currentColor",
+                      }
+                    }
+                    viewBox="0 0 24 24"
+                    width={16}
+                  >
+                    <path
+                      d="M11.7686 0.731368C12.7766 -0.276576 14.5 0.437294 14.5 1.86274V10.8C14.5 12.5673 13.0673 14 11.3 14H2.36274C0.937294 14 0.223427 12.2766 1.23137 11.2686L11.7686 0.731368Z"
+                    />
+                  </svg>
+                  E
+                </button>
+                <span
+                  aria-label="34F Seat Unavailable"
+                  className="map-element map-element__seat"
+                >
+                  <svg
+                    aria-label="close"
+                    data-testid="close"
+                    height={14}
+                    style={
+                      {
+                        "display": "block",
+                        "fill": "currentColor",
+                      }
+                    }
+                    viewBox="0 0 24 24"
+                    width={14}
+                  >
+                    <path
+                      d="M18.3 5.71c-.39-.39-1.02-.39-1.41 0L12 10.59 7.11 5.7c-.39-.39-1.02-.39-1.41 0-.39.39-.39 1.02 0 1.41L10.59 12 5.7 16.89c-.39.39-.39 1.02 0 1.41.39.39 1.02.39 1.41 0L12 13.41l4.89 4.89c.39.39 1.02.39 1.41 0 .39-.39.39-1.02 0-1.41L13.41 12l4.89-4.89c.38-.38.38-1.02 0-1.4z"
+                    />
+                  </svg>
+                </span>
+              </div>
+              <span
+                className="map-section__aisle"
+              >
+                34
+              </span>
+              <div
+                className="map-section map-section--right"
+              >
+                <span
+                  aria-label="34H Seat Unavailable"
+                  className="map-element map-element__seat"
+                >
+                  <svg
+                    aria-label="close"
+                    data-testid="close"
+                    height={14}
+                    style={
+                      {
+                        "display": "block",
+                        "fill": "currentColor",
+                      }
+                    }
+                    viewBox="0 0 24 24"
+                    width={14}
+                  >
+                    <path
+                      d="M18.3 5.71c-.39-.39-1.02-.39-1.41 0L12 10.59 7.11 5.7c-.39-.39-1.02-.39-1.41 0-.39.39-.39 1.02 0 1.41L10.59 12 5.7 16.89c-.39.39-.39 1.02 0 1.41.39.39 1.02.39 1.41 0L12 13.41l4.89 4.89c.39.39 1.02.39 1.41 0 .39-.39.39-1.02 0-1.41L13.41 12l4.89-4.89c.38-.38.38-1.02 0-1.4z"
+                    />
+                  </svg>
+                </span>
+                <span
+                  aria-label="34J Seat Unavailable"
+                  className="map-element map-element__seat"
+                >
+                  <svg
+                    aria-label="close"
+                    data-testid="close"
+                    height={14}
+                    style={
+                      {
+                        "display": "block",
+                        "fill": "currentColor",
+                      }
+                    }
+                    viewBox="0 0 24 24"
+                    width={14}
+                  >
+                    <path
+                      d="M18.3 5.71c-.39-.39-1.02-.39-1.41 0L12 10.59 7.11 5.7c-.39-.39-1.02-.39-1.41 0-.39.39-.39 1.02 0 1.41L10.59 12 5.7 16.89c-.39.39-.39 1.02 0 1.41.39.39 1.02.39 1.41 0L12 13.41l4.89 4.89c.39.39 1.02.39 1.41 0 .39-.39.39-1.02 0-1.41L13.41 12l4.89-4.89c.38-.38.38-1.02 0-1.4z"
+                    />
+                  </svg>
+                </span>
+                <span
+                  aria-label="34K Seat Unavailable"
+                  className="map-element map-element__seat"
+                >
+                  <svg
+                    aria-label="close"
+                    data-testid="close"
+                    height={14}
+                    style={
+                      {
+                        "display": "block",
+                        "fill": "currentColor",
+                      }
+                    }
+                    viewBox="0 0 24 24"
+                    width={14}
+                  >
+                    <path
+                      d="M18.3 5.71c-.39-.39-1.02-.39-1.41 0L12 10.59 7.11 5.7c-.39-.39-1.02-.39-1.41 0-.39.39-.39 1.02 0 1.41L10.59 12 5.7 16.89c-.39.39-.39 1.02 0 1.41.39.39 1.02.39 1.41 0L12 13.41l4.89 4.89c.39.39 1.02.39 1.41 0 .39-.39.39-1.02 0-1.41L13.41 12l4.89-4.89c.38-.38.38-1.02 0-1.4z"
+                    />
+                  </svg>
+                </span>
+              </div>
+              <div
+                className="map-section map-section--left"
+              >
+                <button
+                  aria-label="35A Seat £20.00"
+                  className="map-element map-element__seat map-element--available map-element--actionable"
+                  data-testid="seat-35A"
+                  id="35A"
+                  onClick={[Function]}
+                >
+                  <svg
+                    aria-label="seat_paid_indicator"
+                    className="map-element--fee-payable"
+                    data-testid="seat_paid_indicator"
+                    height={16}
+                    style={
+                      {
+                        "display": "block",
+                        "fill": "currentColor",
+                      }
+                    }
+                    viewBox="0 0 24 24"
+                    width={16}
+                  >
+                    <path
+                      d="M11.7686 0.731368C12.7766 -0.276576 14.5 0.437294 14.5 1.86274V10.8C14.5 12.5673 13.0673 14 11.3 14H2.36274C0.937294 14 0.223427 12.2766 1.23137 11.2686L11.7686 0.731368Z"
+                    />
+                  </svg>
+                  A
+                </button>
+                <span
+                  aria-label="35B Seat Unavailable"
+                  className="map-element map-element__seat"
+                >
+                  <svg
+                    aria-label="close"
+                    data-testid="close"
+                    height={14}
+                    style={
+                      {
+                        "display": "block",
+                        "fill": "currentColor",
+                      }
+                    }
+                    viewBox="0 0 24 24"
+                    width={14}
+                  >
+                    <path
+                      d="M18.3 5.71c-.39-.39-1.02-.39-1.41 0L12 10.59 7.11 5.7c-.39-.39-1.02-.39-1.41 0-.39.39-.39 1.02 0 1.41L10.59 12 5.7 16.89c-.39.39-.39 1.02 0 1.41.39.39 1.02.39 1.41 0L12 13.41l4.89 4.89c.39.39 1.02.39 1.41 0 .39-.39.39-1.02 0-1.41L13.41 12l4.89-4.89c.38-.38.38-1.02 0-1.4z"
+                    />
+                  </svg>
+                </span>
+                <span
+                  aria-label="35C Seat Unavailable"
+                  className="map-element map-element__seat"
+                >
+                  <svg
+                    aria-label="close"
+                    data-testid="close"
+                    height={14}
+                    style={
+                      {
+                        "display": "block",
+                        "fill": "currentColor",
+                      }
+                    }
+                    viewBox="0 0 24 24"
+                    width={14}
+                  >
+                    <path
+                      d="M18.3 5.71c-.39-.39-1.02-.39-1.41 0L12 10.59 7.11 5.7c-.39-.39-1.02-.39-1.41 0-.39.39-.39 1.02 0 1.41L10.59 12 5.7 16.89c-.39.39-.39 1.02 0 1.41.39.39 1.02.39 1.41 0L12 13.41l4.89 4.89c.39.39 1.02.39 1.41 0 .39-.39.39-1.02 0-1.41L13.41 12l4.89-4.89c.38-.38.38-1.02 0-1.4z"
+                    />
+                  </svg>
+                </span>
+              </div>
+              <span
+                className="map-section__aisle"
+              >
+                35
+              </span>
+              <div
+                className="map-section"
+              >
+                <button
+                  aria-label="35D Seat £20.00"
+                  className="map-element map-element__seat map-element--available map-element--actionable"
+                  data-testid="seat-35D"
+                  id="35D"
+                  onClick={[Function]}
+                >
+                  <svg
+                    aria-label="seat_paid_indicator"
+                    className="map-element--fee-payable"
+                    data-testid="seat_paid_indicator"
+                    height={16}
+                    style={
+                      {
+                        "display": "block",
+                        "fill": "currentColor",
+                      }
+                    }
+                    viewBox="0 0 24 24"
+                    width={16}
+                  >
+                    <path
+                      d="M11.7686 0.731368C12.7766 -0.276576 14.5 0.437294 14.5 1.86274V10.8C14.5 12.5673 13.0673 14 11.3 14H2.36274C0.937294 14 0.223427 12.2766 1.23137 11.2686L11.7686 0.731368Z"
+                    />
+                  </svg>
+                  D
+                </button>
+                <span
+                  aria-label="35E Seat Unavailable"
+                  className="map-element map-element__seat"
+                >
+                  <svg
+                    aria-label="close"
+                    data-testid="close"
+                    height={14}
+                    style={
+                      {
+                        "display": "block",
+                        "fill": "currentColor",
+                      }
+                    }
+                    viewBox="0 0 24 24"
+                    width={14}
+                  >
+                    <path
+                      d="M18.3 5.71c-.39-.39-1.02-.39-1.41 0L12 10.59 7.11 5.7c-.39-.39-1.02-.39-1.41 0-.39.39-.39 1.02 0 1.41L10.59 12 5.7 16.89c-.39.39-.39 1.02 0 1.41.39.39 1.02.39 1.41 0L12 13.41l4.89 4.89c.39.39 1.02.39 1.41 0 .39-.39.39-1.02 0-1.41L13.41 12l4.89-4.89c.38-.38.38-1.02 0-1.4z"
+                    />
+                  </svg>
+                </span>
+                <span
+                  aria-label="35F Seat Unavailable"
+                  className="map-element map-element__seat"
+                >
+                  <svg
+                    aria-label="close"
+                    data-testid="close"
+                    height={14}
+                    style={
+                      {
+                        "display": "block",
+                        "fill": "currentColor",
+                      }
+                    }
+                    viewBox="0 0 24 24"
+                    width={14}
+                  >
+                    <path
+                      d="M18.3 5.71c-.39-.39-1.02-.39-1.41 0L12 10.59 7.11 5.7c-.39-.39-1.02-.39-1.41 0-.39.39-.39 1.02 0 1.41L10.59 12 5.7 16.89c-.39.39-.39 1.02 0 1.41.39.39 1.02.39 1.41 0L12 13.41l4.89 4.89c.39.39 1.02.39 1.41 0 .39-.39.39-1.02 0-1.41L13.41 12l4.89-4.89c.38-.38.38-1.02 0-1.4z"
+                    />
+                  </svg>
+                </span>
+              </div>
+              <span
+                className="map-section__aisle"
+              >
+                35
+              </span>
+              <div
+                className="map-section map-section--right"
+              >
+                <button
+                  aria-label="35H Seat £20.00"
+                  className="map-element map-element__seat map-element--available map-element--actionable"
+                  data-testid="seat-35H"
+                  id="35H"
+                  onClick={[Function]}
+                >
+                  <svg
+                    aria-label="seat_paid_indicator"
+                    className="map-element--fee-payable"
+                    data-testid="seat_paid_indicator"
+                    height={16}
+                    style={
+                      {
+                        "display": "block",
+                        "fill": "currentColor",
+                      }
+                    }
+                    viewBox="0 0 24 24"
+                    width={16}
+                  >
+                    <path
+                      d="M11.7686 0.731368C12.7766 -0.276576 14.5 0.437294 14.5 1.86274V10.8C14.5 12.5673 13.0673 14 11.3 14H2.36274C0.937294 14 0.223427 12.2766 1.23137 11.2686L11.7686 0.731368Z"
+                    />
+                  </svg>
+                  H
+                </button>
+                <button
+                  aria-label="35J Seat £20.00"
+                  className="map-element map-element__seat map-element--available map-element--actionable"
+                  data-testid="seat-35J"
+                  id="35J"
+                  onClick={[Function]}
+                >
+                  <svg
+                    aria-label="seat_paid_indicator"
+                    className="map-element--fee-payable"
+                    data-testid="seat_paid_indicator"
+                    height={16}
+                    style={
+                      {
+                        "display": "block",
+                        "fill": "currentColor",
+                      }
+                    }
+                    viewBox="0 0 24 24"
+                    width={16}
+                  >
+                    <path
+                      d="M11.7686 0.731368C12.7766 -0.276576 14.5 0.437294 14.5 1.86274V10.8C14.5 12.5673 13.0673 14 11.3 14H2.36274C0.937294 14 0.223427 12.2766 1.23137 11.2686L11.7686 0.731368Z"
+                    />
+                  </svg>
+                  J
+                </button>
+                <span
+                  aria-label="35K Seat Unavailable"
+                  className="map-element map-element__seat"
+                >
+                  <svg
+                    aria-label="close"
+                    data-testid="close"
+                    height={14}
+                    style={
+                      {
+                        "display": "block",
+                        "fill": "currentColor",
+                      }
+                    }
+                    viewBox="0 0 24 24"
+                    width={14}
+                  >
+                    <path
+                      d="M18.3 5.71c-.39-.39-1.02-.39-1.41 0L12 10.59 7.11 5.7c-.39-.39-1.02-.39-1.41 0-.39.39-.39 1.02 0 1.41L10.59 12 5.7 16.89c-.39.39-.39 1.02 0 1.41.39.39 1.02.39 1.41 0L12 13.41l4.89 4.89c.39.39 1.02.39 1.41 0 .39-.39.39-1.02 0-1.41L13.41 12l4.89-4.89c.38-.38.38-1.02 0-1.4z"
+                    />
+                  </svg>
+                </span>
+              </div>
+              <div
+                className="map-section map-section--left"
+              >
+                <div
+                  aria-label="lavatory"
+                  className="map-element map-element--amenity map-element--wrapped"
+                >
+                  <svg
+                    aria-label="lavatory"
+                    data-testid="lavatory"
+                    height={16}
+                    style={
+                      {
+                        "display": "block",
+                        "fill": "currentColor",
+                      }
+                    }
+                    viewBox="0 0 24 24"
+                    width={16}
+                  >
+                    <path
+                      d="M5.5 22v-7.5H4V9c0-1.1.9-2 2-2h3c1.1 0 2 .9 2 2v5.5H9.5V22h-4zM18 22v-6h3l-2.54-7.63C18.18 7.55 17.42 7 16.56 7h-.12c-.86 0-1.63.55-1.9 1.37L12 16h3v6h3zM7.5 6c1.11 0 2-.89 2-2s-.89-2-2-2-2 .89-2 2 .89 2 2 2zm9 0c1.11 0 2-.89 2-2s-.89-2-2-2-2 .89-2 2 .89 2 2 2z"
+                    />
+                  </svg>
+                </div>
+              </div>
+              <span
+                className="map-section__aisle"
+              />
+              <div
+                className="map-section"
+              >
+                <div
+                  aria-label="lavatory"
+                  className="map-element map-element--amenity map-element--wrapped"
+                >
+                  <svg
+                    aria-label="lavatory"
+                    data-testid="lavatory"
+                    height={16}
+                    style={
+                      {
+                        "display": "block",
+                        "fill": "currentColor",
+                      }
+                    }
+                    viewBox="0 0 24 24"
+                    width={16}
+                  >
+                    <path
+                      d="M5.5 22v-7.5H4V9c0-1.1.9-2 2-2h3c1.1 0 2 .9 2 2v5.5H9.5V22h-4zM18 22v-6h3l-2.54-7.63C18.18 7.55 17.42 7 16.56 7h-.12c-.86 0-1.63.55-1.9 1.37L12 16h3v6h3zM7.5 6c1.11 0 2-.89 2-2s-.89-2-2-2-2 .89-2 2 .89 2 2 2zm9 0c1.11 0 2-.89 2-2s-.89-2-2-2-2 .89-2 2 .89 2 2 2z"
+                    />
+                  </svg>
+                </div>
+              </div>
+              <span
+                className="map-section__aisle"
+              />
+              <div
+                className="map-section map-section--right"
+              >
+                <div
+                  aria-label="lavatory"
+                  className="map-element map-element--amenity map-element--wrapped"
+                >
+                  <svg
+                    aria-label="lavatory"
+                    data-testid="lavatory"
+                    height={16}
+                    style={
+                      {
+                        "display": "block",
+                        "fill": "currentColor",
+                      }
+                    }
+                    viewBox="0 0 24 24"
+                    width={16}
+                  >
+                    <path
+                      d="M5.5 22v-7.5H4V9c0-1.1.9-2 2-2h3c1.1 0 2 .9 2 2v5.5H9.5V22h-4zM18 22v-6h3l-2.54-7.63C18.18 7.55 17.42 7 16.56 7h-.12c-.86 0-1.63.55-1.9 1.37L12 16h3v6h3zM7.5 6c1.11 0 2-.89 2-2s-.89-2-2-2-2 .89-2 2 .89 2 2 2zm9 0c1.11 0 2-.89 2-2s-.89-2-2-2-2 .89-2 2 .89 2 2 2z"
+                    />
+                  </svg>
+                </div>
+              </div>
+              <div
+                className="map-section map-section--left"
+              >
+                <div
+                  className="map-element map-element--exit"
+                >
+                  <svg
+                    aria-label="exit_row"
+                    data-testid="exit_row"
+                    height={24}
+                    style={
+                      {
+                        "display": "block",
+                        "fill": "currentColor",
+                      }
+                    }
+                    viewBox="0 0 24 24"
+                    width={24}
+                  >
+                    <path
+                      d="M20 11H6.83001L9.71001 8.12001C10.1 7.73001 10.1 7.10001 9.71001 6.71001C9.32001 6.32001 8.69001 6.32001 8.30001 6.71001L3.71001 11.3C3.32001 11.69 3.32001 12.32 3.71001 12.71L8.30001 17.3C8.69001 17.69 9.32001 17.69 9.71001 17.3C10.1 16.91 10.1 16.28 9.71001 15.89L6.83001 13H20C20.55 13 21 12.55 21 12C21 11.45 20.55 11 20 11Z"
+                    />
+                  </svg>
+                </div>
+              </div>
+              <span
+                className="map-section__aisle"
+              />
+              <div
+                className="map-section"
+              >
+                <div
+                  className="map-element map-element--empty"
+                />
+              </div>
+              <span
+                className="map-section__aisle"
+              />
+              <div
+                className="map-section map-section--right"
+              >
+                <div
+                  className="map-element map-element--exit map-element--exit--right"
+                >
+                  <svg
+                    aria-label="exit_row_right"
+                    data-testid="exit_row_right"
+                    height={24}
+                    style={
+                      {
+                        "display": "block",
+                        "fill": "currentColor",
+                      }
+                    }
+                    viewBox="0 0 24 24"
+                    width={24}
+                  >
+                    <path
+                      d="M4 11H17.17L14.29 8.12001C13.9 7.73001 13.9 7.10001 14.29 6.71001C14.68 6.32001 15.31 6.32001 15.7 6.71001L20.29 11.3C20.68 11.69 20.68 12.32 20.29 12.71L15.7 17.3C15.31 17.69 14.68 17.69 14.29 17.3C13.9 16.91 13.9 16.28 14.29 15.89L17.17 13H4C3.45 13 3 12.55 3 12C3 11.45 3.45 11 4 11Z"
+                    />
+                  </svg>
+                </div>
+              </div>
+              <div
+                className="map-section map-section--left"
+              >
+                <button
+                  aria-label="37A Seat £20.00"
+                  className="map-element map-element__seat map-element--available map-element--actionable"
+                  data-testid="seat-37A"
+                  id="37A"
+                  onClick={[Function]}
+                >
+                  <svg
+                    aria-label="seat_paid_indicator"
+                    className="map-element--fee-payable"
+                    data-testid="seat_paid_indicator"
+                    height={16}
+                    style={
+                      {
+                        "display": "block",
+                        "fill": "currentColor",
+                      }
+                    }
+                    viewBox="0 0 24 24"
+                    width={16}
+                  >
+                    <path
+                      d="M11.7686 0.731368C12.7766 -0.276576 14.5 0.437294 14.5 1.86274V10.8C14.5 12.5673 13.0673 14 11.3 14H2.36274C0.937294 14 0.223427 12.2766 1.23137 11.2686L11.7686 0.731368Z"
+                    />
+                  </svg>
+                  A
+                </button>
+                <button
+                  aria-label="37B Seat £20.00"
+                  className="map-element map-element__seat map-element--available map-element--actionable"
+                  data-testid="seat-37B"
+                  id="37B"
+                  onClick={[Function]}
+                >
+                  <svg
+                    aria-label="seat_paid_indicator"
+                    className="map-element--fee-payable"
+                    data-testid="seat_paid_indicator"
+                    height={16}
+                    style={
+                      {
+                        "display": "block",
+                        "fill": "currentColor",
+                      }
+                    }
+                    viewBox="0 0 24 24"
+                    width={16}
+                  >
+                    <path
+                      d="M11.7686 0.731368C12.7766 -0.276576 14.5 0.437294 14.5 1.86274V10.8C14.5 12.5673 13.0673 14 11.3 14H2.36274C0.937294 14 0.223427 12.2766 1.23137 11.2686L11.7686 0.731368Z"
+                    />
+                  </svg>
+                  B
+                </button>
+                <button
+                  aria-label="37C Seat £20.00"
+                  className="map-element map-element__seat map-element--available map-element--actionable"
+                  data-testid="seat-37C"
+                  id="37C"
+                  onClick={[Function]}
+                >
+                  <svg
+                    aria-label="seat_paid_indicator"
+                    className="map-element--fee-payable"
+                    data-testid="seat_paid_indicator"
+                    height={16}
+                    style={
+                      {
+                        "display": "block",
+                        "fill": "currentColor",
+                      }
+                    }
+                    viewBox="0 0 24 24"
+                    width={16}
+                  >
+                    <path
+                      d="M11.7686 0.731368C12.7766 -0.276576 14.5 0.437294 14.5 1.86274V10.8C14.5 12.5673 13.0673 14 11.3 14H2.36274C0.937294 14 0.223427 12.2766 1.23137 11.2686L11.7686 0.731368Z"
+                    />
+                  </svg>
+                  C
+                </button>
+              </div>
+              <span
+                className="map-section__aisle"
+              >
+                37
+              </span>
+              <div
+                className="map-section"
+              >
+                <button
+                  aria-label="37D Seat £20.00"
+                  className="map-element map-element__seat map-element--available map-element--actionable"
+                  data-testid="seat-37D"
+                  id="37D"
+                  onClick={[Function]}
+                >
+                  <svg
+                    aria-label="seat_paid_indicator"
+                    className="map-element--fee-payable"
+                    data-testid="seat_paid_indicator"
+                    height={16}
+                    style={
+                      {
+                        "display": "block",
+                        "fill": "currentColor",
+                      }
+                    }
+                    viewBox="0 0 24 24"
+                    width={16}
+                  >
+                    <path
+                      d="M11.7686 0.731368C12.7766 -0.276576 14.5 0.437294 14.5 1.86274V10.8C14.5 12.5673 13.0673 14 11.3 14H2.36274C0.937294 14 0.223427 12.2766 1.23137 11.2686L11.7686 0.731368Z"
+                    />
+                  </svg>
+                  D
+                </button>
+                <button
+                  aria-label="37E Seat £20.00"
+                  className="map-element map-element__seat map-element--available map-element--actionable"
+                  data-testid="seat-37E"
+                  id="37E"
+                  onClick={[Function]}
+                >
+                  <svg
+                    aria-label="seat_paid_indicator"
+                    className="map-element--fee-payable"
+                    data-testid="seat_paid_indicator"
+                    height={16}
+                    style={
+                      {
+                        "display": "block",
+                        "fill": "currentColor",
+                      }
+                    }
+                    viewBox="0 0 24 24"
+                    width={16}
+                  >
+                    <path
+                      d="M11.7686 0.731368C12.7766 -0.276576 14.5 0.437294 14.5 1.86274V10.8C14.5 12.5673 13.0673 14 11.3 14H2.36274C0.937294 14 0.223427 12.2766 1.23137 11.2686L11.7686 0.731368Z"
+                    />
+                  </svg>
+                  E
+                </button>
+                <span
+                  aria-label="37F Seat Unavailable"
+                  className="map-element map-element__seat"
+                >
+                  <svg
+                    aria-label="close"
+                    data-testid="close"
+                    height={14}
+                    style={
+                      {
+                        "display": "block",
+                        "fill": "currentColor",
+                      }
+                    }
+                    viewBox="0 0 24 24"
+                    width={14}
+                  >
+                    <path
+                      d="M18.3 5.71c-.39-.39-1.02-.39-1.41 0L12 10.59 7.11 5.7c-.39-.39-1.02-.39-1.41 0-.39.39-.39 1.02 0 1.41L10.59 12 5.7 16.89c-.39.39-.39 1.02 0 1.41.39.39 1.02.39 1.41 0L12 13.41l4.89 4.89c.39.39 1.02.39 1.41 0 .39-.39.39-1.02 0-1.41L13.41 12l4.89-4.89c.38-.38.38-1.02 0-1.4z"
+                    />
+                  </svg>
+                </span>
+              </div>
+              <span
+                className="map-section__aisle"
+              >
+                37
+              </span>
+              <div
+                className="map-section map-section--right"
+              >
+                <button
+                  aria-label="37H Seat £20.00"
+                  className="map-element map-element__seat map-element--available map-element--actionable"
+                  data-testid="seat-37H"
+                  id="37H"
+                  onClick={[Function]}
+                >
+                  <svg
+                    aria-label="seat_paid_indicator"
+                    className="map-element--fee-payable"
+                    data-testid="seat_paid_indicator"
+                    height={16}
+                    style={
+                      {
+                        "display": "block",
+                        "fill": "currentColor",
+                      }
+                    }
+                    viewBox="0 0 24 24"
+                    width={16}
+                  >
+                    <path
+                      d="M11.7686 0.731368C12.7766 -0.276576 14.5 0.437294 14.5 1.86274V10.8C14.5 12.5673 13.0673 14 11.3 14H2.36274C0.937294 14 0.223427 12.2766 1.23137 11.2686L11.7686 0.731368Z"
+                    />
+                  </svg>
+                  H
+                </button>
+                <button
+                  aria-label="37J Seat £20.00"
+                  className="map-element map-element__seat map-element--available map-element--actionable"
+                  data-testid="seat-37J"
+                  id="37J"
+                  onClick={[Function]}
+                >
+                  <svg
+                    aria-label="seat_paid_indicator"
+                    className="map-element--fee-payable"
+                    data-testid="seat_paid_indicator"
+                    height={16}
+                    style={
+                      {
+                        "display": "block",
+                        "fill": "currentColor",
+                      }
+                    }
+                    viewBox="0 0 24 24"
+                    width={16}
+                  >
+                    <path
+                      d="M11.7686 0.731368C12.7766 -0.276576 14.5 0.437294 14.5 1.86274V10.8C14.5 12.5673 13.0673 14 11.3 14H2.36274C0.937294 14 0.223427 12.2766 1.23137 11.2686L11.7686 0.731368Z"
+                    />
+                  </svg>
+                  J
+                </button>
+                <button
+                  aria-label="37K Seat £20.00"
+                  className="map-element map-element__seat map-element--available map-element--actionable"
+                  data-testid="seat-37K"
+                  id="37K"
+                  onClick={[Function]}
+                >
+                  <svg
+                    aria-label="seat_paid_indicator"
+                    className="map-element--fee-payable"
+                    data-testid="seat_paid_indicator"
+                    height={16}
+                    style={
+                      {
+                        "display": "block",
+                        "fill": "currentColor",
+                      }
+                    }
+                    viewBox="0 0 24 24"
+                    width={16}
+                  >
+                    <path
+                      d="M11.7686 0.731368C12.7766 -0.276576 14.5 0.437294 14.5 1.86274V10.8C14.5 12.5673 13.0673 14 11.3 14H2.36274C0.937294 14 0.223427 12.2766 1.23137 11.2686L11.7686 0.731368Z"
+                    />
+                  </svg>
+                  K
+                </button>
+              </div>
+              <div
+                className="map-section map-section--left"
+              >
+                <span
+                  aria-label="38A Seat Unavailable"
+                  className="map-element map-element__seat"
+                >
+                  <svg
+                    aria-label="close"
+                    data-testid="close"
+                    height={14}
+                    style={
+                      {
+                        "display": "block",
+                        "fill": "currentColor",
+                      }
+                    }
+                    viewBox="0 0 24 24"
+                    width={14}
+                  >
+                    <path
+                      d="M18.3 5.71c-.39-.39-1.02-.39-1.41 0L12 10.59 7.11 5.7c-.39-.39-1.02-.39-1.41 0-.39.39-.39 1.02 0 1.41L10.59 12 5.7 16.89c-.39.39-.39 1.02 0 1.41.39.39 1.02.39 1.41 0L12 13.41l4.89 4.89c.39.39 1.02.39 1.41 0 .39-.39.39-1.02 0-1.41L13.41 12l4.89-4.89c.38-.38.38-1.02 0-1.4z"
+                    />
+                  </svg>
+                </span>
+                <span
+                  aria-label="38B Seat Unavailable"
+                  className="map-element map-element__seat"
+                >
+                  <svg
+                    aria-label="close"
+                    data-testid="close"
+                    height={14}
+                    style={
+                      {
+                        "display": "block",
+                        "fill": "currentColor",
+                      }
+                    }
+                    viewBox="0 0 24 24"
+                    width={14}
+                  >
+                    <path
+                      d="M18.3 5.71c-.39-.39-1.02-.39-1.41 0L12 10.59 7.11 5.7c-.39-.39-1.02-.39-1.41 0-.39.39-.39 1.02 0 1.41L10.59 12 5.7 16.89c-.39.39-.39 1.02 0 1.41.39.39 1.02.39 1.41 0L12 13.41l4.89 4.89c.39.39 1.02.39 1.41 0 .39-.39.39-1.02 0-1.41L13.41 12l4.89-4.89c.38-.38.38-1.02 0-1.4z"
+                    />
+                  </svg>
+                </span>
+                <button
+                  aria-label="38C Seat £20.00"
+                  className="map-element map-element__seat map-element--available map-element--actionable"
+                  data-testid="seat-38C"
+                  id="38C"
+                  onClick={[Function]}
+                >
+                  <svg
+                    aria-label="seat_paid_indicator"
+                    className="map-element--fee-payable"
+                    data-testid="seat_paid_indicator"
+                    height={16}
+                    style={
+                      {
+                        "display": "block",
+                        "fill": "currentColor",
+                      }
+                    }
+                    viewBox="0 0 24 24"
+                    width={16}
+                  >
+                    <path
+                      d="M11.7686 0.731368C12.7766 -0.276576 14.5 0.437294 14.5 1.86274V10.8C14.5 12.5673 13.0673 14 11.3 14H2.36274C0.937294 14 0.223427 12.2766 1.23137 11.2686L11.7686 0.731368Z"
+                    />
+                  </svg>
+                  C
+                </button>
+              </div>
+              <span
+                className="map-section__aisle"
+              >
+                38
+              </span>
+              <div
+                className="map-section"
+              >
+                <span
+                  aria-label="38D Seat Unavailable"
+                  className="map-element map-element__seat"
+                >
+                  <svg
+                    aria-label="close"
+                    data-testid="close"
+                    height={14}
+                    style={
+                      {
+                        "display": "block",
+                        "fill": "currentColor",
+                      }
+                    }
+                    viewBox="0 0 24 24"
+                    width={14}
+                  >
+                    <path
+                      d="M18.3 5.71c-.39-.39-1.02-.39-1.41 0L12 10.59 7.11 5.7c-.39-.39-1.02-.39-1.41 0-.39.39-.39 1.02 0 1.41L10.59 12 5.7 16.89c-.39.39-.39 1.02 0 1.41.39.39 1.02.39 1.41 0L12 13.41l4.89 4.89c.39.39 1.02.39 1.41 0 .39-.39.39-1.02 0-1.41L13.41 12l4.89-4.89c.38-.38.38-1.02 0-1.4z"
+                    />
+                  </svg>
+                </span>
+                <button
+                  aria-label="38E Seat £20.00"
+                  className="map-element map-element__seat map-element--available map-element--actionable"
+                  data-testid="seat-38E"
+                  id="38E"
+                  onClick={[Function]}
+                >
+                  <svg
+                    aria-label="seat_paid_indicator"
+                    className="map-element--fee-payable"
+                    data-testid="seat_paid_indicator"
+                    height={16}
+                    style={
+                      {
+                        "display": "block",
+                        "fill": "currentColor",
+                      }
+                    }
+                    viewBox="0 0 24 24"
+                    width={16}
+                  >
+                    <path
+                      d="M11.7686 0.731368C12.7766 -0.276576 14.5 0.437294 14.5 1.86274V10.8C14.5 12.5673 13.0673 14 11.3 14H2.36274C0.937294 14 0.223427 12.2766 1.23137 11.2686L11.7686 0.731368Z"
+                    />
+                  </svg>
+                  E
+                </button>
+                <span
+                  aria-label="38F Seat Unavailable"
+                  className="map-element map-element__seat"
+                >
+                  <svg
+                    aria-label="close"
+                    data-testid="close"
+                    height={14}
+                    style={
+                      {
+                        "display": "block",
+                        "fill": "currentColor",
+                      }
+                    }
+                    viewBox="0 0 24 24"
+                    width={14}
+                  >
+                    <path
+                      d="M18.3 5.71c-.39-.39-1.02-.39-1.41 0L12 10.59 7.11 5.7c-.39-.39-1.02-.39-1.41 0-.39.39-.39 1.02 0 1.41L10.59 12 5.7 16.89c-.39.39-.39 1.02 0 1.41.39.39 1.02.39 1.41 0L12 13.41l4.89 4.89c.39.39 1.02.39 1.41 0 .39-.39.39-1.02 0-1.41L13.41 12l4.89-4.89c.38-.38.38-1.02 0-1.4z"
+                    />
+                  </svg>
+                </span>
+              </div>
+              <span
+                className="map-section__aisle"
+              >
+                38
+              </span>
+              <div
+                className="map-section map-section--right"
+              >
+                <span
+                  aria-label="38H Seat Unavailable"
+                  className="map-element map-element__seat"
+                >
+                  <svg
+                    aria-label="close"
+                    data-testid="close"
+                    height={14}
+                    style={
+                      {
+                        "display": "block",
+                        "fill": "currentColor",
+                      }
+                    }
+                    viewBox="0 0 24 24"
+                    width={14}
+                  >
+                    <path
+                      d="M18.3 5.71c-.39-.39-1.02-.39-1.41 0L12 10.59 7.11 5.7c-.39-.39-1.02-.39-1.41 0-.39.39-.39 1.02 0 1.41L10.59 12 5.7 16.89c-.39.39-.39 1.02 0 1.41.39.39 1.02.39 1.41 0L12 13.41l4.89 4.89c.39.39 1.02.39 1.41 0 .39-.39.39-1.02 0-1.41L13.41 12l4.89-4.89c.38-.38.38-1.02 0-1.4z"
+                    />
+                  </svg>
+                </span>
+                <span
+                  aria-label="38J Seat Unavailable"
+                  className="map-element map-element__seat"
+                >
+                  <svg
+                    aria-label="close"
+                    data-testid="close"
+                    height={14}
+                    style={
+                      {
+                        "display": "block",
+                        "fill": "currentColor",
+                      }
+                    }
+                    viewBox="0 0 24 24"
+                    width={14}
+                  >
+                    <path
+                      d="M18.3 5.71c-.39-.39-1.02-.39-1.41 0L12 10.59 7.11 5.7c-.39-.39-1.02-.39-1.41 0-.39.39-.39 1.02 0 1.41L10.59 12 5.7 16.89c-.39.39-.39 1.02 0 1.41.39.39 1.02.39 1.41 0L12 13.41l4.89 4.89c.39.39 1.02.39 1.41 0 .39-.39.39-1.02 0-1.41L13.41 12l4.89-4.89c.38-.38.38-1.02 0-1.4z"
+                    />
+                  </svg>
+                </span>
+                <button
+                  aria-label="38K Seat £20.00"
+                  className="map-element map-element__seat map-element--available map-element--actionable"
+                  data-testid="seat-38K"
+                  id="38K"
+                  onClick={[Function]}
+                >
+                  <svg
+                    aria-label="seat_paid_indicator"
+                    className="map-element--fee-payable"
+                    data-testid="seat_paid_indicator"
+                    height={16}
+                    style={
+                      {
+                        "display": "block",
+                        "fill": "currentColor",
+                      }
+                    }
+                    viewBox="0 0 24 24"
+                    width={16}
+                  >
+                    <path
+                      d="M11.7686 0.731368C12.7766 -0.276576 14.5 0.437294 14.5 1.86274V10.8C14.5 12.5673 13.0673 14 11.3 14H2.36274C0.937294 14 0.223427 12.2766 1.23137 11.2686L11.7686 0.731368Z"
+                    />
+                  </svg>
+                  K
+                </button>
+              </div>
+              <div
+                className="map-section map-section--left"
+              >
+                <span
+                  aria-label="39A Seat Unavailable"
+                  className="map-element map-element__seat"
+                >
+                  <svg
+                    aria-label="close"
+                    data-testid="close"
+                    height={14}
+                    style={
+                      {
+                        "display": "block",
+                        "fill": "currentColor",
+                      }
+                    }
+                    viewBox="0 0 24 24"
+                    width={14}
+                  >
+                    <path
+                      d="M18.3 5.71c-.39-.39-1.02-.39-1.41 0L12 10.59 7.11 5.7c-.39-.39-1.02-.39-1.41 0-.39.39-.39 1.02 0 1.41L10.59 12 5.7 16.89c-.39.39-.39 1.02 0 1.41.39.39 1.02.39 1.41 0L12 13.41l4.89 4.89c.39.39 1.02.39 1.41 0 .39-.39.39-1.02 0-1.41L13.41 12l4.89-4.89c.38-.38.38-1.02 0-1.4z"
+                    />
+                  </svg>
+                </span>
+                <span
+                  aria-label="39B Seat Unavailable"
+                  className="map-element map-element__seat"
+                >
+                  <svg
+                    aria-label="close"
+                    data-testid="close"
+                    height={14}
+                    style={
+                      {
+                        "display": "block",
+                        "fill": "currentColor",
+                      }
+                    }
+                    viewBox="0 0 24 24"
+                    width={14}
+                  >
+                    <path
+                      d="M18.3 5.71c-.39-.39-1.02-.39-1.41 0L12 10.59 7.11 5.7c-.39-.39-1.02-.39-1.41 0-.39.39-.39 1.02 0 1.41L10.59 12 5.7 16.89c-.39.39-.39 1.02 0 1.41.39.39 1.02.39 1.41 0L12 13.41l4.89 4.89c.39.39 1.02.39 1.41 0 .39-.39.39-1.02 0-1.41L13.41 12l4.89-4.89c.38-.38.38-1.02 0-1.4z"
+                    />
+                  </svg>
+                </span>
+                <span
+                  aria-label="39C Seat Unavailable"
+                  className="map-element map-element__seat"
+                >
+                  <svg
+                    aria-label="close"
+                    data-testid="close"
+                    height={14}
+                    style={
+                      {
+                        "display": "block",
+                        "fill": "currentColor",
+                      }
+                    }
+                    viewBox="0 0 24 24"
+                    width={14}
+                  >
+                    <path
+                      d="M18.3 5.71c-.39-.39-1.02-.39-1.41 0L12 10.59 7.11 5.7c-.39-.39-1.02-.39-1.41 0-.39.39-.39 1.02 0 1.41L10.59 12 5.7 16.89c-.39.39-.39 1.02 0 1.41.39.39 1.02.39 1.41 0L12 13.41l4.89 4.89c.39.39 1.02.39 1.41 0 .39-.39.39-1.02 0-1.41L13.41 12l4.89-4.89c.38-.38.38-1.02 0-1.4z"
+                    />
+                  </svg>
+                </span>
+              </div>
+              <span
+                className="map-section__aisle"
+              >
+                39
+              </span>
+              <div
+                className="map-section"
+              >
+                <span
+                  aria-label="39D Seat Unavailable"
+                  className="map-element map-element__seat"
+                >
+                  <svg
+                    aria-label="close"
+                    data-testid="close"
+                    height={14}
+                    style={
+                      {
+                        "display": "block",
+                        "fill": "currentColor",
+                      }
+                    }
+                    viewBox="0 0 24 24"
+                    width={14}
+                  >
+                    <path
+                      d="M18.3 5.71c-.39-.39-1.02-.39-1.41 0L12 10.59 7.11 5.7c-.39-.39-1.02-.39-1.41 0-.39.39-.39 1.02 0 1.41L10.59 12 5.7 16.89c-.39.39-.39 1.02 0 1.41.39.39 1.02.39 1.41 0L12 13.41l4.89 4.89c.39.39 1.02.39 1.41 0 .39-.39.39-1.02 0-1.41L13.41 12l4.89-4.89c.38-.38.38-1.02 0-1.4z"
+                    />
+                  </svg>
+                </span>
+                <span
+                  aria-label="39E Seat Unavailable"
+                  className="map-element map-element__seat"
+                >
+                  <svg
+                    aria-label="close"
+                    data-testid="close"
+                    height={14}
+                    style={
+                      {
+                        "display": "block",
+                        "fill": "currentColor",
+                      }
+                    }
+                    viewBox="0 0 24 24"
+                    width={14}
+                  >
+                    <path
+                      d="M18.3 5.71c-.39-.39-1.02-.39-1.41 0L12 10.59 7.11 5.7c-.39-.39-1.02-.39-1.41 0-.39.39-.39 1.02 0 1.41L10.59 12 5.7 16.89c-.39.39-.39 1.02 0 1.41.39.39 1.02.39 1.41 0L12 13.41l4.89 4.89c.39.39 1.02.39 1.41 0 .39-.39.39-1.02 0-1.41L13.41 12l4.89-4.89c.38-.38.38-1.02 0-1.4z"
+                    />
+                  </svg>
+                </span>
+                <span
+                  aria-label="39F Seat Unavailable"
+                  className="map-element map-element__seat"
+                >
+                  <svg
+                    aria-label="close"
+                    data-testid="close"
+                    height={14}
+                    style={
+                      {
+                        "display": "block",
+                        "fill": "currentColor",
+                      }
+                    }
+                    viewBox="0 0 24 24"
+                    width={14}
+                  >
+                    <path
+                      d="M18.3 5.71c-.39-.39-1.02-.39-1.41 0L12 10.59 7.11 5.7c-.39-.39-1.02-.39-1.41 0-.39.39-.39 1.02 0 1.41L10.59 12 5.7 16.89c-.39.39-.39 1.02 0 1.41.39.39 1.02.39 1.41 0L12 13.41l4.89 4.89c.39.39 1.02.39 1.41 0 .39-.39.39-1.02 0-1.41L13.41 12l4.89-4.89c.38-.38.38-1.02 0-1.4z"
+                    />
+                  </svg>
+                </span>
+              </div>
+              <span
+                className="map-section__aisle"
+              >
+                39
+              </span>
+              <div
+                className="map-section map-section--right"
+              >
+                <span
+                  aria-label="39H Seat Unavailable"
+                  className="map-element map-element__seat"
+                >
+                  <svg
+                    aria-label="close"
+                    data-testid="close"
+                    height={14}
+                    style={
+                      {
+                        "display": "block",
+                        "fill": "currentColor",
+                      }
+                    }
+                    viewBox="0 0 24 24"
+                    width={14}
+                  >
+                    <path
+                      d="M18.3 5.71c-.39-.39-1.02-.39-1.41 0L12 10.59 7.11 5.7c-.39-.39-1.02-.39-1.41 0-.39.39-.39 1.02 0 1.41L10.59 12 5.7 16.89c-.39.39-.39 1.02 0 1.41.39.39 1.02.39 1.41 0L12 13.41l4.89 4.89c.39.39 1.02.39 1.41 0 .39-.39.39-1.02 0-1.41L13.41 12l4.89-4.89c.38-.38.38-1.02 0-1.4z"
+                    />
+                  </svg>
+                </span>
+                <span
+                  aria-label="39J Seat Unavailable"
+                  className="map-element map-element__seat"
+                >
+                  <svg
+                    aria-label="close"
+                    data-testid="close"
+                    height={14}
+                    style={
+                      {
+                        "display": "block",
+                        "fill": "currentColor",
+                      }
+                    }
+                    viewBox="0 0 24 24"
+                    width={14}
+                  >
+                    <path
+                      d="M18.3 5.71c-.39-.39-1.02-.39-1.41 0L12 10.59 7.11 5.7c-.39-.39-1.02-.39-1.41 0-.39.39-.39 1.02 0 1.41L10.59 12 5.7 16.89c-.39.39-.39 1.02 0 1.41.39.39 1.02.39 1.41 0L12 13.41l4.89 4.89c.39.39 1.02.39 1.41 0 .39-.39.39-1.02 0-1.41L13.41 12l4.89-4.89c.38-.38.38-1.02 0-1.4z"
+                    />
+                  </svg>
+                </span>
+                <span
+                  aria-label="39K Seat Unavailable"
+                  className="map-element map-element__seat"
+                >
+                  <svg
+                    aria-label="close"
+                    data-testid="close"
+                    height={14}
+                    style={
+                      {
+                        "display": "block",
+                        "fill": "currentColor",
+                      }
+                    }
+                    viewBox="0 0 24 24"
+                    width={14}
+                  >
+                    <path
+                      d="M18.3 5.71c-.39-.39-1.02-.39-1.41 0L12 10.59 7.11 5.7c-.39-.39-1.02-.39-1.41 0-.39.39-.39 1.02 0 1.41L10.59 12 5.7 16.89c-.39.39-.39 1.02 0 1.41.39.39 1.02.39 1.41 0L12 13.41l4.89 4.89c.39.39 1.02.39 1.41 0 .39-.39.39-1.02 0-1.41L13.41 12l4.89-4.89c.38-.38.38-1.02 0-1.4z"
+                    />
+                  </svg>
+                </span>
+              </div>
+              <div
+                className="map-section map-section--left"
+              >
+                <span
+                  aria-label="40A Seat Unavailable"
+                  className="map-element map-element__seat"
+                >
+                  <svg
+                    aria-label="close"
+                    data-testid="close"
+                    height={14}
+                    style={
+                      {
+                        "display": "block",
+                        "fill": "currentColor",
+                      }
+                    }
+                    viewBox="0 0 24 24"
+                    width={14}
+                  >
+                    <path
+                      d="M18.3 5.71c-.39-.39-1.02-.39-1.41 0L12 10.59 7.11 5.7c-.39-.39-1.02-.39-1.41 0-.39.39-.39 1.02 0 1.41L10.59 12 5.7 16.89c-.39.39-.39 1.02 0 1.41.39.39 1.02.39 1.41 0L12 13.41l4.89 4.89c.39.39 1.02.39 1.41 0 .39-.39.39-1.02 0-1.41L13.41 12l4.89-4.89c.38-.38.38-1.02 0-1.4z"
+                    />
+                  </svg>
+                </span>
+                <span
+                  aria-label="40B Seat Unavailable"
+                  className="map-element map-element__seat"
+                >
+                  <svg
+                    aria-label="close"
+                    data-testid="close"
+                    height={14}
+                    style={
+                      {
+                        "display": "block",
+                        "fill": "currentColor",
+                      }
+                    }
+                    viewBox="0 0 24 24"
+                    width={14}
+                  >
+                    <path
+                      d="M18.3 5.71c-.39-.39-1.02-.39-1.41 0L12 10.59 7.11 5.7c-.39-.39-1.02-.39-1.41 0-.39.39-.39 1.02 0 1.41L10.59 12 5.7 16.89c-.39.39-.39 1.02 0 1.41.39.39 1.02.39 1.41 0L12 13.41l4.89 4.89c.39.39 1.02.39 1.41 0 .39-.39.39-1.02 0-1.41L13.41 12l4.89-4.89c.38-.38.38-1.02 0-1.4z"
+                    />
+                  </svg>
+                </span>
+                <span
+                  aria-label="40C Seat Unavailable"
+                  className="map-element map-element__seat"
+                >
+                  <svg
+                    aria-label="close"
+                    data-testid="close"
+                    height={14}
+                    style={
+                      {
+                        "display": "block",
+                        "fill": "currentColor",
+                      }
+                    }
+                    viewBox="0 0 24 24"
+                    width={14}
+                  >
+                    <path
+                      d="M18.3 5.71c-.39-.39-1.02-.39-1.41 0L12 10.59 7.11 5.7c-.39-.39-1.02-.39-1.41 0-.39.39-.39 1.02 0 1.41L10.59 12 5.7 16.89c-.39.39-.39 1.02 0 1.41.39.39 1.02.39 1.41 0L12 13.41l4.89 4.89c.39.39 1.02.39 1.41 0 .39-.39.39-1.02 0-1.41L13.41 12l4.89-4.89c.38-.38.38-1.02 0-1.4z"
+                    />
+                  </svg>
+                </span>
+              </div>
+              <span
+                className="map-section__aisle"
+              >
+                40
+              </span>
+              <div
+                className="map-section"
+              >
+                <span
+                  aria-label="40D Seat Unavailable"
+                  className="map-element map-element__seat"
+                >
+                  <svg
+                    aria-label="close"
+                    data-testid="close"
+                    height={14}
+                    style={
+                      {
+                        "display": "block",
+                        "fill": "currentColor",
+                      }
+                    }
+                    viewBox="0 0 24 24"
+                    width={14}
+                  >
+                    <path
+                      d="M18.3 5.71c-.39-.39-1.02-.39-1.41 0L12 10.59 7.11 5.7c-.39-.39-1.02-.39-1.41 0-.39.39-.39 1.02 0 1.41L10.59 12 5.7 16.89c-.39.39-.39 1.02 0 1.41.39.39 1.02.39 1.41 0L12 13.41l4.89 4.89c.39.39 1.02.39 1.41 0 .39-.39.39-1.02 0-1.41L13.41 12l4.89-4.89c.38-.38.38-1.02 0-1.4z"
+                    />
+                  </svg>
+                </span>
+                <button
+                  aria-label="40E Seat £20.00"
+                  className="map-element map-element__seat map-element--available map-element--actionable"
+                  data-testid="seat-40E"
+                  id="40E"
+                  onClick={[Function]}
+                >
+                  <svg
+                    aria-label="seat_paid_indicator"
+                    className="map-element--fee-payable"
+                    data-testid="seat_paid_indicator"
+                    height={16}
+                    style={
+                      {
+                        "display": "block",
+                        "fill": "currentColor",
+                      }
+                    }
+                    viewBox="0 0 24 24"
+                    width={16}
+                  >
+                    <path
+                      d="M11.7686 0.731368C12.7766 -0.276576 14.5 0.437294 14.5 1.86274V10.8C14.5 12.5673 13.0673 14 11.3 14H2.36274C0.937294 14 0.223427 12.2766 1.23137 11.2686L11.7686 0.731368Z"
+                    />
+                  </svg>
+                  E
+                </button>
+                <span
+                  aria-label="40F Seat Unavailable"
+                  className="map-element map-element__seat"
+                >
+                  <svg
+                    aria-label="close"
+                    data-testid="close"
+                    height={14}
+                    style={
+                      {
+                        "display": "block",
+                        "fill": "currentColor",
+                      }
+                    }
+                    viewBox="0 0 24 24"
+                    width={14}
+                  >
+                    <path
+                      d="M18.3 5.71c-.39-.39-1.02-.39-1.41 0L12 10.59 7.11 5.7c-.39-.39-1.02-.39-1.41 0-.39.39-.39 1.02 0 1.41L10.59 12 5.7 16.89c-.39.39-.39 1.02 0 1.41.39.39 1.02.39 1.41 0L12 13.41l4.89 4.89c.39.39 1.02.39 1.41 0 .39-.39.39-1.02 0-1.41L13.41 12l4.89-4.89c.38-.38.38-1.02 0-1.4z"
+                    />
+                  </svg>
+                </span>
+              </div>
+              <span
+                className="map-section__aisle"
+              >
+                40
+              </span>
+              <div
+                className="map-section map-section--right"
+              >
+                <button
+                  aria-label="40H Seat £20.00"
+                  className="map-element map-element__seat map-element--available map-element--actionable"
+                  data-testid="seat-40H"
+                  id="40H"
+                  onClick={[Function]}
+                >
+                  <svg
+                    aria-label="seat_paid_indicator"
+                    className="map-element--fee-payable"
+                    data-testid="seat_paid_indicator"
+                    height={16}
+                    style={
+                      {
+                        "display": "block",
+                        "fill": "currentColor",
+                      }
+                    }
+                    viewBox="0 0 24 24"
+                    width={16}
+                  >
+                    <path
+                      d="M11.7686 0.731368C12.7766 -0.276576 14.5 0.437294 14.5 1.86274V10.8C14.5 12.5673 13.0673 14 11.3 14H2.36274C0.937294 14 0.223427 12.2766 1.23137 11.2686L11.7686 0.731368Z"
+                    />
+                  </svg>
+                  H
+                </button>
+                <span
+                  aria-label="40J Seat Unavailable"
+                  className="map-element map-element__seat"
+                >
+                  <svg
+                    aria-label="close"
+                    data-testid="close"
+                    height={14}
+                    style={
+                      {
+                        "display": "block",
+                        "fill": "currentColor",
+                      }
+                    }
+                    viewBox="0 0 24 24"
+                    width={14}
+                  >
+                    <path
+                      d="M18.3 5.71c-.39-.39-1.02-.39-1.41 0L12 10.59 7.11 5.7c-.39-.39-1.02-.39-1.41 0-.39.39-.39 1.02 0 1.41L10.59 12 5.7 16.89c-.39.39-.39 1.02 0 1.41.39.39 1.02.39 1.41 0L12 13.41l4.89 4.89c.39.39 1.02.39 1.41 0 .39-.39.39-1.02 0-1.41L13.41 12l4.89-4.89c.38-.38.38-1.02 0-1.4z"
+                    />
+                  </svg>
+                </span>
+                <span
+                  aria-label="40K Seat Unavailable"
+                  className="map-element map-element__seat"
+                >
+                  <svg
+                    aria-label="close"
+                    data-testid="close"
+                    height={14}
+                    style={
+                      {
+                        "display": "block",
+                        "fill": "currentColor",
+                      }
+                    }
+                    viewBox="0 0 24 24"
+                    width={14}
+                  >
+                    <path
+                      d="M18.3 5.71c-.39-.39-1.02-.39-1.41 0L12 10.59 7.11 5.7c-.39-.39-1.02-.39-1.41 0-.39.39-.39 1.02 0 1.41L10.59 12 5.7 16.89c-.39.39-.39 1.02 0 1.41.39.39 1.02.39 1.41 0L12 13.41l4.89 4.89c.39.39 1.02.39 1.41 0 .39-.39.39-1.02 0-1.41L13.41 12l4.89-4.89c.38-.38.38-1.02 0-1.4z"
+                    />
+                  </svg>
+                </span>
+              </div>
+              <div
+                className="map-section map-section--left"
+              >
+                <span
+                  aria-label="41A Seat Unavailable"
+                  className="map-element map-element__seat"
+                >
+                  <svg
+                    aria-label="close"
+                    data-testid="close"
+                    height={14}
+                    style={
+                      {
+                        "display": "block",
+                        "fill": "currentColor",
+                      }
+                    }
+                    viewBox="0 0 24 24"
+                    width={14}
+                  >
+                    <path
+                      d="M18.3 5.71c-.39-.39-1.02-.39-1.41 0L12 10.59 7.11 5.7c-.39-.39-1.02-.39-1.41 0-.39.39-.39 1.02 0 1.41L10.59 12 5.7 16.89c-.39.39-.39 1.02 0 1.41.39.39 1.02.39 1.41 0L12 13.41l4.89 4.89c.39.39 1.02.39 1.41 0 .39-.39.39-1.02 0-1.41L13.41 12l4.89-4.89c.38-.38.38-1.02 0-1.4z"
+                    />
+                  </svg>
+                </span>
+                <span
+                  aria-label="41B Seat Unavailable"
+                  className="map-element map-element__seat"
+                >
+                  <svg
+                    aria-label="close"
+                    data-testid="close"
+                    height={14}
+                    style={
+                      {
+                        "display": "block",
+                        "fill": "currentColor",
+                      }
+                    }
+                    viewBox="0 0 24 24"
+                    width={14}
+                  >
+                    <path
+                      d="M18.3 5.71c-.39-.39-1.02-.39-1.41 0L12 10.59 7.11 5.7c-.39-.39-1.02-.39-1.41 0-.39.39-.39 1.02 0 1.41L10.59 12 5.7 16.89c-.39.39-.39 1.02 0 1.41.39.39 1.02.39 1.41 0L12 13.41l4.89 4.89c.39.39 1.02.39 1.41 0 .39-.39.39-1.02 0-1.41L13.41 12l4.89-4.89c.38-.38.38-1.02 0-1.4z"
+                    />
+                  </svg>
+                </span>
+                <span
+                  aria-label="41C Seat Unavailable"
+                  className="map-element map-element__seat"
+                >
+                  <svg
+                    aria-label="close"
+                    data-testid="close"
+                    height={14}
+                    style={
+                      {
+                        "display": "block",
+                        "fill": "currentColor",
+                      }
+                    }
+                    viewBox="0 0 24 24"
+                    width={14}
+                  >
+                    <path
+                      d="M18.3 5.71c-.39-.39-1.02-.39-1.41 0L12 10.59 7.11 5.7c-.39-.39-1.02-.39-1.41 0-.39.39-.39 1.02 0 1.41L10.59 12 5.7 16.89c-.39.39-.39 1.02 0 1.41.39.39 1.02.39 1.41 0L12 13.41l4.89 4.89c.39.39 1.02.39 1.41 0 .39-.39.39-1.02 0-1.41L13.41 12l4.89-4.89c.38-.38.38-1.02 0-1.4z"
+                    />
+                  </svg>
+                </span>
+              </div>
+              <span
+                className="map-section__aisle"
+              >
+                41
+              </span>
+              <div
+                className="map-section"
+              >
+                <button
+                  aria-label="41D Seat £20.00"
+                  className="map-element map-element__seat map-element--available map-element--actionable"
+                  data-testid="seat-41D"
+                  id="41D"
+                  onClick={[Function]}
+                >
+                  <svg
+                    aria-label="seat_paid_indicator"
+                    className="map-element--fee-payable"
+                    data-testid="seat_paid_indicator"
+                    height={16}
+                    style={
+                      {
+                        "display": "block",
+                        "fill": "currentColor",
+                      }
+                    }
+                    viewBox="0 0 24 24"
+                    width={16}
+                  >
+                    <path
+                      d="M11.7686 0.731368C12.7766 -0.276576 14.5 0.437294 14.5 1.86274V10.8C14.5 12.5673 13.0673 14 11.3 14H2.36274C0.937294 14 0.223427 12.2766 1.23137 11.2686L11.7686 0.731368Z"
+                    />
+                  </svg>
+                  D
+                </button>
+                <button
+                  aria-label="41E Seat £20.00"
+                  className="map-element map-element__seat map-element--available map-element--actionable"
+                  data-testid="seat-41E"
+                  id="41E"
+                  onClick={[Function]}
+                >
+                  <svg
+                    aria-label="seat_paid_indicator"
+                    className="map-element--fee-payable"
+                    data-testid="seat_paid_indicator"
+                    height={16}
+                    style={
+                      {
+                        "display": "block",
+                        "fill": "currentColor",
+                      }
+                    }
+                    viewBox="0 0 24 24"
+                    width={16}
+                  >
+                    <path
+                      d="M11.7686 0.731368C12.7766 -0.276576 14.5 0.437294 14.5 1.86274V10.8C14.5 12.5673 13.0673 14 11.3 14H2.36274C0.937294 14 0.223427 12.2766 1.23137 11.2686L11.7686 0.731368Z"
+                    />
+                  </svg>
+                  E
+                </button>
+                <span
+                  aria-label="41F Seat Unavailable"
+                  className="map-element map-element__seat"
+                >
+                  <svg
+                    aria-label="close"
+                    data-testid="close"
+                    height={14}
+                    style={
+                      {
+                        "display": "block",
+                        "fill": "currentColor",
+                      }
+                    }
+                    viewBox="0 0 24 24"
+                    width={14}
+                  >
+                    <path
+                      d="M18.3 5.71c-.39-.39-1.02-.39-1.41 0L12 10.59 7.11 5.7c-.39-.39-1.02-.39-1.41 0-.39.39-.39 1.02 0 1.41L10.59 12 5.7 16.89c-.39.39-.39 1.02 0 1.41.39.39 1.02.39 1.41 0L12 13.41l4.89 4.89c.39.39 1.02.39 1.41 0 .39-.39.39-1.02 0-1.41L13.41 12l4.89-4.89c.38-.38.38-1.02 0-1.4z"
+                    />
+                  </svg>
+                </span>
+              </div>
+              <span
+                className="map-section__aisle"
+              >
+                41
+              </span>
+              <div
+                className="map-section map-section--right"
+              >
+                <button
+                  aria-label="41H Seat £20.00"
+                  className="map-element map-element__seat map-element--available map-element--actionable"
+                  data-testid="seat-41H"
+                  id="41H"
+                  onClick={[Function]}
+                >
+                  <svg
+                    aria-label="seat_paid_indicator"
+                    className="map-element--fee-payable"
+                    data-testid="seat_paid_indicator"
+                    height={16}
+                    style={
+                      {
+                        "display": "block",
+                        "fill": "currentColor",
+                      }
+                    }
+                    viewBox="0 0 24 24"
+                    width={16}
+                  >
+                    <path
+                      d="M11.7686 0.731368C12.7766 -0.276576 14.5 0.437294 14.5 1.86274V10.8C14.5 12.5673 13.0673 14 11.3 14H2.36274C0.937294 14 0.223427 12.2766 1.23137 11.2686L11.7686 0.731368Z"
+                    />
+                  </svg>
+                  H
+                </button>
+                <button
+                  aria-label="41J Seat £20.00"
+                  className="map-element map-element__seat map-element--available map-element--actionable"
+                  data-testid="seat-41J"
+                  id="41J"
+                  onClick={[Function]}
+                >
+                  <svg
+                    aria-label="seat_paid_indicator"
+                    className="map-element--fee-payable"
+                    data-testid="seat_paid_indicator"
+                    height={16}
+                    style={
+                      {
+                        "display": "block",
+                        "fill": "currentColor",
+                      }
+                    }
+                    viewBox="0 0 24 24"
+                    width={16}
+                  >
+                    <path
+                      d="M11.7686 0.731368C12.7766 -0.276576 14.5 0.437294 14.5 1.86274V10.8C14.5 12.5673 13.0673 14 11.3 14H2.36274C0.937294 14 0.223427 12.2766 1.23137 11.2686L11.7686 0.731368Z"
+                    />
+                  </svg>
+                  J
+                </button>
+                <button
+                  aria-label="41K Seat £20.00"
+                  className="map-element map-element__seat map-element--available map-element--actionable"
+                  data-testid="seat-41K"
+                  id="41K"
+                  onClick={[Function]}
+                >
+                  <svg
+                    aria-label="seat_paid_indicator"
+                    className="map-element--fee-payable"
+                    data-testid="seat_paid_indicator"
+                    height={16}
+                    style={
+                      {
+                        "display": "block",
+                        "fill": "currentColor",
+                      }
+                    }
+                    viewBox="0 0 24 24"
+                    width={16}
+                  >
+                    <path
+                      d="M11.7686 0.731368C12.7766 -0.276576 14.5 0.437294 14.5 1.86274V10.8C14.5 12.5673 13.0673 14 11.3 14H2.36274C0.937294 14 0.223427 12.2766 1.23137 11.2686L11.7686 0.731368Z"
+                    />
+                  </svg>
+                  K
+                </button>
+              </div>
+              <div
+                className="map-section map-section--left"
+              >
+                <span
+                  aria-label="42A Seat Unavailable"
+                  className="map-element map-element__seat"
+                >
+                  <svg
+                    aria-label="close"
+                    data-testid="close"
+                    height={14}
+                    style={
+                      {
+                        "display": "block",
+                        "fill": "currentColor",
+                      }
+                    }
+                    viewBox="0 0 24 24"
+                    width={14}
+                  >
+                    <path
+                      d="M18.3 5.71c-.39-.39-1.02-.39-1.41 0L12 10.59 7.11 5.7c-.39-.39-1.02-.39-1.41 0-.39.39-.39 1.02 0 1.41L10.59 12 5.7 16.89c-.39.39-.39 1.02 0 1.41.39.39 1.02.39 1.41 0L12 13.41l4.89 4.89c.39.39 1.02.39 1.41 0 .39-.39.39-1.02 0-1.41L13.41 12l4.89-4.89c.38-.38.38-1.02 0-1.4z"
+                    />
+                  </svg>
+                </span>
+                <span
+                  aria-label="42B Seat Unavailable"
+                  className="map-element map-element__seat"
+                >
+                  <svg
+                    aria-label="close"
+                    data-testid="close"
+                    height={14}
+                    style={
+                      {
+                        "display": "block",
+                        "fill": "currentColor",
+                      }
+                    }
+                    viewBox="0 0 24 24"
+                    width={14}
+                  >
+                    <path
+                      d="M18.3 5.71c-.39-.39-1.02-.39-1.41 0L12 10.59 7.11 5.7c-.39-.39-1.02-.39-1.41 0-.39.39-.39 1.02 0 1.41L10.59 12 5.7 16.89c-.39.39-.39 1.02 0 1.41.39.39 1.02.39 1.41 0L12 13.41l4.89 4.89c.39.39 1.02.39 1.41 0 .39-.39.39-1.02 0-1.41L13.41 12l4.89-4.89c.38-.38.38-1.02 0-1.4z"
+                    />
+                  </svg>
+                </span>
+                <button
+                  aria-label="42C Seat £20.00"
+                  className="map-element map-element__seat map-element--available map-element--actionable"
+                  data-testid="seat-42C"
+                  id="42C"
+                  onClick={[Function]}
+                >
+                  <svg
+                    aria-label="seat_paid_indicator"
+                    className="map-element--fee-payable"
+                    data-testid="seat_paid_indicator"
+                    height={16}
+                    style={
+                      {
+                        "display": "block",
+                        "fill": "currentColor",
+                      }
+                    }
+                    viewBox="0 0 24 24"
+                    width={16}
+                  >
+                    <path
+                      d="M11.7686 0.731368C12.7766 -0.276576 14.5 0.437294 14.5 1.86274V10.8C14.5 12.5673 13.0673 14 11.3 14H2.36274C0.937294 14 0.223427 12.2766 1.23137 11.2686L11.7686 0.731368Z"
+                    />
+                  </svg>
+                  C
+                </button>
+              </div>
+              <span
+                className="map-section__aisle"
+              >
+                42
+              </span>
+              <div
+                className="map-section"
+              >
+                <button
+                  aria-label="42D Seat £20.00"
+                  className="map-element map-element__seat map-element--available map-element--actionable"
+                  data-testid="seat-42D"
+                  id="42D"
+                  onClick={[Function]}
+                >
+                  <svg
+                    aria-label="seat_paid_indicator"
+                    className="map-element--fee-payable"
+                    data-testid="seat_paid_indicator"
+                    height={16}
+                    style={
+                      {
+                        "display": "block",
+                        "fill": "currentColor",
+                      }
+                    }
+                    viewBox="0 0 24 24"
+                    width={16}
+                  >
+                    <path
+                      d="M11.7686 0.731368C12.7766 -0.276576 14.5 0.437294 14.5 1.86274V10.8C14.5 12.5673 13.0673 14 11.3 14H2.36274C0.937294 14 0.223427 12.2766 1.23137 11.2686L11.7686 0.731368Z"
+                    />
+                  </svg>
+                  D
+                </button>
+                <button
+                  aria-label="42E Seat £20.00"
+                  className="map-element map-element__seat map-element--available map-element--actionable"
+                  data-testid="seat-42E"
+                  id="42E"
+                  onClick={[Function]}
+                >
+                  <svg
+                    aria-label="seat_paid_indicator"
+                    className="map-element--fee-payable"
+                    data-testid="seat_paid_indicator"
+                    height={16}
+                    style={
+                      {
+                        "display": "block",
+                        "fill": "currentColor",
+                      }
+                    }
+                    viewBox="0 0 24 24"
+                    width={16}
+                  >
+                    <path
+                      d="M11.7686 0.731368C12.7766 -0.276576 14.5 0.437294 14.5 1.86274V10.8C14.5 12.5673 13.0673 14 11.3 14H2.36274C0.937294 14 0.223427 12.2766 1.23137 11.2686L11.7686 0.731368Z"
+                    />
+                  </svg>
+                  E
+                </button>
+                <span
+                  aria-label="42F Seat Unavailable"
+                  className="map-element map-element__seat"
+                >
+                  <svg
+                    aria-label="close"
+                    data-testid="close"
+                    height={14}
+                    style={
+                      {
+                        "display": "block",
+                        "fill": "currentColor",
+                      }
+                    }
+                    viewBox="0 0 24 24"
+                    width={14}
+                  >
+                    <path
+                      d="M18.3 5.71c-.39-.39-1.02-.39-1.41 0L12 10.59 7.11 5.7c-.39-.39-1.02-.39-1.41 0-.39.39-.39 1.02 0 1.41L10.59 12 5.7 16.89c-.39.39-.39 1.02 0 1.41.39.39 1.02.39 1.41 0L12 13.41l4.89 4.89c.39.39 1.02.39 1.41 0 .39-.39.39-1.02 0-1.41L13.41 12l4.89-4.89c.38-.38.38-1.02 0-1.4z"
+                    />
+                  </svg>
+                </span>
+              </div>
+              <span
+                className="map-section__aisle"
+              >
+                42
+              </span>
+              <div
+                className="map-section map-section--right"
+              >
+                <span
+                  aria-label="42H Seat Unavailable"
+                  className="map-element map-element__seat"
+                >
+                  <svg
+                    aria-label="close"
+                    data-testid="close"
+                    height={14}
+                    style={
+                      {
+                        "display": "block",
+                        "fill": "currentColor",
+                      }
+                    }
+                    viewBox="0 0 24 24"
+                    width={14}
+                  >
+                    <path
+                      d="M18.3 5.71c-.39-.39-1.02-.39-1.41 0L12 10.59 7.11 5.7c-.39-.39-1.02-.39-1.41 0-.39.39-.39 1.02 0 1.41L10.59 12 5.7 16.89c-.39.39-.39 1.02 0 1.41.39.39 1.02.39 1.41 0L12 13.41l4.89 4.89c.39.39 1.02.39 1.41 0 .39-.39.39-1.02 0-1.41L13.41 12l4.89-4.89c.38-.38.38-1.02 0-1.4z"
+                    />
+                  </svg>
+                </span>
+                <span
+                  aria-label="42J Seat Unavailable"
+                  className="map-element map-element__seat"
+                >
+                  <svg
+                    aria-label="close"
+                    data-testid="close"
+                    height={14}
+                    style={
+                      {
+                        "display": "block",
+                        "fill": "currentColor",
+                      }
+                    }
+                    viewBox="0 0 24 24"
+                    width={14}
+                  >
+                    <path
+                      d="M18.3 5.71c-.39-.39-1.02-.39-1.41 0L12 10.59 7.11 5.7c-.39-.39-1.02-.39-1.41 0-.39.39-.39 1.02 0 1.41L10.59 12 5.7 16.89c-.39.39-.39 1.02 0 1.41.39.39 1.02.39 1.41 0L12 13.41l4.89 4.89c.39.39 1.02.39 1.41 0 .39-.39.39-1.02 0-1.41L13.41 12l4.89-4.89c.38-.38.38-1.02 0-1.4z"
+                    />
+                  </svg>
+                </span>
+                <button
+                  aria-label="42K Seat £20.00"
+                  className="map-element map-element__seat map-element--available map-element--actionable"
+                  data-testid="seat-42K"
+                  id="42K"
+                  onClick={[Function]}
+                >
+                  <svg
+                    aria-label="seat_paid_indicator"
+                    className="map-element--fee-payable"
+                    data-testid="seat_paid_indicator"
+                    height={16}
+                    style={
+                      {
+                        "display": "block",
+                        "fill": "currentColor",
+                      }
+                    }
+                    viewBox="0 0 24 24"
+                    width={16}
+                  >
+                    <path
+                      d="M11.7686 0.731368C12.7766 -0.276576 14.5 0.437294 14.5 1.86274V10.8C14.5 12.5673 13.0673 14 11.3 14H2.36274C0.937294 14 0.223427 12.2766 1.23137 11.2686L11.7686 0.731368Z"
+                    />
+                  </svg>
+                  K
+                </button>
+              </div>
+              <div
+                className="map-section map-section--left"
+              >
+                <span
+                  aria-label="43A Seat Unavailable"
+                  className="map-element map-element__seat"
+                >
+                  <svg
+                    aria-label="close"
+                    data-testid="close"
+                    height={14}
+                    style={
+                      {
+                        "display": "block",
+                        "fill": "currentColor",
+                      }
+                    }
+                    viewBox="0 0 24 24"
+                    width={14}
+                  >
+                    <path
+                      d="M18.3 5.71c-.39-.39-1.02-.39-1.41 0L12 10.59 7.11 5.7c-.39-.39-1.02-.39-1.41 0-.39.39-.39 1.02 0 1.41L10.59 12 5.7 16.89c-.39.39-.39 1.02 0 1.41.39.39 1.02.39 1.41 0L12 13.41l4.89 4.89c.39.39 1.02.39 1.41 0 .39-.39.39-1.02 0-1.41L13.41 12l4.89-4.89c.38-.38.38-1.02 0-1.4z"
+                    />
+                  </svg>
+                </span>
+                <span
+                  aria-label="43B Seat Unavailable"
+                  className="map-element map-element__seat"
+                >
+                  <svg
+                    aria-label="close"
+                    data-testid="close"
+                    height={14}
+                    style={
+                      {
+                        "display": "block",
+                        "fill": "currentColor",
+                      }
+                    }
+                    viewBox="0 0 24 24"
+                    width={14}
+                  >
+                    <path
+                      d="M18.3 5.71c-.39-.39-1.02-.39-1.41 0L12 10.59 7.11 5.7c-.39-.39-1.02-.39-1.41 0-.39.39-.39 1.02 0 1.41L10.59 12 5.7 16.89c-.39.39-.39 1.02 0 1.41.39.39 1.02.39 1.41 0L12 13.41l4.89 4.89c.39.39 1.02.39 1.41 0 .39-.39.39-1.02 0-1.41L13.41 12l4.89-4.89c.38-.38.38-1.02 0-1.4z"
+                    />
+                  </svg>
+                </span>
+                <button
+                  aria-label="43C Seat £20.00"
+                  className="map-element map-element__seat map-element--available map-element--actionable"
+                  data-testid="seat-43C"
+                  id="43C"
+                  onClick={[Function]}
+                >
+                  <svg
+                    aria-label="seat_paid_indicator"
+                    className="map-element--fee-payable"
+                    data-testid="seat_paid_indicator"
+                    height={16}
+                    style={
+                      {
+                        "display": "block",
+                        "fill": "currentColor",
+                      }
+                    }
+                    viewBox="0 0 24 24"
+                    width={16}
+                  >
+                    <path
+                      d="M11.7686 0.731368C12.7766 -0.276576 14.5 0.437294 14.5 1.86274V10.8C14.5 12.5673 13.0673 14 11.3 14H2.36274C0.937294 14 0.223427 12.2766 1.23137 11.2686L11.7686 0.731368Z"
+                    />
+                  </svg>
+                  C
+                </button>
+              </div>
+              <span
+                className="map-section__aisle"
+              >
+                43
+              </span>
+              <div
+                className="map-section"
+              >
+                <span
+                  aria-label="43D Seat Unavailable"
+                  className="map-element map-element__seat"
+                >
+                  <svg
+                    aria-label="close"
+                    data-testid="close"
+                    height={14}
+                    style={
+                      {
+                        "display": "block",
+                        "fill": "currentColor",
+                      }
+                    }
+                    viewBox="0 0 24 24"
+                    width={14}
+                  >
+                    <path
+                      d="M18.3 5.71c-.39-.39-1.02-.39-1.41 0L12 10.59 7.11 5.7c-.39-.39-1.02-.39-1.41 0-.39.39-.39 1.02 0 1.41L10.59 12 5.7 16.89c-.39.39-.39 1.02 0 1.41.39.39 1.02.39 1.41 0L12 13.41l4.89 4.89c.39.39 1.02.39 1.41 0 .39-.39.39-1.02 0-1.41L13.41 12l4.89-4.89c.38-.38.38-1.02 0-1.4z"
+                    />
+                  </svg>
+                </span>
+                <span
+                  aria-label="43E Seat Unavailable"
+                  className="map-element map-element__seat"
+                >
+                  <svg
+                    aria-label="close"
+                    data-testid="close"
+                    height={14}
+                    style={
+                      {
+                        "display": "block",
+                        "fill": "currentColor",
+                      }
+                    }
+                    viewBox="0 0 24 24"
+                    width={14}
+                  >
+                    <path
+                      d="M18.3 5.71c-.39-.39-1.02-.39-1.41 0L12 10.59 7.11 5.7c-.39-.39-1.02-.39-1.41 0-.39.39-.39 1.02 0 1.41L10.59 12 5.7 16.89c-.39.39-.39 1.02 0 1.41.39.39 1.02.39 1.41 0L12 13.41l4.89 4.89c.39.39 1.02.39 1.41 0 .39-.39.39-1.02 0-1.41L13.41 12l4.89-4.89c.38-.38.38-1.02 0-1.4z"
+                    />
+                  </svg>
+                </span>
+                <button
+                  aria-label="43F Seat £20.00"
+                  className="map-element map-element__seat map-element--available map-element--actionable"
+                  data-testid="seat-43F"
+                  id="43F"
+                  onClick={[Function]}
+                >
+                  <svg
+                    aria-label="seat_paid_indicator"
+                    className="map-element--fee-payable"
+                    data-testid="seat_paid_indicator"
+                    height={16}
+                    style={
+                      {
+                        "display": "block",
+                        "fill": "currentColor",
+                      }
+                    }
+                    viewBox="0 0 24 24"
+                    width={16}
+                  >
+                    <path
+                      d="M11.7686 0.731368C12.7766 -0.276576 14.5 0.437294 14.5 1.86274V10.8C14.5 12.5673 13.0673 14 11.3 14H2.36274C0.937294 14 0.223427 12.2766 1.23137 11.2686L11.7686 0.731368Z"
+                    />
+                  </svg>
+                  F
+                </button>
+              </div>
+              <span
+                className="map-section__aisle"
+              >
+                43
+              </span>
+              <div
+                className="map-section map-section--right"
+              >
+                <span
+                  aria-label="43H Seat Unavailable"
+                  className="map-element map-element__seat"
+                >
+                  <svg
+                    aria-label="close"
+                    data-testid="close"
+                    height={14}
+                    style={
+                      {
+                        "display": "block",
+                        "fill": "currentColor",
+                      }
+                    }
+                    viewBox="0 0 24 24"
+                    width={14}
+                  >
+                    <path
+                      d="M18.3 5.71c-.39-.39-1.02-.39-1.41 0L12 10.59 7.11 5.7c-.39-.39-1.02-.39-1.41 0-.39.39-.39 1.02 0 1.41L10.59 12 5.7 16.89c-.39.39-.39 1.02 0 1.41.39.39 1.02.39 1.41 0L12 13.41l4.89 4.89c.39.39 1.02.39 1.41 0 .39-.39.39-1.02 0-1.41L13.41 12l4.89-4.89c.38-.38.38-1.02 0-1.4z"
+                    />
+                  </svg>
+                </span>
+                <span
+                  aria-label="43J Seat Unavailable"
+                  className="map-element map-element__seat"
+                >
+                  <svg
+                    aria-label="close"
+                    data-testid="close"
+                    height={14}
+                    style={
+                      {
+                        "display": "block",
+                        "fill": "currentColor",
+                      }
+                    }
+                    viewBox="0 0 24 24"
+                    width={14}
+                  >
+                    <path
+                      d="M18.3 5.71c-.39-.39-1.02-.39-1.41 0L12 10.59 7.11 5.7c-.39-.39-1.02-.39-1.41 0-.39.39-.39 1.02 0 1.41L10.59 12 5.7 16.89c-.39.39-.39 1.02 0 1.41.39.39 1.02.39 1.41 0L12 13.41l4.89 4.89c.39.39 1.02.39 1.41 0 .39-.39.39-1.02 0-1.41L13.41 12l4.89-4.89c.38-.38.38-1.02 0-1.4z"
+                    />
+                  </svg>
+                </span>
+                <span
+                  aria-label="43K Seat Unavailable"
+                  className="map-element map-element__seat"
+                >
+                  <svg
+                    aria-label="close"
+                    data-testid="close"
+                    height={14}
+                    style={
+                      {
+                        "display": "block",
+                        "fill": "currentColor",
+                      }
+                    }
+                    viewBox="0 0 24 24"
+                    width={14}
+                  >
+                    <path
+                      d="M18.3 5.71c-.39-.39-1.02-.39-1.41 0L12 10.59 7.11 5.7c-.39-.39-1.02-.39-1.41 0-.39.39-.39 1.02 0 1.41L10.59 12 5.7 16.89c-.39.39-.39 1.02 0 1.41.39.39 1.02.39 1.41 0L12 13.41l4.89 4.89c.39.39 1.02.39 1.41 0 .39-.39.39-1.02 0-1.41L13.41 12l4.89-4.89c.38-.38.38-1.02 0-1.4z"
+                    />
+                  </svg>
+                </span>
+              </div>
+              <div
+                className="map-section map-section--left"
+              >
+                <span
+                  aria-label="44A Seat Unavailable"
+                  className="map-element map-element__seat"
+                >
+                  <svg
+                    aria-label="close"
+                    data-testid="close"
+                    height={14}
+                    style={
+                      {
+                        "display": "block",
+                        "fill": "currentColor",
+                      }
+                    }
+                    viewBox="0 0 24 24"
+                    width={14}
+                  >
+                    <path
+                      d="M18.3 5.71c-.39-.39-1.02-.39-1.41 0L12 10.59 7.11 5.7c-.39-.39-1.02-.39-1.41 0-.39.39-.39 1.02 0 1.41L10.59 12 5.7 16.89c-.39.39-.39 1.02 0 1.41.39.39 1.02.39 1.41 0L12 13.41l4.89 4.89c.39.39 1.02.39 1.41 0 .39-.39.39-1.02 0-1.41L13.41 12l4.89-4.89c.38-.38.38-1.02 0-1.4z"
+                    />
+                  </svg>
+                </span>
+                <button
+                  aria-label="44B Seat £20.00"
+                  className="map-element map-element__seat map-element--available map-element--actionable"
+                  data-testid="seat-44B"
+                  id="44B"
+                  onClick={[Function]}
+                >
+                  <svg
+                    aria-label="seat_paid_indicator"
+                    className="map-element--fee-payable"
+                    data-testid="seat_paid_indicator"
+                    height={16}
+                    style={
+                      {
+                        "display": "block",
+                        "fill": "currentColor",
+                      }
+                    }
+                    viewBox="0 0 24 24"
+                    width={16}
+                  >
+                    <path
+                      d="M11.7686 0.731368C12.7766 -0.276576 14.5 0.437294 14.5 1.86274V10.8C14.5 12.5673 13.0673 14 11.3 14H2.36274C0.937294 14 0.223427 12.2766 1.23137 11.2686L11.7686 0.731368Z"
+                    />
+                  </svg>
+                  B
+                </button>
+                <span
+                  aria-label="44C Seat Unavailable"
+                  className="map-element map-element__seat"
+                >
+                  <svg
+                    aria-label="close"
+                    data-testid="close"
+                    height={14}
+                    style={
+                      {
+                        "display": "block",
+                        "fill": "currentColor",
+                      }
+                    }
+                    viewBox="0 0 24 24"
+                    width={14}
+                  >
+                    <path
+                      d="M18.3 5.71c-.39-.39-1.02-.39-1.41 0L12 10.59 7.11 5.7c-.39-.39-1.02-.39-1.41 0-.39.39-.39 1.02 0 1.41L10.59 12 5.7 16.89c-.39.39-.39 1.02 0 1.41.39.39 1.02.39 1.41 0L12 13.41l4.89 4.89c.39.39 1.02.39 1.41 0 .39-.39.39-1.02 0-1.41L13.41 12l4.89-4.89c.38-.38.38-1.02 0-1.4z"
+                    />
+                  </svg>
+                </span>
+              </div>
+              <span
+                className="map-section__aisle"
+              >
+                44
+              </span>
+              <div
+                className="map-section"
+              >
+                <span
+                  aria-label="44D Seat Unavailable"
+                  className="map-element map-element__seat"
+                >
+                  <svg
+                    aria-label="close"
+                    data-testid="close"
+                    height={14}
+                    style={
+                      {
+                        "display": "block",
+                        "fill": "currentColor",
+                      }
+                    }
+                    viewBox="0 0 24 24"
+                    width={14}
+                  >
+                    <path
+                      d="M18.3 5.71c-.39-.39-1.02-.39-1.41 0L12 10.59 7.11 5.7c-.39-.39-1.02-.39-1.41 0-.39.39-.39 1.02 0 1.41L10.59 12 5.7 16.89c-.39.39-.39 1.02 0 1.41.39.39 1.02.39 1.41 0L12 13.41l4.89 4.89c.39.39 1.02.39 1.41 0 .39-.39.39-1.02 0-1.41L13.41 12l4.89-4.89c.38-.38.38-1.02 0-1.4z"
+                    />
+                  </svg>
+                </span>
+                <span
+                  aria-label="44E Seat Unavailable"
+                  className="map-element map-element__seat"
+                >
+                  <svg
+                    aria-label="close"
+                    data-testid="close"
+                    height={14}
+                    style={
+                      {
+                        "display": "block",
+                        "fill": "currentColor",
+                      }
+                    }
+                    viewBox="0 0 24 24"
+                    width={14}
+                  >
+                    <path
+                      d="M18.3 5.71c-.39-.39-1.02-.39-1.41 0L12 10.59 7.11 5.7c-.39-.39-1.02-.39-1.41 0-.39.39-.39 1.02 0 1.41L10.59 12 5.7 16.89c-.39.39-.39 1.02 0 1.41.39.39 1.02.39 1.41 0L12 13.41l4.89 4.89c.39.39 1.02.39 1.41 0 .39-.39.39-1.02 0-1.41L13.41 12l4.89-4.89c.38-.38.38-1.02 0-1.4z"
+                    />
+                  </svg>
+                </span>
+                <span
+                  aria-label="44F Seat Unavailable"
+                  className="map-element map-element__seat"
+                >
+                  <svg
+                    aria-label="close"
+                    data-testid="close"
+                    height={14}
+                    style={
+                      {
+                        "display": "block",
+                        "fill": "currentColor",
+                      }
+                    }
+                    viewBox="0 0 24 24"
+                    width={14}
+                  >
+                    <path
+                      d="M18.3 5.71c-.39-.39-1.02-.39-1.41 0L12 10.59 7.11 5.7c-.39-.39-1.02-.39-1.41 0-.39.39-.39 1.02 0 1.41L10.59 12 5.7 16.89c-.39.39-.39 1.02 0 1.41.39.39 1.02.39 1.41 0L12 13.41l4.89 4.89c.39.39 1.02.39 1.41 0 .39-.39.39-1.02 0-1.41L13.41 12l4.89-4.89c.38-.38.38-1.02 0-1.4z"
+                    />
+                  </svg>
+                </span>
+              </div>
+              <span
+                className="map-section__aisle"
+              >
+                44
+              </span>
+              <div
+                className="map-section map-section--right"
+              >
+                <button
+                  aria-label="44H Seat £20.00"
+                  className="map-element map-element__seat map-element--available map-element--actionable"
+                  data-testid="seat-44H"
+                  id="44H"
+                  onClick={[Function]}
+                >
+                  <svg
+                    aria-label="seat_paid_indicator"
+                    className="map-element--fee-payable"
+                    data-testid="seat_paid_indicator"
+                    height={16}
+                    style={
+                      {
+                        "display": "block",
+                        "fill": "currentColor",
+                      }
+                    }
+                    viewBox="0 0 24 24"
+                    width={16}
+                  >
+                    <path
+                      d="M11.7686 0.731368C12.7766 -0.276576 14.5 0.437294 14.5 1.86274V10.8C14.5 12.5673 13.0673 14 11.3 14H2.36274C0.937294 14 0.223427 12.2766 1.23137 11.2686L11.7686 0.731368Z"
+                    />
+                  </svg>
+                  H
+                </button>
+                <button
+                  aria-label="44J Seat £20.00"
+                  className="map-element map-element__seat map-element--available map-element--actionable"
+                  data-testid="seat-44J"
+                  id="44J"
+                  onClick={[Function]}
+                >
+                  <svg
+                    aria-label="seat_paid_indicator"
+                    className="map-element--fee-payable"
+                    data-testid="seat_paid_indicator"
+                    height={16}
+                    style={
+                      {
+                        "display": "block",
+                        "fill": "currentColor",
+                      }
+                    }
+                    viewBox="0 0 24 24"
+                    width={16}
+                  >
+                    <path
+                      d="M11.7686 0.731368C12.7766 -0.276576 14.5 0.437294 14.5 1.86274V10.8C14.5 12.5673 13.0673 14 11.3 14H2.36274C0.937294 14 0.223427 12.2766 1.23137 11.2686L11.7686 0.731368Z"
+                    />
+                  </svg>
+                  J
+                </button>
+                <span
+                  aria-label="44K Seat Unavailable"
+                  className="map-element map-element__seat"
+                >
+                  <svg
+                    aria-label="close"
+                    data-testid="close"
+                    height={14}
+                    style={
+                      {
+                        "display": "block",
+                        "fill": "currentColor",
+                      }
+                    }
+                    viewBox="0 0 24 24"
+                    width={14}
+                  >
+                    <path
+                      d="M18.3 5.71c-.39-.39-1.02-.39-1.41 0L12 10.59 7.11 5.7c-.39-.39-1.02-.39-1.41 0-.39.39-.39 1.02 0 1.41L10.59 12 5.7 16.89c-.39.39-.39 1.02 0 1.41.39.39 1.02.39 1.41 0L12 13.41l4.89 4.89c.39.39 1.02.39 1.41 0 .39-.39.39-1.02 0-1.41L13.41 12l4.89-4.89c.38-.38.38-1.02 0-1.4z"
+                    />
+                  </svg>
+                </span>
+              </div>
+              <div
+                className="map-section map-section--left"
+              >
+                <span
+                  aria-label="45A Seat Unavailable"
+                  className="map-element map-element__seat"
+                >
+                  <svg
+                    aria-label="close"
+                    data-testid="close"
+                    height={14}
+                    style={
+                      {
+                        "display": "block",
+                        "fill": "currentColor",
+                      }
+                    }
+                    viewBox="0 0 24 24"
+                    width={14}
+                  >
+                    <path
+                      d="M18.3 5.71c-.39-.39-1.02-.39-1.41 0L12 10.59 7.11 5.7c-.39-.39-1.02-.39-1.41 0-.39.39-.39 1.02 0 1.41L10.59 12 5.7 16.89c-.39.39-.39 1.02 0 1.41.39.39 1.02.39 1.41 0L12 13.41l4.89 4.89c.39.39 1.02.39 1.41 0 .39-.39.39-1.02 0-1.41L13.41 12l4.89-4.89c.38-.38.38-1.02 0-1.4z"
+                    />
+                  </svg>
+                </span>
+                <span
+                  aria-label="45B Seat Unavailable"
+                  className="map-element map-element__seat"
+                >
+                  <svg
+                    aria-label="close"
+                    data-testid="close"
+                    height={14}
+                    style={
+                      {
+                        "display": "block",
+                        "fill": "currentColor",
+                      }
+                    }
+                    viewBox="0 0 24 24"
+                    width={14}
+                  >
+                    <path
+                      d="M18.3 5.71c-.39-.39-1.02-.39-1.41 0L12 10.59 7.11 5.7c-.39-.39-1.02-.39-1.41 0-.39.39-.39 1.02 0 1.41L10.59 12 5.7 16.89c-.39.39-.39 1.02 0 1.41.39.39 1.02.39 1.41 0L12 13.41l4.89 4.89c.39.39 1.02.39 1.41 0 .39-.39.39-1.02 0-1.41L13.41 12l4.89-4.89c.38-.38.38-1.02 0-1.4z"
+                    />
+                  </svg>
+                </span>
+                <button
+                  aria-label="45C Seat £20.00"
+                  className="map-element map-element__seat map-element--available map-element--actionable"
+                  data-testid="seat-45C"
+                  id="45C"
+                  onClick={[Function]}
+                >
+                  <svg
+                    aria-label="seat_paid_indicator"
+                    className="map-element--fee-payable"
+                    data-testid="seat_paid_indicator"
+                    height={16}
+                    style={
+                      {
+                        "display": "block",
+                        "fill": "currentColor",
+                      }
+                    }
+                    viewBox="0 0 24 24"
+                    width={16}
+                  >
+                    <path
+                      d="M11.7686 0.731368C12.7766 -0.276576 14.5 0.437294 14.5 1.86274V10.8C14.5 12.5673 13.0673 14 11.3 14H2.36274C0.937294 14 0.223427 12.2766 1.23137 11.2686L11.7686 0.731368Z"
+                    />
+                  </svg>
+                  C
+                </button>
+              </div>
+              <span
+                className="map-section__aisle"
+              >
+                45
+              </span>
+              <div
+                className="map-section"
+              >
+                <button
+                  aria-label="45D Seat £20.00"
+                  className="map-element map-element__seat map-element--available map-element--actionable"
+                  data-testid="seat-45D"
+                  id="45D"
+                  onClick={[Function]}
+                >
+                  <svg
+                    aria-label="seat_paid_indicator"
+                    className="map-element--fee-payable"
+                    data-testid="seat_paid_indicator"
+                    height={16}
+                    style={
+                      {
+                        "display": "block",
+                        "fill": "currentColor",
+                      }
+                    }
+                    viewBox="0 0 24 24"
+                    width={16}
+                  >
+                    <path
+                      d="M11.7686 0.731368C12.7766 -0.276576 14.5 0.437294 14.5 1.86274V10.8C14.5 12.5673 13.0673 14 11.3 14H2.36274C0.937294 14 0.223427 12.2766 1.23137 11.2686L11.7686 0.731368Z"
+                    />
+                  </svg>
+                  D
+                </button>
+                <button
+                  aria-label="45E Seat £20.00"
+                  className="map-element map-element__seat map-element--available map-element--actionable"
+                  data-testid="seat-45E"
+                  id="45E"
+                  onClick={[Function]}
+                >
+                  <svg
+                    aria-label="seat_paid_indicator"
+                    className="map-element--fee-payable"
+                    data-testid="seat_paid_indicator"
+                    height={16}
+                    style={
+                      {
+                        "display": "block",
+                        "fill": "currentColor",
+                      }
+                    }
+                    viewBox="0 0 24 24"
+                    width={16}
+                  >
+                    <path
+                      d="M11.7686 0.731368C12.7766 -0.276576 14.5 0.437294 14.5 1.86274V10.8C14.5 12.5673 13.0673 14 11.3 14H2.36274C0.937294 14 0.223427 12.2766 1.23137 11.2686L11.7686 0.731368Z"
+                    />
+                  </svg>
+                  E
+                </button>
+                <span
+                  aria-label="45F Seat Unavailable"
+                  className="map-element map-element__seat"
+                >
+                  <svg
+                    aria-label="close"
+                    data-testid="close"
+                    height={14}
+                    style={
+                      {
+                        "display": "block",
+                        "fill": "currentColor",
+                      }
+                    }
+                    viewBox="0 0 24 24"
+                    width={14}
+                  >
+                    <path
+                      d="M18.3 5.71c-.39-.39-1.02-.39-1.41 0L12 10.59 7.11 5.7c-.39-.39-1.02-.39-1.41 0-.39.39-.39 1.02 0 1.41L10.59 12 5.7 16.89c-.39.39-.39 1.02 0 1.41.39.39 1.02.39 1.41 0L12 13.41l4.89 4.89c.39.39 1.02.39 1.41 0 .39-.39.39-1.02 0-1.41L13.41 12l4.89-4.89c.38-.38.38-1.02 0-1.4z"
+                    />
+                  </svg>
+                </span>
+              </div>
+              <span
+                className="map-section__aisle"
+              >
+                45
+              </span>
+              <div
+                className="map-section map-section--right"
+              >
+                <span
+                  aria-label="45H Seat Unavailable"
+                  className="map-element map-element__seat"
+                >
+                  <svg
+                    aria-label="close"
+                    data-testid="close"
+                    height={14}
+                    style={
+                      {
+                        "display": "block",
+                        "fill": "currentColor",
+                      }
+                    }
+                    viewBox="0 0 24 24"
+                    width={14}
+                  >
+                    <path
+                      d="M18.3 5.71c-.39-.39-1.02-.39-1.41 0L12 10.59 7.11 5.7c-.39-.39-1.02-.39-1.41 0-.39.39-.39 1.02 0 1.41L10.59 12 5.7 16.89c-.39.39-.39 1.02 0 1.41.39.39 1.02.39 1.41 0L12 13.41l4.89 4.89c.39.39 1.02.39 1.41 0 .39-.39.39-1.02 0-1.41L13.41 12l4.89-4.89c.38-.38.38-1.02 0-1.4z"
+                    />
+                  </svg>
+                </span>
+                <span
+                  aria-label="45J Seat Unavailable"
+                  className="map-element map-element__seat"
+                >
+                  <svg
+                    aria-label="close"
+                    data-testid="close"
+                    height={14}
+                    style={
+                      {
+                        "display": "block",
+                        "fill": "currentColor",
+                      }
+                    }
+                    viewBox="0 0 24 24"
+                    width={14}
+                  >
+                    <path
+                      d="M18.3 5.71c-.39-.39-1.02-.39-1.41 0L12 10.59 7.11 5.7c-.39-.39-1.02-.39-1.41 0-.39.39-.39 1.02 0 1.41L10.59 12 5.7 16.89c-.39.39-.39 1.02 0 1.41.39.39 1.02.39 1.41 0L12 13.41l4.89 4.89c.39.39 1.02.39 1.41 0 .39-.39.39-1.02 0-1.41L13.41 12l4.89-4.89c.38-.38.38-1.02 0-1.4z"
+                    />
+                  </svg>
+                </span>
+                <span
+                  aria-label="45K Seat Unavailable"
+                  className="map-element map-element__seat"
+                >
+                  <svg
+                    aria-label="close"
+                    data-testid="close"
+                    height={14}
+                    style={
+                      {
+                        "display": "block",
+                        "fill": "currentColor",
+                      }
+                    }
+                    viewBox="0 0 24 24"
+                    width={14}
+                  >
+                    <path
+                      d="M18.3 5.71c-.39-.39-1.02-.39-1.41 0L12 10.59 7.11 5.7c-.39-.39-1.02-.39-1.41 0-.39.39-.39 1.02 0 1.41L10.59 12 5.7 16.89c-.39.39-.39 1.02 0 1.41.39.39 1.02.39 1.41 0L12 13.41l4.89 4.89c.39.39 1.02.39 1.41 0 .39-.39.39-1.02 0-1.41L13.41 12l4.89-4.89c.38-.38.38-1.02 0-1.4z"
+                    />
+                  </svg>
+                </span>
+              </div>
+              <div
+                className="map-section map-section--left"
+              >
+                <button
+                  aria-label="46A Seat £20.00"
+                  className="map-element map-element__seat map-element--available map-element--actionable"
+                  data-testid="seat-46A"
+                  id="46A"
+                  onClick={[Function]}
+                >
+                  <svg
+                    aria-label="seat_paid_indicator"
+                    className="map-element--fee-payable"
+                    data-testid="seat_paid_indicator"
+                    height={16}
+                    style={
+                      {
+                        "display": "block",
+                        "fill": "currentColor",
+                      }
+                    }
+                    viewBox="0 0 24 24"
+                    width={16}
+                  >
+                    <path
+                      d="M11.7686 0.731368C12.7766 -0.276576 14.5 0.437294 14.5 1.86274V10.8C14.5 12.5673 13.0673 14 11.3 14H2.36274C0.937294 14 0.223427 12.2766 1.23137 11.2686L11.7686 0.731368Z"
+                    />
+                  </svg>
+                  A
+                </button>
+                <button
+                  aria-label="46B Seat £20.00"
+                  className="map-element map-element__seat map-element--available map-element--actionable"
+                  data-testid="seat-46B"
+                  id="46B"
+                  onClick={[Function]}
+                >
+                  <svg
+                    aria-label="seat_paid_indicator"
+                    className="map-element--fee-payable"
+                    data-testid="seat_paid_indicator"
+                    height={16}
+                    style={
+                      {
+                        "display": "block",
+                        "fill": "currentColor",
+                      }
+                    }
+                    viewBox="0 0 24 24"
+                    width={16}
+                  >
+                    <path
+                      d="M11.7686 0.731368C12.7766 -0.276576 14.5 0.437294 14.5 1.86274V10.8C14.5 12.5673 13.0673 14 11.3 14H2.36274C0.937294 14 0.223427 12.2766 1.23137 11.2686L11.7686 0.731368Z"
+                    />
+                  </svg>
+                  B
+                </button>
+                <span
+                  aria-label="46C Seat Unavailable"
+                  className="map-element map-element__seat"
+                >
+                  <svg
+                    aria-label="close"
+                    data-testid="close"
+                    height={14}
+                    style={
+                      {
+                        "display": "block",
+                        "fill": "currentColor",
+                      }
+                    }
+                    viewBox="0 0 24 24"
+                    width={14}
+                  >
+                    <path
+                      d="M18.3 5.71c-.39-.39-1.02-.39-1.41 0L12 10.59 7.11 5.7c-.39-.39-1.02-.39-1.41 0-.39.39-.39 1.02 0 1.41L10.59 12 5.7 16.89c-.39.39-.39 1.02 0 1.41.39.39 1.02.39 1.41 0L12 13.41l4.89 4.89c.39.39 1.02.39 1.41 0 .39-.39.39-1.02 0-1.41L13.41 12l4.89-4.89c.38-.38.38-1.02 0-1.4z"
+                    />
+                  </svg>
+                </span>
+              </div>
+              <span
+                className="map-section__aisle"
+              >
+                46
+              </span>
+              <div
+                className="map-section"
+              >
+                <span
+                  aria-label="46D Seat Unavailable"
+                  className="map-element map-element__seat"
+                >
+                  <svg
+                    aria-label="close"
+                    data-testid="close"
+                    height={14}
+                    style={
+                      {
+                        "display": "block",
+                        "fill": "currentColor",
+                      }
+                    }
+                    viewBox="0 0 24 24"
+                    width={14}
+                  >
+                    <path
+                      d="M18.3 5.71c-.39-.39-1.02-.39-1.41 0L12 10.59 7.11 5.7c-.39-.39-1.02-.39-1.41 0-.39.39-.39 1.02 0 1.41L10.59 12 5.7 16.89c-.39.39-.39 1.02 0 1.41.39.39 1.02.39 1.41 0L12 13.41l4.89 4.89c.39.39 1.02.39 1.41 0 .39-.39.39-1.02 0-1.41L13.41 12l4.89-4.89c.38-.38.38-1.02 0-1.4z"
+                    />
+                  </svg>
+                </span>
+                <span
+                  aria-label="46E Seat Unavailable"
+                  className="map-element map-element__seat"
+                >
+                  <svg
+                    aria-label="close"
+                    data-testid="close"
+                    height={14}
+                    style={
+                      {
+                        "display": "block",
+                        "fill": "currentColor",
+                      }
+                    }
+                    viewBox="0 0 24 24"
+                    width={14}
+                  >
+                    <path
+                      d="M18.3 5.71c-.39-.39-1.02-.39-1.41 0L12 10.59 7.11 5.7c-.39-.39-1.02-.39-1.41 0-.39.39-.39 1.02 0 1.41L10.59 12 5.7 16.89c-.39.39-.39 1.02 0 1.41.39.39 1.02.39 1.41 0L12 13.41l4.89 4.89c.39.39 1.02.39 1.41 0 .39-.39.39-1.02 0-1.41L13.41 12l4.89-4.89c.38-.38.38-1.02 0-1.4z"
+                    />
+                  </svg>
+                </span>
+                <button
+                  aria-label="46F Seat £20.00"
+                  className="map-element map-element__seat map-element--available map-element--actionable"
+                  data-testid="seat-46F"
+                  id="46F"
+                  onClick={[Function]}
+                >
+                  <svg
+                    aria-label="seat_paid_indicator"
+                    className="map-element--fee-payable"
+                    data-testid="seat_paid_indicator"
+                    height={16}
+                    style={
+                      {
+                        "display": "block",
+                        "fill": "currentColor",
+                      }
+                    }
+                    viewBox="0 0 24 24"
+                    width={16}
+                  >
+                    <path
+                      d="M11.7686 0.731368C12.7766 -0.276576 14.5 0.437294 14.5 1.86274V10.8C14.5 12.5673 13.0673 14 11.3 14H2.36274C0.937294 14 0.223427 12.2766 1.23137 11.2686L11.7686 0.731368Z"
+                    />
+                  </svg>
+                  F
+                </button>
+              </div>
+              <span
+                className="map-section__aisle"
+              >
+                46
+              </span>
+              <div
+                className="map-section map-section--right"
+              >
+                <button
+                  aria-label="46H Seat £20.00"
+                  className="map-element map-element__seat map-element--available map-element--actionable"
+                  data-testid="seat-46H"
+                  id="46H"
+                  onClick={[Function]}
+                >
+                  <svg
+                    aria-label="seat_paid_indicator"
+                    className="map-element--fee-payable"
+                    data-testid="seat_paid_indicator"
+                    height={16}
+                    style={
+                      {
+                        "display": "block",
+                        "fill": "currentColor",
+                      }
+                    }
+                    viewBox="0 0 24 24"
+                    width={16}
+                  >
+                    <path
+                      d="M11.7686 0.731368C12.7766 -0.276576 14.5 0.437294 14.5 1.86274V10.8C14.5 12.5673 13.0673 14 11.3 14H2.36274C0.937294 14 0.223427 12.2766 1.23137 11.2686L11.7686 0.731368Z"
+                    />
+                  </svg>
+                  H
+                </button>
+                <span
+                  aria-label="46J Seat Unavailable"
+                  className="map-element map-element__seat"
+                >
+                  <svg
+                    aria-label="close"
+                    data-testid="close"
+                    height={14}
+                    style={
+                      {
+                        "display": "block",
+                        "fill": "currentColor",
+                      }
+                    }
+                    viewBox="0 0 24 24"
+                    width={14}
+                  >
+                    <path
+                      d="M18.3 5.71c-.39-.39-1.02-.39-1.41 0L12 10.59 7.11 5.7c-.39-.39-1.02-.39-1.41 0-.39.39-.39 1.02 0 1.41L10.59 12 5.7 16.89c-.39.39-.39 1.02 0 1.41.39.39 1.02.39 1.41 0L12 13.41l4.89 4.89c.39.39 1.02.39 1.41 0 .39-.39.39-1.02 0-1.41L13.41 12l4.89-4.89c.38-.38.38-1.02 0-1.4z"
+                    />
+                  </svg>
+                </span>
+                <button
+                  aria-label="46K Seat £20.00"
+                  className="map-element map-element__seat map-element--available map-element--actionable"
+                  data-testid="seat-46K"
+                  id="46K"
+                  onClick={[Function]}
+                >
+                  <svg
+                    aria-label="seat_paid_indicator"
+                    className="map-element--fee-payable"
+                    data-testid="seat_paid_indicator"
+                    height={16}
+                    style={
+                      {
+                        "display": "block",
+                        "fill": "currentColor",
+                      }
+                    }
+                    viewBox="0 0 24 24"
+                    width={16}
+                  >
+                    <path
+                      d="M11.7686 0.731368C12.7766 -0.276576 14.5 0.437294 14.5 1.86274V10.8C14.5 12.5673 13.0673 14 11.3 14H2.36274C0.937294 14 0.223427 12.2766 1.23137 11.2686L11.7686 0.731368Z"
+                    />
+                  </svg>
+                  K
+                </button>
+              </div>
+              <div
+                className="map-section map-section--left"
+              >
+                <button
+                  aria-label="47A Seat £20.00"
+                  className="map-element map-element__seat map-element--available map-element--actionable"
+                  data-testid="seat-47A"
+                  id="47A"
+                  onClick={[Function]}
+                >
+                  <svg
+                    aria-label="seat_paid_indicator"
+                    className="map-element--fee-payable"
+                    data-testid="seat_paid_indicator"
+                    height={16}
+                    style={
+                      {
+                        "display": "block",
+                        "fill": "currentColor",
+                      }
+                    }
+                    viewBox="0 0 24 24"
+                    width={16}
+                  >
+                    <path
+                      d="M11.7686 0.731368C12.7766 -0.276576 14.5 0.437294 14.5 1.86274V10.8C14.5 12.5673 13.0673 14 11.3 14H2.36274C0.937294 14 0.223427 12.2766 1.23137 11.2686L11.7686 0.731368Z"
+                    />
+                  </svg>
+                  A
+                </button>
+                <button
+                  aria-label="47B Seat £20.00"
+                  className="map-element map-element__seat map-element--available map-element--actionable"
+                  data-testid="seat-47B"
+                  id="47B"
+                  onClick={[Function]}
+                >
+                  <svg
+                    aria-label="seat_paid_indicator"
+                    className="map-element--fee-payable"
+                    data-testid="seat_paid_indicator"
+                    height={16}
+                    style={
+                      {
+                        "display": "block",
+                        "fill": "currentColor",
+                      }
+                    }
+                    viewBox="0 0 24 24"
+                    width={16}
+                  >
+                    <path
+                      d="M11.7686 0.731368C12.7766 -0.276576 14.5 0.437294 14.5 1.86274V10.8C14.5 12.5673 13.0673 14 11.3 14H2.36274C0.937294 14 0.223427 12.2766 1.23137 11.2686L11.7686 0.731368Z"
+                    />
+                  </svg>
+                  B
+                </button>
+                <button
+                  aria-label="47C Seat £20.00"
+                  className="map-element map-element__seat map-element--available map-element--actionable"
+                  data-testid="seat-47C"
+                  id="47C"
+                  onClick={[Function]}
+                >
+                  <svg
+                    aria-label="seat_paid_indicator"
+                    className="map-element--fee-payable"
+                    data-testid="seat_paid_indicator"
+                    height={16}
+                    style={
+                      {
+                        "display": "block",
+                        "fill": "currentColor",
+                      }
+                    }
+                    viewBox="0 0 24 24"
+                    width={16}
+                  >
+                    <path
+                      d="M11.7686 0.731368C12.7766 -0.276576 14.5 0.437294 14.5 1.86274V10.8C14.5 12.5673 13.0673 14 11.3 14H2.36274C0.937294 14 0.223427 12.2766 1.23137 11.2686L11.7686 0.731368Z"
+                    />
+                  </svg>
+                  C
+                </button>
+              </div>
+              <span
+                className="map-section__aisle"
+              >
+                47
+              </span>
+              <div
+                className="map-section"
+              >
+                <span
+                  aria-label="47D Seat Unavailable"
+                  className="map-element map-element__seat"
+                >
+                  <svg
+                    aria-label="close"
+                    data-testid="close"
+                    height={14}
+                    style={
+                      {
+                        "display": "block",
+                        "fill": "currentColor",
+                      }
+                    }
+                    viewBox="0 0 24 24"
+                    width={14}
+                  >
+                    <path
+                      d="M18.3 5.71c-.39-.39-1.02-.39-1.41 0L12 10.59 7.11 5.7c-.39-.39-1.02-.39-1.41 0-.39.39-.39 1.02 0 1.41L10.59 12 5.7 16.89c-.39.39-.39 1.02 0 1.41.39.39 1.02.39 1.41 0L12 13.41l4.89 4.89c.39.39 1.02.39 1.41 0 .39-.39.39-1.02 0-1.41L13.41 12l4.89-4.89c.38-.38.38-1.02 0-1.4z"
+                    />
+                  </svg>
+                </span>
+                <button
+                  aria-label="47E Seat £20.00"
+                  className="map-element map-element__seat map-element--available map-element--actionable"
+                  data-testid="seat-47E"
+                  id="47E"
+                  onClick={[Function]}
+                >
+                  <svg
+                    aria-label="seat_paid_indicator"
+                    className="map-element--fee-payable"
+                    data-testid="seat_paid_indicator"
+                    height={16}
+                    style={
+                      {
+                        "display": "block",
+                        "fill": "currentColor",
+                      }
+                    }
+                    viewBox="0 0 24 24"
+                    width={16}
+                  >
+                    <path
+                      d="M11.7686 0.731368C12.7766 -0.276576 14.5 0.437294 14.5 1.86274V10.8C14.5 12.5673 13.0673 14 11.3 14H2.36274C0.937294 14 0.223427 12.2766 1.23137 11.2686L11.7686 0.731368Z"
+                    />
+                  </svg>
+                  E
+                </button>
+                <button
+                  aria-label="47F Seat £20.00"
+                  className="map-element map-element__seat map-element--available map-element--actionable"
+                  data-testid="seat-47F"
+                  id="47F"
+                  onClick={[Function]}
+                >
+                  <svg
+                    aria-label="seat_paid_indicator"
+                    className="map-element--fee-payable"
+                    data-testid="seat_paid_indicator"
+                    height={16}
+                    style={
+                      {
+                        "display": "block",
+                        "fill": "currentColor",
+                      }
+                    }
+                    viewBox="0 0 24 24"
+                    width={16}
+                  >
+                    <path
+                      d="M11.7686 0.731368C12.7766 -0.276576 14.5 0.437294 14.5 1.86274V10.8C14.5 12.5673 13.0673 14 11.3 14H2.36274C0.937294 14 0.223427 12.2766 1.23137 11.2686L11.7686 0.731368Z"
+                    />
+                  </svg>
+                  F
+                </button>
+              </div>
+              <span
+                className="map-section__aisle"
+              >
+                47
+              </span>
+              <div
+                className="map-section map-section--right"
+              >
+                <span
+                  aria-label="47H Seat Unavailable"
+                  className="map-element map-element__seat"
+                >
+                  <svg
+                    aria-label="close"
+                    data-testid="close"
+                    height={14}
+                    style={
+                      {
+                        "display": "block",
+                        "fill": "currentColor",
+                      }
+                    }
+                    viewBox="0 0 24 24"
+                    width={14}
+                  >
+                    <path
+                      d="M18.3 5.71c-.39-.39-1.02-.39-1.41 0L12 10.59 7.11 5.7c-.39-.39-1.02-.39-1.41 0-.39.39-.39 1.02 0 1.41L10.59 12 5.7 16.89c-.39.39-.39 1.02 0 1.41.39.39 1.02.39 1.41 0L12 13.41l4.89 4.89c.39.39 1.02.39 1.41 0 .39-.39.39-1.02 0-1.41L13.41 12l4.89-4.89c.38-.38.38-1.02 0-1.4z"
+                    />
+                  </svg>
+                </span>
+                <button
+                  aria-label="47J Seat £20.00"
+                  className="map-element map-element__seat map-element--available map-element--actionable"
+                  data-testid="seat-47J"
+                  id="47J"
+                  onClick={[Function]}
+                >
+                  <svg
+                    aria-label="seat_paid_indicator"
+                    className="map-element--fee-payable"
+                    data-testid="seat_paid_indicator"
+                    height={16}
+                    style={
+                      {
+                        "display": "block",
+                        "fill": "currentColor",
+                      }
+                    }
+                    viewBox="0 0 24 24"
+                    width={16}
+                  >
+                    <path
+                      d="M11.7686 0.731368C12.7766 -0.276576 14.5 0.437294 14.5 1.86274V10.8C14.5 12.5673 13.0673 14 11.3 14H2.36274C0.937294 14 0.223427 12.2766 1.23137 11.2686L11.7686 0.731368Z"
+                    />
+                  </svg>
+                  J
+                </button>
+                <button
+                  aria-label="47K Seat £20.00"
+                  className="map-element map-element__seat map-element--available map-element--actionable"
+                  data-testid="seat-47K"
+                  id="47K"
+                  onClick={[Function]}
+                >
+                  <svg
+                    aria-label="seat_paid_indicator"
+                    className="map-element--fee-payable"
+                    data-testid="seat_paid_indicator"
+                    height={16}
+                    style={
+                      {
+                        "display": "block",
+                        "fill": "currentColor",
+                      }
+                    }
+                    viewBox="0 0 24 24"
+                    width={16}
+                  >
+                    <path
+                      d="M11.7686 0.731368C12.7766 -0.276576 14.5 0.437294 14.5 1.86274V10.8C14.5 12.5673 13.0673 14 11.3 14H2.36274C0.937294 14 0.223427 12.2766 1.23137 11.2686L11.7686 0.731368Z"
+                    />
+                  </svg>
+                  K
+                </button>
+              </div>
+              <div
+                className="map-section map-section--left"
+              >
+                <span
+                  aria-label="48A Seat Unavailable"
+                  className="map-element map-element__seat"
+                >
+                  <svg
+                    aria-label="close"
+                    data-testid="close"
+                    height={14}
+                    style={
+                      {
+                        "display": "block",
+                        "fill": "currentColor",
+                      }
+                    }
+                    viewBox="0 0 24 24"
+                    width={14}
+                  >
+                    <path
+                      d="M18.3 5.71c-.39-.39-1.02-.39-1.41 0L12 10.59 7.11 5.7c-.39-.39-1.02-.39-1.41 0-.39.39-.39 1.02 0 1.41L10.59 12 5.7 16.89c-.39.39-.39 1.02 0 1.41.39.39 1.02.39 1.41 0L12 13.41l4.89 4.89c.39.39 1.02.39 1.41 0 .39-.39.39-1.02 0-1.41L13.41 12l4.89-4.89c.38-.38.38-1.02 0-1.4z"
+                    />
+                  </svg>
+                </span>
+                <button
+                  aria-label="48B Seat £20.00"
+                  className="map-element map-element__seat map-element--available map-element--actionable"
+                  data-testid="seat-48B"
+                  id="48B"
+                  onClick={[Function]}
+                >
+                  <svg
+                    aria-label="seat_paid_indicator"
+                    className="map-element--fee-payable"
+                    data-testid="seat_paid_indicator"
+                    height={16}
+                    style={
+                      {
+                        "display": "block",
+                        "fill": "currentColor",
+                      }
+                    }
+                    viewBox="0 0 24 24"
+                    width={16}
+                  >
+                    <path
+                      d="M11.7686 0.731368C12.7766 -0.276576 14.5 0.437294 14.5 1.86274V10.8C14.5 12.5673 13.0673 14 11.3 14H2.36274C0.937294 14 0.223427 12.2766 1.23137 11.2686L11.7686 0.731368Z"
+                    />
+                  </svg>
+                  B
+                </button>
+                <button
+                  aria-label="48C Seat £20.00"
+                  className="map-element map-element__seat map-element--available map-element--actionable"
+                  data-testid="seat-48C"
+                  id="48C"
+                  onClick={[Function]}
+                >
+                  <svg
+                    aria-label="seat_paid_indicator"
+                    className="map-element--fee-payable"
+                    data-testid="seat_paid_indicator"
+                    height={16}
+                    style={
+                      {
+                        "display": "block",
+                        "fill": "currentColor",
+                      }
+                    }
+                    viewBox="0 0 24 24"
+                    width={16}
+                  >
+                    <path
+                      d="M11.7686 0.731368C12.7766 -0.276576 14.5 0.437294 14.5 1.86274V10.8C14.5 12.5673 13.0673 14 11.3 14H2.36274C0.937294 14 0.223427 12.2766 1.23137 11.2686L11.7686 0.731368Z"
+                    />
+                  </svg>
+                  C
+                </button>
+              </div>
+              <span
+                className="map-section__aisle"
+              >
+                48
+              </span>
+              <div
+                className="map-section"
+              >
+                <span
+                  aria-label="48D Seat Unavailable"
+                  className="map-element map-element__seat"
+                >
+                  <svg
+                    aria-label="close"
+                    data-testid="close"
+                    height={14}
+                    style={
+                      {
+                        "display": "block",
+                        "fill": "currentColor",
+                      }
+                    }
+                    viewBox="0 0 24 24"
+                    width={14}
+                  >
+                    <path
+                      d="M18.3 5.71c-.39-.39-1.02-.39-1.41 0L12 10.59 7.11 5.7c-.39-.39-1.02-.39-1.41 0-.39.39-.39 1.02 0 1.41L10.59 12 5.7 16.89c-.39.39-.39 1.02 0 1.41.39.39 1.02.39 1.41 0L12 13.41l4.89 4.89c.39.39 1.02.39 1.41 0 .39-.39.39-1.02 0-1.41L13.41 12l4.89-4.89c.38-.38.38-1.02 0-1.4z"
+                    />
+                  </svg>
+                </span>
+                <span
+                  aria-label="48E Seat Unavailable"
+                  className="map-element map-element__seat"
+                >
+                  <svg
+                    aria-label="close"
+                    data-testid="close"
+                    height={14}
+                    style={
+                      {
+                        "display": "block",
+                        "fill": "currentColor",
+                      }
+                    }
+                    viewBox="0 0 24 24"
+                    width={14}
+                  >
+                    <path
+                      d="M18.3 5.71c-.39-.39-1.02-.39-1.41 0L12 10.59 7.11 5.7c-.39-.39-1.02-.39-1.41 0-.39.39-.39 1.02 0 1.41L10.59 12 5.7 16.89c-.39.39-.39 1.02 0 1.41.39.39 1.02.39 1.41 0L12 13.41l4.89 4.89c.39.39 1.02.39 1.41 0 .39-.39.39-1.02 0-1.41L13.41 12l4.89-4.89c.38-.38.38-1.02 0-1.4z"
+                    />
+                  </svg>
+                </span>
+                <span
+                  aria-label="48F Seat Unavailable"
+                  className="map-element map-element__seat"
+                >
+                  <svg
+                    aria-label="close"
+                    data-testid="close"
+                    height={14}
+                    style={
+                      {
+                        "display": "block",
+                        "fill": "currentColor",
+                      }
+                    }
+                    viewBox="0 0 24 24"
+                    width={14}
+                  >
+                    <path
+                      d="M18.3 5.71c-.39-.39-1.02-.39-1.41 0L12 10.59 7.11 5.7c-.39-.39-1.02-.39-1.41 0-.39.39-.39 1.02 0 1.41L10.59 12 5.7 16.89c-.39.39-.39 1.02 0 1.41.39.39 1.02.39 1.41 0L12 13.41l4.89 4.89c.39.39 1.02.39 1.41 0 .39-.39.39-1.02 0-1.41L13.41 12l4.89-4.89c.38-.38.38-1.02 0-1.4z"
+                    />
+                  </svg>
+                </span>
+              </div>
+              <span
+                className="map-section__aisle"
+              >
+                48
+              </span>
+              <div
+                className="map-section map-section--right"
+              >
+                <button
+                  aria-label="48H Seat £20.00"
+                  className="map-element map-element__seat map-element--available map-element--actionable"
+                  data-testid="seat-48H"
+                  id="48H"
+                  onClick={[Function]}
+                >
+                  <svg
+                    aria-label="seat_paid_indicator"
+                    className="map-element--fee-payable"
+                    data-testid="seat_paid_indicator"
+                    height={16}
+                    style={
+                      {
+                        "display": "block",
+                        "fill": "currentColor",
+                      }
+                    }
+                    viewBox="0 0 24 24"
+                    width={16}
+                  >
+                    <path
+                      d="M11.7686 0.731368C12.7766 -0.276576 14.5 0.437294 14.5 1.86274V10.8C14.5 12.5673 13.0673 14 11.3 14H2.36274C0.937294 14 0.223427 12.2766 1.23137 11.2686L11.7686 0.731368Z"
+                    />
+                  </svg>
+                  H
+                </button>
+                <span
+                  aria-label="48J Seat Unavailable"
+                  className="map-element map-element__seat"
+                >
+                  <svg
+                    aria-label="close"
+                    data-testid="close"
+                    height={14}
+                    style={
+                      {
+                        "display": "block",
+                        "fill": "currentColor",
+                      }
+                    }
+                    viewBox="0 0 24 24"
+                    width={14}
+                  >
+                    <path
+                      d="M18.3 5.71c-.39-.39-1.02-.39-1.41 0L12 10.59 7.11 5.7c-.39-.39-1.02-.39-1.41 0-.39.39-.39 1.02 0 1.41L10.59 12 5.7 16.89c-.39.39-.39 1.02 0 1.41.39.39 1.02.39 1.41 0L12 13.41l4.89 4.89c.39.39 1.02.39 1.41 0 .39-.39.39-1.02 0-1.41L13.41 12l4.89-4.89c.38-.38.38-1.02 0-1.4z"
+                    />
+                  </svg>
+                </span>
+                <span
+                  aria-label="48K Seat Unavailable"
+                  className="map-element map-element__seat"
+                >
+                  <svg
+                    aria-label="close"
+                    data-testid="close"
+                    height={14}
+                    style={
+                      {
+                        "display": "block",
+                        "fill": "currentColor",
+                      }
+                    }
+                    viewBox="0 0 24 24"
+                    width={14}
+                  >
+                    <path
+                      d="M18.3 5.71c-.39-.39-1.02-.39-1.41 0L12 10.59 7.11 5.7c-.39-.39-1.02-.39-1.41 0-.39.39-.39 1.02 0 1.41L10.59 12 5.7 16.89c-.39.39-.39 1.02 0 1.41.39.39 1.02.39 1.41 0L12 13.41l4.89 4.89c.39.39 1.02.39 1.41 0 .39-.39.39-1.02 0-1.41L13.41 12l4.89-4.89c.38-.38.38-1.02 0-1.4z"
+                    />
+                  </svg>
+                </span>
+              </div>
+              <div
+                className="map-section map-section--left"
+              >
+                <span
+                  aria-label="49A Seat Unavailable"
+                  className="map-element map-element__seat"
+                >
+                  <svg
+                    aria-label="close"
+                    data-testid="close"
+                    height={14}
+                    style={
+                      {
+                        "display": "block",
+                        "fill": "currentColor",
+                      }
+                    }
+                    viewBox="0 0 24 24"
+                    width={14}
+                  >
+                    <path
+                      d="M18.3 5.71c-.39-.39-1.02-.39-1.41 0L12 10.59 7.11 5.7c-.39-.39-1.02-.39-1.41 0-.39.39-.39 1.02 0 1.41L10.59 12 5.7 16.89c-.39.39-.39 1.02 0 1.41.39.39 1.02.39 1.41 0L12 13.41l4.89 4.89c.39.39 1.02.39 1.41 0 .39-.39.39-1.02 0-1.41L13.41 12l4.89-4.89c.38-.38.38-1.02 0-1.4z"
+                    />
+                  </svg>
+                </span>
+                <button
+                  aria-label="49C Seat £20.00"
+                  className="map-element map-element__seat map-element--available map-element--actionable"
+                  data-testid="seat-49C"
+                  id="49C"
+                  onClick={[Function]}
+                >
+                  <svg
+                    aria-label="seat_paid_indicator"
+                    className="map-element--fee-payable"
+                    data-testid="seat_paid_indicator"
+                    height={16}
+                    style={
+                      {
+                        "display": "block",
+                        "fill": "currentColor",
+                      }
+                    }
+                    viewBox="0 0 24 24"
+                    width={16}
+                  >
+                    <path
+                      d="M11.7686 0.731368C12.7766 -0.276576 14.5 0.437294 14.5 1.86274V10.8C14.5 12.5673 13.0673 14 11.3 14H2.36274C0.937294 14 0.223427 12.2766 1.23137 11.2686L11.7686 0.731368Z"
+                    />
+                  </svg>
+                  C
+                </button>
+              </div>
+              <span
+                className="map-section__aisle"
+              >
+                49
+              </span>
+              <div
+                className="map-section"
+              >
+                <span
+                  aria-label="49D Seat Unavailable"
+                  className="map-element map-element__seat"
+                >
+                  <svg
+                    aria-label="close"
+                    data-testid="close"
+                    height={14}
+                    style={
+                      {
+                        "display": "block",
+                        "fill": "currentColor",
+                      }
+                    }
+                    viewBox="0 0 24 24"
+                    width={14}
+                  >
+                    <path
+                      d="M18.3 5.71c-.39-.39-1.02-.39-1.41 0L12 10.59 7.11 5.7c-.39-.39-1.02-.39-1.41 0-.39.39-.39 1.02 0 1.41L10.59 12 5.7 16.89c-.39.39-.39 1.02 0 1.41.39.39 1.02.39 1.41 0L12 13.41l4.89 4.89c.39.39 1.02.39 1.41 0 .39-.39.39-1.02 0-1.41L13.41 12l4.89-4.89c.38-.38.38-1.02 0-1.4z"
+                    />
+                  </svg>
+                </span>
+                <span
+                  aria-label="49E Seat Unavailable"
+                  className="map-element map-element__seat"
+                >
+                  <svg
+                    aria-label="close"
+                    data-testid="close"
+                    height={14}
+                    style={
+                      {
+                        "display": "block",
+                        "fill": "currentColor",
+                      }
+                    }
+                    viewBox="0 0 24 24"
+                    width={14}
+                  >
+                    <path
+                      d="M18.3 5.71c-.39-.39-1.02-.39-1.41 0L12 10.59 7.11 5.7c-.39-.39-1.02-.39-1.41 0-.39.39-.39 1.02 0 1.41L10.59 12 5.7 16.89c-.39.39-.39 1.02 0 1.41.39.39 1.02.39 1.41 0L12 13.41l4.89 4.89c.39.39 1.02.39 1.41 0 .39-.39.39-1.02 0-1.41L13.41 12l4.89-4.89c.38-.38.38-1.02 0-1.4z"
+                    />
+                  </svg>
+                </span>
+                <button
+                  aria-label="49F Seat £20.00"
+                  className="map-element map-element__seat map-element--available map-element--actionable"
+                  data-testid="seat-49F"
+                  id="49F"
+                  onClick={[Function]}
+                >
+                  <svg
+                    aria-label="seat_paid_indicator"
+                    className="map-element--fee-payable"
+                    data-testid="seat_paid_indicator"
+                    height={16}
+                    style={
+                      {
+                        "display": "block",
+                        "fill": "currentColor",
+                      }
+                    }
+                    viewBox="0 0 24 24"
+                    width={16}
+                  >
+                    <path
+                      d="M11.7686 0.731368C12.7766 -0.276576 14.5 0.437294 14.5 1.86274V10.8C14.5 12.5673 13.0673 14 11.3 14H2.36274C0.937294 14 0.223427 12.2766 1.23137 11.2686L11.7686 0.731368Z"
+                    />
+                  </svg>
+                  F
+                </button>
+              </div>
+              <span
+                className="map-section__aisle"
+              >
+                49
+              </span>
+              <div
+                className="map-section map-section--right"
+              >
+                <button
+                  aria-label="49J Seat £20.00"
+                  className="map-element map-element__seat map-element--available map-element--actionable"
+                  data-testid="seat-49J"
+                  id="49J"
+                  onClick={[Function]}
+                >
+                  <svg
+                    aria-label="seat_paid_indicator"
+                    className="map-element--fee-payable"
+                    data-testid="seat_paid_indicator"
+                    height={16}
+                    style={
+                      {
+                        "display": "block",
+                        "fill": "currentColor",
+                      }
+                    }
+                    viewBox="0 0 24 24"
+                    width={16}
+                  >
+                    <path
+                      d="M11.7686 0.731368C12.7766 -0.276576 14.5 0.437294 14.5 1.86274V10.8C14.5 12.5673 13.0673 14 11.3 14H2.36274C0.937294 14 0.223427 12.2766 1.23137 11.2686L11.7686 0.731368Z"
+                    />
+                  </svg>
+                  J
+                </button>
+                <span
+                  aria-label="49K Seat Unavailable"
+                  className="map-element map-element__seat"
+                >
+                  <svg
+                    aria-label="close"
+                    data-testid="close"
+                    height={14}
+                    style={
+                      {
+                        "display": "block",
+                        "fill": "currentColor",
+                      }
+                    }
+                    viewBox="0 0 24 24"
+                    width={14}
+                  >
+                    <path
+                      d="M18.3 5.71c-.39-.39-1.02-.39-1.41 0L12 10.59 7.11 5.7c-.39-.39-1.02-.39-1.41 0-.39.39-.39 1.02 0 1.41L10.59 12 5.7 16.89c-.39.39-.39 1.02 0 1.41.39.39 1.02.39 1.41 0L12 13.41l4.89 4.89c.39.39 1.02.39 1.41 0 .39-.39.39-1.02 0-1.41L13.41 12l4.89-4.89c.38-.38.38-1.02 0-1.4z"
+                    />
+                  </svg>
+                </span>
+              </div>
+              <div
+                className="map-section map-section--left"
+              >
+                <button
+                  aria-label="50A Seat £20.00"
+                  className="map-element map-element__seat map-element--available map-element--actionable"
+                  data-testid="seat-50A"
+                  id="50A"
+                  onClick={[Function]}
+                >
+                  <svg
+                    aria-label="seat_paid_indicator"
+                    className="map-element--fee-payable"
+                    data-testid="seat_paid_indicator"
+                    height={16}
+                    style={
+                      {
+                        "display": "block",
+                        "fill": "currentColor",
+                      }
+                    }
+                    viewBox="0 0 24 24"
+                    width={16}
+                  >
+                    <path
+                      d="M11.7686 0.731368C12.7766 -0.276576 14.5 0.437294 14.5 1.86274V10.8C14.5 12.5673 13.0673 14 11.3 14H2.36274C0.937294 14 0.223427 12.2766 1.23137 11.2686L11.7686 0.731368Z"
+                    />
+                  </svg>
+                  A
+                </button>
+                <span
+                  aria-label="50C Seat Unavailable"
+                  className="map-element map-element__seat"
+                >
+                  <svg
+                    aria-label="close"
+                    data-testid="close"
+                    height={14}
+                    style={
+                      {
+                        "display": "block",
+                        "fill": "currentColor",
+                      }
+                    }
+                    viewBox="0 0 24 24"
+                    width={14}
+                  >
+                    <path
+                      d="M18.3 5.71c-.39-.39-1.02-.39-1.41 0L12 10.59 7.11 5.7c-.39-.39-1.02-.39-1.41 0-.39.39-.39 1.02 0 1.41L10.59 12 5.7 16.89c-.39.39-.39 1.02 0 1.41.39.39 1.02.39 1.41 0L12 13.41l4.89 4.89c.39.39 1.02.39 1.41 0 .39-.39.39-1.02 0-1.41L13.41 12l4.89-4.89c.38-.38.38-1.02 0-1.4z"
+                    />
+                  </svg>
+                </span>
+              </div>
+              <span
+                className="map-section__aisle"
+              >
+                50
+              </span>
+              <div
+                className="map-section"
+              >
+                <span
+                  aria-label="50D Seat Unavailable"
+                  className="map-element map-element__seat"
+                >
+                  <svg
+                    aria-label="close"
+                    data-testid="close"
+                    height={14}
+                    style={
+                      {
+                        "display": "block",
+                        "fill": "currentColor",
+                      }
+                    }
+                    viewBox="0 0 24 24"
+                    width={14}
+                  >
+                    <path
+                      d="M18.3 5.71c-.39-.39-1.02-.39-1.41 0L12 10.59 7.11 5.7c-.39-.39-1.02-.39-1.41 0-.39.39-.39 1.02 0 1.41L10.59 12 5.7 16.89c-.39.39-.39 1.02 0 1.41.39.39 1.02.39 1.41 0L12 13.41l4.89 4.89c.39.39 1.02.39 1.41 0 .39-.39.39-1.02 0-1.41L13.41 12l4.89-4.89c.38-.38.38-1.02 0-1.4z"
+                    />
+                  </svg>
+                </span>
+                <span
+                  aria-label="50E Seat Unavailable"
+                  className="map-element map-element__seat"
+                >
+                  <svg
+                    aria-label="close"
+                    data-testid="close"
+                    height={14}
+                    style={
+                      {
+                        "display": "block",
+                        "fill": "currentColor",
+                      }
+                    }
+                    viewBox="0 0 24 24"
+                    width={14}
+                  >
+                    <path
+                      d="M18.3 5.71c-.39-.39-1.02-.39-1.41 0L12 10.59 7.11 5.7c-.39-.39-1.02-.39-1.41 0-.39.39-.39 1.02 0 1.41L10.59 12 5.7 16.89c-.39.39-.39 1.02 0 1.41.39.39 1.02.39 1.41 0L12 13.41l4.89 4.89c.39.39 1.02.39 1.41 0 .39-.39.39-1.02 0-1.41L13.41 12l4.89-4.89c.38-.38.38-1.02 0-1.4z"
+                    />
+                  </svg>
+                </span>
+                <button
+                  aria-label="50F Seat £20.00"
+                  className="map-element map-element__seat map-element--available map-element--actionable"
+                  data-testid="seat-50F"
+                  id="50F"
+                  onClick={[Function]}
+                >
+                  <svg
+                    aria-label="seat_paid_indicator"
+                    className="map-element--fee-payable"
+                    data-testid="seat_paid_indicator"
+                    height={16}
+                    style={
+                      {
+                        "display": "block",
+                        "fill": "currentColor",
+                      }
+                    }
+                    viewBox="0 0 24 24"
+                    width={16}
+                  >
+                    <path
+                      d="M11.7686 0.731368C12.7766 -0.276576 14.5 0.437294 14.5 1.86274V10.8C14.5 12.5673 13.0673 14 11.3 14H2.36274C0.937294 14 0.223427 12.2766 1.23137 11.2686L11.7686 0.731368Z"
+                    />
+                  </svg>
+                  F
+                </button>
+              </div>
+              <span
+                className="map-section__aisle"
+              >
+                50
+              </span>
+              <div
+                className="map-section map-section--right"
+              >
+                <button
+                  aria-label="50J Seat £20.00"
+                  className="map-element map-element__seat map-element--available map-element--actionable"
+                  data-testid="seat-50J"
+                  id="50J"
+                  onClick={[Function]}
+                >
+                  <svg
+                    aria-label="seat_paid_indicator"
+                    className="map-element--fee-payable"
+                    data-testid="seat_paid_indicator"
+                    height={16}
+                    style={
+                      {
+                        "display": "block",
+                        "fill": "currentColor",
+                      }
+                    }
+                    viewBox="0 0 24 24"
+                    width={16}
+                  >
+                    <path
+                      d="M11.7686 0.731368C12.7766 -0.276576 14.5 0.437294 14.5 1.86274V10.8C14.5 12.5673 13.0673 14 11.3 14H2.36274C0.937294 14 0.223427 12.2766 1.23137 11.2686L11.7686 0.731368Z"
+                    />
+                  </svg>
+                  J
+                </button>
+                <span
+                  aria-label="50K Seat Unavailable"
+                  className="map-element map-element__seat"
+                >
+                  <svg
+                    aria-label="close"
+                    data-testid="close"
+                    height={14}
+                    style={
+                      {
+                        "display": "block",
+                        "fill": "currentColor",
+                      }
+                    }
+                    viewBox="0 0 24 24"
+                    width={14}
+                  >
+                    <path
+                      d="M18.3 5.71c-.39-.39-1.02-.39-1.41 0L12 10.59 7.11 5.7c-.39-.39-1.02-.39-1.41 0-.39.39-.39 1.02 0 1.41L10.59 12 5.7 16.89c-.39.39-.39 1.02 0 1.41.39.39 1.02.39 1.41 0L12 13.41l4.89 4.89c.39.39 1.02.39 1.41 0 .39-.39.39-1.02 0-1.41L13.41 12l4.89-4.89c.38-.38.38-1.02 0-1.4z"
+                    />
+                  </svg>
+                </span>
+              </div>
+              <div
+                className="map-section map-section--left"
+              >
+                <div
+                  aria-label="lavatory"
+                  className="map-element map-element--amenity map-element--wrapped"
+                >
+                  <svg
+                    aria-label="lavatory"
+                    data-testid="lavatory"
+                    height={16}
+                    style={
+                      {
+                        "display": "block",
+                        "fill": "currentColor",
+                      }
+                    }
+                    viewBox="0 0 24 24"
+                    width={16}
+                  >
+                    <path
+                      d="M5.5 22v-7.5H4V9c0-1.1.9-2 2-2h3c1.1 0 2 .9 2 2v5.5H9.5V22h-4zM18 22v-6h3l-2.54-7.63C18.18 7.55 17.42 7 16.56 7h-.12c-.86 0-1.63.55-1.9 1.37L12 16h3v6h3zM7.5 6c1.11 0 2-.89 2-2s-.89-2-2-2-2 .89-2 2 .89 2 2 2zm9 0c1.11 0 2-.89 2-2s-.89-2-2-2-2 .89-2 2 .89 2 2 2z"
+                    />
+                  </svg>
+                </div>
+              </div>
+              <span
+                className="map-section__aisle"
+              />
+              <div
+                className="map-section"
+              >
+                <div
+                  className="map-element map-element--empty"
+                />
+              </div>
+              <span
+                className="map-section__aisle"
+              />
+              <div
+                className="map-section map-section--right"
+              >
+                <div
+                  aria-label="lavatory"
+                  className="map-element map-element--amenity map-element--wrapped"
+                >
+                  <svg
+                    aria-label="lavatory"
+                    data-testid="lavatory"
+                    height={16}
+                    style={
+                      {
+                        "display": "block",
+                        "fill": "currentColor",
+                      }
+                    }
+                    viewBox="0 0 24 24"
+                    width={16}
+                  >
+                    <path
+                      d="M5.5 22v-7.5H4V9c0-1.1.9-2 2-2h3c1.1 0 2 .9 2 2v5.5H9.5V22h-4zM18 22v-6h3l-2.54-7.63C18.18 7.55 17.42 7 16.56 7h-.12c-.86 0-1.63.55-1.9 1.37L12 16h3v6h3zM7.5 6c1.11 0 2-.89 2-2s-.89-2-2-2-2 .89-2 2 .89 2 2 2zm9 0c1.11 0 2-.89 2-2s-.89-2-2-2-2 .89-2 2 .89 2 2 2z"
+                    />
+                  </svg>
+                </div>
+              </div>
+              <div
+                className="map-section map-section--left"
+              >
+                <div
+                  aria-label="galley"
+                  className="map-element map-element--amenity map-element--wrapped"
+                >
+                  <svg
+                    aria-label="galley"
+                    data-testid="galley"
+                    height={16}
+                    style={
+                      {
+                        "display": "block",
+                        "fill": "currentColor",
+                      }
+                    }
+                    viewBox="0 0 24 24"
+                    width={16}
+                  >
+                    <path
+                      d="M20 3H4v10c0 2.21 1.79 4 4 4h6c2.21 0 4-1.79 4-4v-3h2c1.11 0 2-.9 2-2V5c0-1.11-.89-2-2-2zm0 5h-2V5h2v3zM4 19h16v2H4z"
+                    />
+                  </svg>
+                </div>
+              </div>
+              <span
+                className="map-section__aisle"
+              />
+              <div
+                className="map-section"
+              >
+                <div
+                  aria-label="galley"
+                  className="map-element map-element--amenity map-element--wrapped"
+                >
+                  <svg
+                    aria-label="galley"
+                    data-testid="galley"
+                    height={16}
+                    style={
+                      {
+                        "display": "block",
+                        "fill": "currentColor",
+                      }
+                    }
+                    viewBox="0 0 24 24"
+                    width={16}
+                  >
+                    <path
+                      d="M20 3H4v10c0 2.21 1.79 4 4 4h6c2.21 0 4-1.79 4-4v-3h2c1.11 0 2-.9 2-2V5c0-1.11-.89-2-2-2zm0 5h-2V5h2v3zM4 19h16v2H4z"
+                    />
+                  </svg>
+                </div>
+              </div>
+              <span
+                className="map-section__aisle"
+              />
+              <div
+                className="map-section map-section--right"
+              >
+                <div
+                  aria-label="galley"
+                  className="map-element map-element--amenity map-element--wrapped"
+                >
+                  <svg
+                    aria-label="galley"
+                    data-testid="galley"
+                    height={16}
+                    style={
+                      {
+                        "display": "block",
+                        "fill": "currentColor",
+                      }
+                    }
+                    viewBox="0 0 24 24"
+                    width={16}
+                  >
+                    <path
+                      d="M20 3H4v10c0 2.21 1.79 4 4 4h6c2.21 0 4-1.79 4-4v-3h2c1.11 0 2-.9 2-2V5c0-1.11-.89-2-2-2zm0 5h-2V5h2v3zM4 19h16v2H4z"
+                    />
+                  </svg>
+                </div>
+              </div>
+            </div>
+          </div>
+        </div>
+        <div
+          style={
+            {
+              "padding": "16px 24px 24px",
+            }
+          }
+        >
+          <div
+            className="flex--space-between"
+          >
+            <div>
+              Price for 
+              0 seats
+            </div>
+            <div
+              className="h3--semibold"
+            >
+              + 
+              £0.00
+            </div>
+          </div>
+          <div
+            style={
+              {
+                "display": "grid",
+                "marginTop": "16px",
+              }
+            }
+          >
+            <button
+              className="button button--primary button--48"
+              data-testid="confirm-selection-for-seats"
+              onClick={[Function]}
+              type="button"
+            >
+              Confirm
+            </button>
+          </div>
+        </div>
+        <button
+          className="icon-button icon-button--primary modal--close-button"
+          onClick={[Function]}
+          title="Close modal"
+          type="button"
+        >
+          <svg
+            aria-label="close"
+            data-testid="close"
+            height={24}
+            style={
+              {
+                "display": "block",
+                "fill": "currentColor",
+              }
+            }
+            viewBox="0 0 24 24"
+            width={24}
+          >
+            <path
+              d="M18.3 5.71c-.39-.39-1.02-.39-1.41 0L12 10.59 7.11 5.7c-.39-.39-1.02-.39-1.41 0-.39.39-.39 1.02 0 1.41L10.59 12 5.7 16.89c-.39.39-.39 1.02 0 1.41.39.39 1.02.39 1.41 0L12 13.41l4.89 4.89c.39.39 1.02.39 1.41 0 .39-.39.39-1.02 0-1.41L13.41 12l4.89-4.89c.38-.38.38-1.02 0-1.4z"
+            />
+          </svg>
+        </button>
+      </div>
+    </div>
+    <button
+      className="ancillary-card"
+      disabled={true}
+      style={
+        {
+          "background": "transparent",
+          "border": "solid 1px rgba(226, 226, 232, 1)",
+          "borderRadius": "8px",
+          "boxSizing": "border-box",
+          "color": "var(--GREY-900)",
+          "cursor": "pointer",
+          "display": "flex",
+          "flexDirection": "column",
+          "flexWrap": "wrap",
+          "fontSize": "16px",
+          "fontWeight": "400",
+          "justifyContent": "space-between",
+          "letterSpacing": "0em",
+          "lineHeight": "24px",
+          "padding": "20px",
+          "rowGap": "4px",
+          "transition": "border-color 0.3s var(--TRANSITION-CUBIC-BEZIER) background-color 0.3s var(--TRANSITION-CUBIC-BEZIER)",
+          "width": "100%",
+        }
+      }
+      title="Add cancel for any reason"
+    >
+      <div
+        style={
+          {
+            "alignItems": "flex-start",
+            "columnGap": "12px",
+            "display": "flex",
+            "marginBlock": "0",
+            "marginTop": "2px",
+            "textAlign": "start",
+            "width": "100%",
+          }
+        }
+      >
+        <div>
+          <svg
+            aria-label="shield_with_moon"
+            data-testid="shield_with_moon"
+            height={24}
+            style={
+              {
+                "display": "block",
+                "fill": "currentColor",
+              }
+            }
+            viewBox="0 0 24 24"
+            width={24}
+          >
+            <path
+              d="M12.525 15.75C13.0814 15.75 13.6269 15.6408 14.1615 15.4222C14.6961 15.2036 15.166 14.8757 15.5711 14.4385C15.6749 14.3244 15.7032 14.2033 15.6557 14.0751C15.6083 13.9469 15.5077 13.8629 15.3538 13.8232C14.7269 13.6783 14.1477 13.4183 13.6163 13.0433C13.0849 12.6683 12.6474 12.1789 12.3038 11.5751C11.9769 11.0046 11.7682 10.393 11.6778 9.74048C11.5874 9.08791 11.6589 8.45458 11.8923 7.84048C11.9525 7.68663 11.9301 7.55586 11.8249 7.44817C11.7198 7.34049 11.5916 7.30332 11.4403 7.33665C10.4442 7.59177 9.65927 8.1142 9.08555 8.90395C8.51185 9.69368 8.225 10.5591 8.225 11.5001C8.225 12.6796 8.64519 13.6828 9.48558 14.5097C10.3259 15.3366 11.3391 15.75 12.525 15.75ZM12 21.4808C9.83716 20.8911 8.04646 19.618 6.62787 17.6616C5.20929 15.7052 4.5 13.518 4.5 11.1001V5.34625L12 2.53857L19.5 5.34625V11.1001C19.5 13.518 18.7907 15.7052 17.3721 17.6616C15.9535 19.618 14.1628 20.8911 12 21.4808ZM12 19.9001C13.7333 19.3501 15.1666 18.2501 16.3 16.6001C17.4333 14.9501 18 13.1167 18 11.1001V6.37507L12 4.1347L5.99997 6.37507V11.1001C5.99997 13.1167 6.56664 14.9501 7.69997 16.6001C8.83331 18.2501 10.2666 19.3501 12 19.9001Z"
+            />
+          </svg>
+        </div>
+        <div
+          style={
+            {
+              "alignItems": "start",
+              "display": "flex",
+              "justifyContent": "space-between",
+              "width": "100%",
+            }
+          }
+        >
+          <p
+            className="p1--semibold"
+            style={
+              {
+                "marginBlock": "0",
+              }
+            }
+          >
+            Cancel for any reason
+          </p>
+          <div
+            className="ancillary-card__children"
+          >
+            <div
+              style={
+                {
+                  "backgroundColor": "var(--GREY-200)",
+                  "borderRadius": "4px",
+                  "color": "var(--GREY-700)",
+                  "fontSize": "14px",
+                  "fontWeight": "600",
+                  "lineHeight": "20px",
+                  "padding": "2px 8px",
+                  "textAlign": "center",
+                  "whiteSpace": "nowrap",
+                }
+              }
+            >
+              Not available
+            </div>
+          </div>
+        </div>
+      </div>
+      <p
+        className="p1--regular"
+        style={
+          {
+            "color": "var(--GREY-600)",
+            "marginBlock": "0",
+            "marginLeft": "34px",
+            "textAlign": "start",
+          }
+        }
+      >
+        Protect your purchase if you decide to cancel
+      </p>
+    </button>
+    <div
+      className="modal"
+      style={
+        {
+          "opacity": 0,
+        }
+      }
+    >
+      <div
+        className="modal--content"
+        role="presentation"
+      >
+        <div
+          style={
+            {
+              "padding": "24px 24px 16px",
+            }
+          }
+        >
+          <h2
+            className="h3--semibold"
+            style={
+              {
+                "marginBlock": 0,
+              }
+            }
+          >
+            Cancel for any reason
+          </h2>
+        </div>
+        <button
+          className="icon-button icon-button--primary modal--close-button"
+          onClick={[Function]}
+          title="Close modal"
+          type="button"
+        >
+          <svg
+            aria-label="close"
+            data-testid="close"
+            height={24}
+            style={
+              {
+                "display": "block",
+                "fill": "currentColor",
+              }
+            }
+            viewBox="0 0 24 24"
+            width={24}
+          >
+            <path
+              d="M18.3 5.71c-.39-.39-1.02-.39-1.41 0L12 10.59 7.11 5.7c-.39-.39-1.02-.39-1.41 0-.39.39-.39 1.02 0 1.41L10.59 12 5.7 16.89c-.39.39-.39 1.02 0 1.41.39.39 1.02.39 1.41 0L12 13.41l4.89 4.89c.39.39 1.02.39 1.41 0 .39-.39.39-1.02 0-1.41L13.41 12l4.89-4.89c.38-.38.38-1.02 0-1.4z"
+            />
+          </svg>
+        </button>
+      </div>
+    </div>
+  </div>,
+]
+`;
+
 exports[`Storyshots DuffelAncillaries With Custom Styles 1`] = `
 [
   <link
@@ -40820,21 +47141,11 @@ exports[`Storyshots DuffelAncillaries With Custom Styles 1`] = `
           <div
             style={
               {
-                "columnGap": "12px",
                 "display": "grid",
-                "gridTemplateColumns": "repeat(2, 1fr)",
                 "marginTop": "16px",
               }
             }
           >
-            <button
-              className="button button--outlined button--48"
-              disabled={true}
-              onClick={[Function]}
-              type="button"
-            >
-              Back
-            </button>
             <button
               className="button button--primary button--48"
               data-testid="confirm-selection-for-baggage"

--- a/src/components/DuffelAncillaries/bags/BaggageSelectionModalFooter.tsx
+++ b/src/components/DuffelAncillaries/bags/BaggageSelectionModalFooter.tsx
@@ -38,6 +38,7 @@ export const BaggageSelectionModalFooter: React.FC<
     selectedServices
   );
   const totalAmountLabel = moneyStringFormatter(currency)(totalAmount);
+  const isOneWay = isFirstSegment && isFirstSegment;
 
   return (
     <div style={{ padding: "16px 24px 24px" }}>
@@ -51,21 +52,27 @@ export const BaggageSelectionModalFooter: React.FC<
       </div>
 
       <div
-        style={{
-          marginTop: "16px",
-          display: "grid",
-          columnGap: "12px",
-          gridTemplateColumns: "repeat(2, 1fr)",
-        }}
+        style={
+          isOneWay
+            ? { marginTop: "16px", display: "grid" }
+            : {
+                marginTop: "16px",
+                display: "grid",
+                columnGap: "12px",
+                gridTemplateColumns: "repeat(2, 1fr)",
+              }
+        }
       >
-        <Button
-          size={48}
-          variant="outlined"
-          disabled={isFirstSegment}
-          onClick={() => onPreviousSegmentButtonClicked()}
-        >
-          Back
-        </Button>
+        {!isOneWay && (
+          <Button
+            size={48}
+            variant="outlined"
+            disabled={isFirstSegment}
+            onClick={() => onPreviousSegmentButtonClicked()}
+          >
+            Back
+          </Button>
+        )}
         <Button
           size={48}
           data-testid="confirm-selection-for-baggage"

--- a/src/components/DuffelAncillaries/bags/BaggageSelectionModalHeader.tsx
+++ b/src/components/DuffelAncillaries/bags/BaggageSelectionModalHeader.tsx
@@ -18,21 +18,26 @@ export const BaggageSelectionModalHeader: React.FC<
   setCurrentSegmentIndex,
 }) => (
   <div style={{ padding: "24px 24px 16px" }}>
-    <div style={{ display: "flex", columnGap: "4px" }}>
-      {Array(segmentCount)
-        .fill(0)
-        .map((_, index) =>
-          index === currentSegmentIndex ? (
-            <ActiveSegment key={`segment_${index}`} />
-          ) : (
-            <InactiveSegment
-              key={`segment_${index}`}
-              onClick={() => setCurrentSegmentIndex(index)}
-            />
-          )
-        )}
-    </div>
-    <h2 className="h3--semibold" style={{ marginTop: "12px" }}>
+    {segmentCount > 1 && (
+      <div style={{ display: "flex", columnGap: "4px" }}>
+        {Array(segmentCount)
+          .fill(0)
+          .map((_, index) =>
+            index === currentSegmentIndex ? (
+              <ActiveSegment key={`segment_${index}`} />
+            ) : (
+              <InactiveSegment
+                key={`segment_${index}`}
+                onClick={() => setCurrentSegmentIndex(index)}
+              />
+            )
+          )}
+      </div>
+    )}
+    <h2
+      className="h3--semibold"
+      style={segmentCount > 1 ? { marginTop: "12px" } : {}}
+    >
       Flight to {currentSegment.destination.iata_code}
       <span
         className="p2--regular"

--- a/src/components/DuffelAncillaries/seats/SeatSelectionModalFooter.tsx
+++ b/src/components/DuffelAncillaries/seats/SeatSelectionModalFooter.tsx
@@ -42,6 +42,7 @@ export const SeatSelectionModalFooter: React.FC<
     seatMaps
   );
   const totalAmountLabel = moneyStringFormatter(currency)(totalAmount);
+  const isOneWay = isFirstSegment && isLastSegment;
 
   return (
     <div style={{ padding: "16px 24px 24px" }}>
@@ -51,21 +52,27 @@ export const SeatSelectionModalFooter: React.FC<
       </div>
 
       <div
-        style={{
-          marginTop: "16px",
-          display: "grid",
-          columnGap: "12px",
-          gridTemplateColumns: "repeat(2, 1fr)",
-        }}
+        style={
+          isOneWay
+            ? { marginTop: "16px", display: "grid" }
+            : {
+                marginTop: "16px",
+                display: "grid",
+                columnGap: "12px",
+                gridTemplateColumns: "repeat(2, 1fr)",
+              }
+        }
       >
-        <Button
-          size={48}
-          disabled={isFirstSegment}
-          variant="outlined"
-          onClick={() => onPreviousSegmentButtonClicked()}
-        >
-          Back
-        </Button>
+        {!isOneWay && (
+          <Button
+            size={48}
+            disabled={isFirstSegment}
+            variant="outlined"
+            onClick={() => onPreviousSegmentButtonClicked()}
+          >
+            Back
+          </Button>
+        )}
 
         <Button
           size={48}

--- a/src/components/DuffelAncillaries/seats/SeatSelectionModalHeader.tsx
+++ b/src/components/DuffelAncillaries/seats/SeatSelectionModalHeader.tsx
@@ -21,23 +21,32 @@ export const SeatSelectionModalHeader: React.FC<
   setCurrentSegmentAndPassengerPermutationsIndex,
 }) => (
   <div style={{ padding: "24px 24px 16px" }}>
-    <div style={{ display: "flex", columnGap: "4px" }}>
-      {Array(segmentAndPassengerPermutationsCount)
-        .fill(0)
-        .map((_, index) =>
-          index === currentSegmentAndPassengerPermutationsIndex ? (
-            <ActiveSegment key={`segment_${index}`} />
-          ) : (
-            <InactiveSegment
-              key={`segment_${index}`}
-              onClick={() =>
-                setCurrentSegmentAndPassengerPermutationsIndex(index)
-              }
-            />
-          )
-        )}
-    </div>
-    <h2 className="h3--semibold" style={{ marginBlock: "12px 0px" }}>
+    {segmentAndPassengerPermutationsCount > 1 && (
+      <div style={{ display: "flex", columnGap: "4px" }}>
+        {Array(segmentAndPassengerPermutationsCount)
+          .fill(0)
+          .map((_, index) =>
+            index === currentSegmentAndPassengerPermutationsIndex ? (
+              <ActiveSegment key={`segment_${index}`} />
+            ) : (
+              <InactiveSegment
+                key={`segment_${index}`}
+                onClick={() =>
+                  setCurrentSegmentAndPassengerPermutationsIndex(index)
+                }
+              />
+            )
+          )}
+      </div>
+    )}
+    <h2
+      className="h3--semibold"
+      style={
+        segmentAndPassengerPermutationsCount > 1
+          ? { marginBlock: "12px 0px" }
+          : {}
+      }
+    >
       Flight to {currentSegment.destination.iata_code}
       <span
         className="p2--regular"

--- a/src/stories/DuffelAncillaries.stories.tsx
+++ b/src/stories/DuffelAncillaries.stories.tsx
@@ -62,6 +62,28 @@ export const ExpiredOffer: DuffelAncillariesStory = {
   },
 };
 
+export const OneWayOnePassengerOffer: DuffelAncillariesStory = {
+  args: {
+    ...defaultProps,
+    offer: {
+      ...offer,
+      slices: [
+        {
+          ...offer.slices[0],
+          segments: [
+            {
+              ...offer.slices[0].segments[0],
+              passengers: [offer.slices[0].segments[0].passengers[0]],
+            },
+          ],
+        },
+      ],
+      passengers: [offer.passengers[0]],
+      available_services: [offer.available_services[0]],
+    },
+  },
+};
+
 export const WithCustomStyles: DuffelAncillariesStory = {
   args: {
     ...defaultProps,


### PR DESCRIPTION
There's no need to have the indicator dots and disabled buttons when we only have a one way flight (and one passenger for seats).

Check out the "One way one passenger story" for an interactive test.

Before:

<img width="673" alt="Screenshot 2023-07-13 at 15 02 10" src="https://github.com/duffelhq/duffel-components/assets/1416759/8a935ced-fbd9-4382-9283-23af4c5df209">
<img width="668" alt="Screenshot 2023-07-13 at 15 02 16" src="https://github.com/duffelhq/duffel-components/assets/1416759/1537a8fa-10d5-4129-9918-3abee35ecb0c">

After:

<img width="690" alt="Screenshot 2023-07-13 at 14 55 07" src="https://github.com/duffelhq/duffel-components/assets/1416759/b1b9d54c-4368-45ec-a795-7d6777e14e90">
<img width="695" alt="Screenshot 2023-07-13 at 14 55 14" src="https://github.com/duffelhq/duffel-components/assets/1416759/1ffd868e-4d76-4e08-84c5-2aca8f636552">