### PR TITLE
Allow to use any nodejs version starting from 18

### DIFF
--- a/package.json
+++ b/package.json
@@ -129,7 +129,7 @@
     "typescript": "5.0.4"
   },
   "engines": {
-    "node": "~18.*"
+    "node": ">=18.*"
   },
   "config": {
     "commitizen": {


### PR DESCRIPTION
As on October 24 2023 Node.js 20.x was transitioned into Long Term Support (LTS), any project that will update to this version won't be able to use this package.

I believe that everything should work fine with Node.js 20.x too.