### PR TITLE
fix: display proper warning message if no cabins present

### DIFF
--- a/src/components/DuffelAncillaries/seats/SeatMap.tsx
+++ b/src/components/DuffelAncillaries/seats/SeatMap.tsx
@@ -29,7 +29,7 @@ export const SeatMap: React.FC<SeatMapProps> = ({
 }) => {
   const [selectedDeck, setSelectedDeck] = React.useState(0);
 
-  if (!seatMap) {
+  if (!seatMap || !seatMap.cabins || !seatMap.cabins.length) {
     return <SeatMapUnavailable />;
   }
 


### PR DESCRIPTION
Display seatmaps as unavailable if no cabins are present, rather than erroring in the code later.

https://duffel.atlassian.net/browse/FR-4421