### PR TITLE
fix: handle white accent color

### DIFF
--- a/.storybook/__snapshots__/Storyshots.test.js.snap
+++ b/.storybook/__snapshots__/Storyshots.test.js.snap
@@ -223,6 +223,25 @@ exports[`Storyshots Button With Size 48 1`] = `
 </button>
 `;
 
+exports[`Storyshots Button With White Accent Color Set 1`] = `
+<div
+  style={
+    {
+      "--ACCENT": "255, 255, 255",
+      "--SECONDARY": "black",
+    }
+  }
+>
+  <button
+    className="button button--primary button--40"
+    onClick={[Function]}
+    type="button"
+  >
+    Click me
+  </button>
+</div>
+`;
+
 exports[`Storyshots DuffelAncillaries All Services 1`] = `
 [
   <link

--- a/src/components/DuffelAncillaries/DuffelAncillaries.tsx
+++ b/src/components/DuffelAncillaries/DuffelAncillaries.tsx
@@ -4,6 +4,7 @@ import { compileCreateOrderPayload } from "@lib/compileCreateOrderPayload";
 import { createPriceFormatters } from "@lib/createPriceFormatters";
 import { formatAvailableServices } from "@lib/formatAvailableServices";
 import { formatSeatMaps } from "@lib/formatSeatMaps";
+import { hasHighLuminance } from "@lib/hasHighLuminance";
 import { isPayloadComplete } from "@lib/isPayloadComplete";
 import { initializeLogger, logGroup } from "@lib/logging";
 import { offerIsExpired } from "@lib/offerIsExpired";
@@ -263,6 +264,10 @@ export const DuffelAncillaries: React.FC<DuffelAncillariesProps> = (props) => {
     ...(props.styles?.accentColor && {
       "--ACCENT": props.styles.accentColor,
     }),
+    ...(props.styles?.accentColor &&
+      hasHighLuminance(props.styles.accentColor) && {
+        "--SECONDARY": "black",
+      }),
     ...(props.styles?.fontFamily && {
       "--FONT-FAMILY": props.styles.fontFamily,
     }),

--- a/src/components/DuffelPayments/DuffelPayments.tsx
+++ b/src/components/DuffelPayments/DuffelPayments.tsx
@@ -1,4 +1,5 @@
 import { ErrorBoundary } from "@components/shared/ErrorBoundary";
+import { hasHighLuminance } from "@lib/hasHighLuminance";
 import { initializeLogger } from "@lib/logging";
 import {
   CardElement,
@@ -192,6 +193,10 @@ export const DuffelPayments: React.FC<DuffelPaymentsProps> = (props) => {
     ...(props.styles?.accentColor && {
       "--ACCENT": props.styles.accentColor,
     }),
+    ...(props.styles?.accentColor &&
+      hasHighLuminance(props.styles.accentColor) && {
+        "--SECONDARY": "black",
+      }),
     ...(props.styles?.fontFamily && {
       "--FONT-FAMILY": props.styles.fontFamily,
     }),

--- a/src/lib/hasHighLuminance.ts
+++ b/src/lib/hasHighLuminance.ts
@@ -1,0 +1,9 @@
+/*
+ * Use relative-luminance to determine whether the color is dark enough or not.
+ * See also: https://www.w3.org/WAI/GL/wiki/Relative_luminance
+ */
+export const hasHighLuminance = (accentColor: string) => {
+  const rgb = accentColor.split(", ").map((x) => parseInt(x));
+  const luminance = (0.2126 * rgb[0] + 0.7152 * rgb[1] + 0.0722 * rgb[2]) / 255;
+  return luminance > 0.5;
+};

--- a/src/stories/Button.stories.tsx
+++ b/src/stories/Button.stories.tsx
@@ -67,3 +67,24 @@ export const WithAccentColorSet: StoryFn<ButtonProps> = () => (
     <Button {...defaultProps} />
   </AccentColorWrapper>
 );
+
+const WhiteAccentColorWrapper: React.FC<{ children: React.ReactNode }> = ({
+  children,
+}) => (
+  <div
+    style={
+      {
+        "--ACCENT": "255, 255, 255",
+        "--SECONDARY": "black",
+      } as any
+    }
+  >
+    {children}
+  </div>
+);
+
+export const WithWhiteAccentColorSet: StoryFn<ButtonProps> = () => (
+  <WhiteAccentColorWrapper>
+    <Button {...defaultProps} />
+  </WhiteAccentColorWrapper>
+);

--- a/src/styles/components/Button.css
+++ b/src/styles/components/Button.css
@@ -62,7 +62,7 @@ button:-moz-focusring,
 }
 
 .button {
-  --button-color: white;
+  --button-color: var(--SECONDARY, white);
 
   box-sizing: border-box;
   border-radius: var(--BUTTON-RADIUS, 6px);
@@ -80,6 +80,8 @@ button:-moz-focusring,
   box-shadow: 0px 0px 0px rgba(0, 0, 0, 0.25), 0px 0px 0px #e9e9eb;
 
   border: 1px solid rgba(var(--ACCENT), var(--ACCENT-LIGHT-1000));
+  /* Will give the button an outline if the accent color has high luminance */
+  border: 1px solid var(--SECONDARY);
   transition: background-color 0.3s var(--TRANSITION-CUBIC-BEZIER),
     box-shadow 0.3s var(--TRANSITION-CUBIC-BEZIER),
     color 0.3s var(--TRANSITION-CUBIC-BEZIER);
@@ -128,13 +130,19 @@ button:-moz-focusring,
 
 .button--primary:not(:disabled):hover {
   background-color: rgba(var(--ACCENT), var(--ACCENT-LIGHT-800));
-  border-color: rgba(var(--ACCENT), var(--ACCENT-LIGHT-800));
+  border-color: (
+    var(--SECONDARY),
+    rgba(var(--ACCENT), var(--ACCENT-LIGHT-800))
+  );
   box-shadow: 0px 2px 4px 1px rgba(0, 0, 0, 0.15), 0px 0px 0px 2px #e9e9eb;
 }
 
 .button--primary:not(:disabled):active {
   background-color: rgba(var(--ACCENT), var(--ACCENT-LIGHT-1000));
-  border-color: rgba(var(--ACCENT), var(--ACCENT-LIGHT-1000));
+  border-color: (
+    var(--SECONDARY),
+    rgba(var(--ACCENT), var(--ACCENT-LIGHT-1000))
+  );
   box-shadow: 0px 1px 2px 1px rgba(0, 0, 0, 0.25), 0px 0px 0px 1px #dcdcde;
 }
 


### PR DESCRIPTION
This adds a secondary colour and outline for buttons if the accent color is too bright using the luminance function as in Links.

White accent color story:
<img width="515" alt="Screenshot 2023-09-13 at 10 17 21"
 src="https://github.com/duffelhq/duffel-components/assets/1416759/88690843-6564-4213-9479-768c5c017ce3">
Regular accent color:
<img width="522" alt="Screenshot 2023-09-13 at 10 17 25" src="https://github.com/duffelhq/duffel-components/assets/1416759/0bfd593b-439a-405b-b969-744fd1a733fb">