### PR TITLE
Adds offer slice card to our component library 

### DIFF
--- a/src/components/DuffelOfferSlice/DuffelOfferSlice.tsx
+++ b/src/components/DuffelOfferSlice/DuffelOfferSlice.tsx
@@ -1,0 +1,65 @@
+import { OfferSlice } from "src/types";
+import OfferSliceCondition from "./OfferSliceCondition";
+import { getItineraryItems } from "./lib/getItineraryItems";
+
+// TODO(idp): need to make the type for PartialOfferSlice
+// and make it clear what's the distinction between them
+type PartialOfferSlice = OfferSlice;
+
+interface DuffelOfferSliceProps {
+  /**
+   * The slice you'd like to display
+   */
+  slice: OfferSlice | PartialOfferSlice;
+
+  /**
+   * Set this value to true to disable the click interaction
+   */
+  isAlwaysExtendedView: boolean;
+}
+
+export const DuffelOfferSlice: React.FC<DuffelOfferSliceProps> = ({
+  slice,
+  isAlwaysExtendedView,
+}) => {
+  return (
+    <div className="slice-summary" data-selector="fs-show">
+      <OfferSliceSummary
+        slice={slice}
+        showFullDate={showFullDate}
+        showFlightNumbers={!isExpanded}
+        hideFareBrand={hideFareBrand}
+      />
+
+      {/* TODO(idp): 
+    don't have vspace in this code base yet. how do we want to handle this?
+    maybe we can introduce a small set of utility classes for spacing?
+    */}
+      <VSpace space={32}>
+        {sliceDetails.map((item, index) => (
+          <TravelItineraryItem item={item} key={index} />
+        ))}
+      </VSpace>
+
+      {isExpanded &&
+        !hideConditions &&
+        slice.conditions?.changeBeforeDeparture?.allowed && (
+          <div className="slice-summary__condition">
+            <OfferSliceCondition
+              type="changeBeforeDeparture"
+              condition={slice.conditions.changeBeforeDeparture}
+            />
+          </div>
+        )}
+
+      {/* TODO(idp): remove JSX */}
+      <style jsx>{`
+        .slice-summary__condition {
+          margin-top: 24px;
+          margin-left: 64px;
+          max-width: 500px;
+        }
+      `}</style>
+    </div>
+  );
+};

--- a/src/components/DuffelOfferSlice/OfferSliceCondition.tsx
+++ b/src/components/DuffelOfferSlice/OfferSliceCondition.tsx
@@ -1,0 +1,15 @@
+import React from 'react';
+
+type Props = {
+    // Define props here
+};
+
+const OfferSliceCondition: React.FC<Props> = ({ /* Destructure props here */ }) => {
+    // Component logic here
+
+    return (
+        // JSX here
+    );
+};
+
+export default OfferSliceCondition;

--- a/src/components/DuffelOfferSlice/OfferSliceSummary.tsx
+++ b/src/components/DuffelOfferSlice/OfferSliceSummary.tsx
@@ -1,0 +1,157 @@
+import { OfferSlice } from "src/types";
+import { getItineraryItems } from "./lib/getItineraryItems";
+import { convertDurationToString } from "@lib/convertDurationToString";
+
+export interface OfferSliceSummaryProps {
+  slice: OfferSlice;
+  showFullDate?: boolean;
+  showFlightNumbers?: boolean;
+  hideFareBrand?: boolean;
+  highlightAll?: boolean;
+  keysToHighlight?: string[];
+
+  //   TODO(idp): need to get this from somewhere, tbd. Also how are we enabling customisation
+  highlightColor?: ColorWithoutWeight;
+}
+
+export const OfferSliceSummary: React.FC<OfferSliceSummaryProps> = ({
+  slice,
+  showFullDate = false,
+  showFlightNumbers,
+  hideFareBrand = false,
+  highlightAll = false,
+  keysToHighlight,
+  highlightColor,
+}) => {
+  const { segments } = slice;
+  const firstSegment = segments[0];
+  const sliceDetails = getItineraryItems(slice);
+  const lastSegment = segments[segments.length - 1];
+  const departingAt = sliceDetails[0].travelDetails?.departingAt;
+  const arrivingAt =
+    sliceDetails[sliceDetails.length - 1].travelDetails?.arrivingAt;
+  // We need to strip out the time as getDayDiff rounds the time difference up, but here we
+  // only care whether the day is the same or not
+  const dayDiff =
+    departingAt && arrivingAt
+      ? getDayDiff(arrivingAt.split("T")[0], departingAt.split("T")[0])
+      : 0;
+  const duration =
+    slice.duration &&
+    typeof slice.duration === "string" &&
+    slice.duration.match(iso8601DurationRegex) &&
+    arrivingAt &&
+    departingAt
+      ? convertDurationToString(String(slice.duration))
+      : null;
+
+  const highlightStyles = (key?: string) =>
+    getHighlightStyles(
+      styles,
+      highlightAll,
+      key,
+      keysToHighlight,
+      highlightColor
+    );
+
+  const numberOfStops = sliceDetails.filter(
+    (item) => item.type === "layover"
+  ).length;
+
+  const layoverItems = (sliceDetails.filter(
+    (item) => item.type === "layover"
+    // using type assertion here because typescript cannot infer that item.type of 'layover' is SliceLayoverItem
+  ) || []) as SliceLayoverItem[];
+
+  return (
+    <div className={styles["slice-summary-info"]}>
+      <div className={styles["slice-summary-info__airline-logo-wrapper"]}>
+        <AirlineLogo
+          name={firstSegment.marketingCarrier.name}
+          iataCode={firstSegment.marketingCarrier.iataCode}
+          size={40}
+        />
+      </div>
+      <div>
+        <VSpace space={8} className={styles["slice-summary-info__column"]}>
+          <div>
+            {showFullDate && departingAt && (
+              <span className={styles["slice-summary-info__date-label"]}>
+                {getDateString(departingAt, "long")}
+              </span>
+            )}
+
+            {departingAt && arrivingAt && (
+              <span className="u-skeletonable" {...highlightStyles()}>
+                <span {...highlightStyles("departingAt")}>
+                  {getTimeString(departingAt)}
+                </span>
+                {" - "}
+                <span {...highlightStyles("dayDiff")}>
+                  <span {...highlightStyles("arrivingAt")}>
+                    {getTimeString(arrivingAt)}
+                  </span>
+                  {dayDiff > 0 && (
+                    <sup
+                      className={
+                        keysToHighlight?.includes("arrivingAt") &&
+                        !keysToHighlight?.includes("dayDiff")
+                          ? styles["slice-summary-info__sup--pad"]
+                          : undefined
+                      }
+                    >
+                      +{dayDiff}
+                    </sup>
+                  )}
+                </span>
+              </span>
+            )}
+          </div>
+          <div>
+            <span
+              className="u-skeletonable u-skeletonable--small"
+              {...highlightStyles("airlinesText")}
+            >
+              {getAirlinesText(slice, showFlightNumbers, !hideFareBrand)}
+            </span>
+          </div>
+        </VSpace>
+        <VSpace space={8} className={styles["slice-summary-info__column"]}>
+          {duration && (
+            <div>
+              <span className="u-skeletonable" {...highlightStyles("duration")}>
+                {duration}
+              </span>
+            </div>
+          )}
+          <div>
+            <span
+              className="u-skeletonable u-skeletonable--small"
+              {...highlightStyles()}
+            >
+              {firstSegment.origin.iataCode} -{" "}
+              {lastSegment.destination.iataCode}
+            </span>
+          </div>
+        </VSpace>
+        <VSpace space={8} className={styles["slice-summary-info__column"]}>
+          <div>
+            <span className="u-skeletonable" {...highlightStyles("stops")}>
+              {numberOfStops === 0
+                ? "Non-stop"
+                : `${numberOfStops} stop${numberOfStops > 1 ? "s" : ""}`}
+            </span>
+          </div>
+          <div>
+            <div />
+            {layoverItems.map(({ layoverDetails }, index) => (
+              <div className="u-skeletonable" key={index}>
+                {layoverDetails.duration} {layoverDetails.airport.iataCode}
+              </div>
+            ))}
+          </div>
+        </VSpace>
+      </div>
+    </div>
+  );
+};

--- a/src/components/DuffelOfferSlice/lib/getFareBrandName.ts
+++ b/src/components/DuffelOfferSlice/lib/getFareBrandName.ts
@@ -1,0 +1,12 @@
+import { CabinClassMap, OfferSliceSegment } from "src/types";
+
+export const getFareBrandName = (
+  fareBrandName: string | null,
+  forSegment: OfferSliceSegment
+) =>
+  fareBrandName ||
+  (forSegment.passengers &&
+    forSegment.passengers.length > 0 &&
+    (forSegment.passengers[0]?.cabin_class_marketing_name ||
+      CabinClassMap[forSegment.passengers[0].cabin_class])) ||
+  "";

--- a/src/components/DuffelOfferSlice/lib/getItineraryItems.ts
+++ b/src/components/DuffelOfferSlice/lib/getItineraryItems.ts
@@ -1,0 +1,248 @@
+import {
+  Airline,
+  Airport,
+  OfferSlice,
+  OfferSliceSegment,
+  OfferSliceSegmentStop,
+} from "src/types";
+import { convertDurationToString } from "@lib/convertDurationToString";
+import { getDurationString } from "@lib/getDurationString";
+import { getFareBrandName } from "./getFareBrandName";
+import { getLayoverOriginDestinationKey } from "./getLayoverOriginDestinationKey";
+import { getSegmentDates } from "./getSegmentDates";
+import { getSegmentFlightNumber } from "./getSegmentFlightNumber";
+import { isISO8601Duration } from "@lib/isISO8601Duration";
+
+interface TravelDetails<T extends "order" | "offer" | "diff"> {
+  originDestination: string;
+  departingAt: string;
+  origin: T extends "diff" ? string : Airport;
+
+  arrivingAt: string;
+  destination: T extends "diff" ? string : Airport;
+
+  aircraft: string | null;
+  cabinClass: string;
+
+  fareBrandName?: T extends "offer" ? string : never;
+  flightDuration: string | null;
+
+  flight: string;
+
+  // For the diff view of an order, we use the `operatingCarrier` and `marketingCarrier` properties directly
+  airline: T extends "diff" ? null : Airline;
+  operatedBy?: string;
+
+  baggagesIncluded?: {
+    carryOn?: number;
+    checked?: number;
+  };
+
+  originTerminal?: string | null;
+  destinationTerminal?: string | null;
+}
+
+interface LayoverDetails {
+  airport: Airport;
+  duration: string;
+  originDestinationKey?: string;
+}
+
+interface ItineraryTravelItem {
+  type: "travel";
+  id: string;
+  layoverDetails: undefined;
+  travelDetails: TravelDetails<"order" | "offer">;
+}
+
+interface ItineraryLayoverItem {
+  type: "layover";
+  travelDetails: undefined;
+  layoverDetails: LayoverDetails;
+}
+
+export type ItineraryItemUnion = ItineraryTravelItem | ItineraryLayoverItem;
+export type ItineraryItems = Array<ItineraryItemUnion>;
+
+export function getItineraryItems(slice: OfferSlice): ItineraryItems {
+  const numberOfSegments = slice.segments.length;
+  const sliceDetailsStack: ItineraryItems = [];
+
+  for (let index = 0; index < numberOfSegments; index++) {
+    const currentSegment = slice.segments[index];
+    const lastOnStack = sliceDetailsStack[sliceDetailsStack.length - 1] || {};
+    const fareBrandName =
+      "fare_brand_name" in slice ? slice.fare_brand_name : null;
+    const travelDetails = getTravelItem(currentSegment, fareBrandName);
+
+    const { departingAt } = getSegmentDates(currentSegment);
+    if (lastOnStack.type === "travel") {
+      if (numberOfSegments === 1) break;
+
+      const duration = getDurationString(
+        lastOnStack.travelDetails!.arrivingAt,
+        departingAt!
+      );
+
+      sliceDetailsStack.push({
+        type: "layover",
+        travelDetails: undefined,
+        layoverDetails: {
+          airport: lastOnStack.travelDetails!.destination,
+          duration,
+          originDestinationKey: getLayoverOriginDestinationKey(
+            lastOnStack.travelDetails?.origin.iata_code,
+            lastOnStack.travelDetails?.destination.iata_code,
+            currentSegment.destination?.iata_code
+          ),
+        },
+      });
+    }
+
+    // We have to do this in a type-unsafe way for now because this union of offer and order segment
+    // is not collapsible due to the lack of a discriminant field
+    if (currentSegment.stops) {
+      const stops: OfferSliceSegment["stops"] = currentSegment.stops;
+      if (stops.length === 0) {
+        sliceDetailsStack.push({
+          type: "travel",
+          id: currentSegment.id || "",
+          travelDetails: travelDetails,
+          layoverDetails: undefined,
+        });
+      } else {
+        sliceDetailsStack.push(
+          ...splitTravelDetailsWithStops(
+            travelDetails,
+            stops,
+            currentSegment.id
+          )
+        );
+      }
+    } else {
+      sliceDetailsStack.push({
+        type: "travel",
+        id: currentSegment.id || "",
+        travelDetails: travelDetails,
+        layoverDetails: undefined,
+      });
+    }
+  }
+
+  return sliceDetailsStack;
+}
+
+const getTravelItem = (
+  fromSegment: OfferSliceSegment,
+  fareBrandName: string | null
+): TravelDetails<"order" | "offer"> => {
+  const { origin, destination } = fromSegment;
+  const { arrivingAt, departingAt } = getSegmentDates(fromSegment);
+
+  return {
+    originDestination: `${origin.iata_code}-${destination.iata_code}`,
+    arrivingAt: arrivingAt!,
+    departingAt: departingAt!,
+    origin,
+    destination,
+    fareBrandName: getFareBrandName(fareBrandName, fromSegment),
+    cabinClass:
+      fromSegment.passengers?.length > 0
+        ? fromSegment.passengers[0].cabin_class_marketing_name ||
+          fromSegment.passengers[0].cabin_class
+        : "",
+    flight: getSegmentFlightNumber(fromSegment),
+    aircraft: fromSegment.aircraft && fromSegment.aircraft.name,
+    flightDuration:
+      fromSegment.duration &&
+      typeof fromSegment.duration === "string" &&
+      isISO8601Duration(fromSegment.duration)
+        ? convertDurationToString(fromSegment.duration)
+        : null,
+
+    airline: fromSegment.marketing_carrier,
+    operatedBy: fromSegment.operating_carrier
+      ? fromSegment.operating_carrier.name
+      : undefined,
+    baggagesIncluded: {
+      // NOTE: need to make passengers optional because order request change offer slice
+      // shares the same type as offer's slice when it shouldn't
+      carryOn: fromSegment.passengers?.[0].baggages?.find(
+        (baggage) => baggage.type === "carry_on"
+      )?.quantity,
+      checked: fromSegment.passengers?.[0].baggages?.find(
+        (baggage) => baggage.type === "checked"
+      )?.quantity,
+    },
+    originTerminal: fromSegment.origin_terminal,
+    destinationTerminal: fromSegment.destination_terminal,
+  };
+};
+
+const splitTravelDetailsWithStops = (
+  travelDetails: TravelDetails<"offer">,
+  stops: OfferSliceSegmentStop[],
+  segmentId: string
+): ItineraryItems => {
+  const items: ItineraryItems = [];
+  // split the travel details by the number of stops
+  let nextOrigin = travelDetails.origin;
+  let nextDepartingAt = travelDetails.departingAt;
+  stops.forEach((stop, index) => {
+    // add a travel item from the origin to this stop
+    items.push({
+      type: "travel",
+      id: segmentId,
+      layoverDetails: undefined,
+      travelDetails: {
+        ...travelDetails,
+        originDestination: `${nextOrigin.iata_code}-${stop.airport.iata_code}`,
+        departingAt: nextDepartingAt,
+        arrivingAt: stop.arriving_at,
+        origin: nextOrigin,
+        destination: stop.airport,
+        flightDuration: getDurationString(nextDepartingAt, stop.arriving_at),
+      },
+    });
+    // show a stop as a layover item
+    items.push({
+      type: "layover",
+      travelDetails: undefined,
+      layoverDetails: {
+        airport: stop.airport,
+        duration: convertDurationToString(stop.duration),
+        originDestinationKey: getLayoverOriginDestinationKey(
+          nextOrigin.iata_code,
+          stop.airport.iata_code,
+          travelDetails.destination.iata_code
+        ),
+      },
+    });
+    // the stop becomes the next origin
+    nextOrigin = stop.airport;
+    nextDepartingAt = stop.departing_at;
+
+    // if it's the last stop, add a travel item from the last stop to the segment's destination
+    if (index === stops.length - 1) {
+      items.push({
+        type: "travel",
+        id: segmentId,
+        layoverDetails: undefined,
+        travelDetails: {
+          ...travelDetails,
+          originDestination: `${stop.airport.iata_code}-${travelDetails.destination.iata_code}`,
+          departingAt: stop.departing_at,
+          arrivingAt: travelDetails.arrivingAt,
+          origin: stop.airport,
+          destination: travelDetails.destination,
+          flightDuration: getDurationString(
+            stop.departing_at,
+            travelDetails.arrivingAt
+          ),
+        },
+      });
+    }
+  });
+
+  return items;
+};

--- a/src/components/DuffelOfferSlice/lib/getLayoverOriginDestinationKey.ts
+++ b/src/components/DuffelOfferSlice/lib/getLayoverOriginDestinationKey.ts
@@ -1,0 +1,5 @@
+export const getLayoverOriginDestinationKey = (
+  from?: string | null,
+  at?: string | null,
+  to?: string | null
+) => from + "-" + at + "-" + to;

--- a/src/components/DuffelOfferSlice/lib/getSegmentDates.ts
+++ b/src/components/DuffelOfferSlice/lib/getSegmentDates.ts
@@ -1,0 +1,10 @@
+import { OfferSliceSegment } from "src/types";
+
+// TODO(idp): for this to work for both dashboard and links we need to include the duffel order types
+
+export const getSegmentDates = (segment: OfferSliceSegment) => {
+  // TODO: remove the fallback once AIC returns arrivingAt and departingAt for AICs as well
+  const arrivingAt = segment.arriving_at ?? segment["arrivalDatetime"];
+  const departingAt = segment.departing_at ?? segment["departureDatetime"];
+  return { arrivingAt, departingAt };
+};

--- a/src/components/DuffelOfferSlice/lib/getSegmentFlightNumber.ts
+++ b/src/components/DuffelOfferSlice/lib/getSegmentFlightNumber.ts
@@ -1,0 +1,4 @@
+import { OfferSliceSegment } from "src/types";
+
+export const getSegmentFlightNumber = (segment: OfferSliceSegment) =>
+  `${segment.marketing_carrier.iata_code}${segment.marketing_carrier_flight_number}`;

--- a/src/lib/convertDurationToString.ts
+++ b/src/lib/convertDurationToString.ts
@@ -1,0 +1,18 @@
+import { isISO8601Duration } from "./isISO8601Duration";
+
+export function convertDurationToString(duration: string): string {
+  const matches = isISO8601Duration(duration);
+  if (!matches) return duration;
+
+  const daysString = matches[1] && matches[1] !== "0" ? `${matches[1]}d` : "";
+  const hoursString =
+    matches[2] && matches[2] !== "0"
+      ? `${matches[2].toString().padStart(2, "0")}h`
+      : "";
+  const minutesString =
+    matches[3] && matches[3] !== "0"
+      ? `${matches[3].toString().padStart(2, "0")}m`
+      : "";
+
+  return `${daysString} ${hoursString} ${minutesString}`.trim();
+}

--- a/src/lib/getDurationString.ts
+++ b/src/lib/getDurationString.ts
@@ -1,0 +1,69 @@
+const MS = 1000;
+const MS_PER_MINUTE = MS * 60;
+const MS_PER_HOUR = MS_PER_MINUTE * 60;
+const MS_PER_DAY = MS_PER_HOUR * 24;
+
+export function getDurationString(
+  start: Date | string,
+  end: Date | string,
+  format?: "long"
+): string {
+  let startDate: Date = typeof start === "string" ? new Date(start) : start;
+  let prefix = "";
+
+  let endDate = new Date();
+  if (end) {
+    if (typeof end === "string") {
+      endDate = new Date(end);
+    } else {
+      endDate = end;
+    }
+  }
+
+  // If the end date is before the start date, this usually indicates an error
+  // But we still want to make sure we show that to the user nicely
+  if (endDate < startDate) {
+    const temp = startDate;
+    startDate = endDate;
+    endDate = temp;
+    prefix = "-";
+  }
+
+  const diff = endDate.valueOf() - startDate.valueOf();
+
+  const days = Math.floor(diff / MS_PER_DAY);
+  const hours = Math.floor((diff - days * MS_PER_DAY) / MS_PER_HOUR);
+  const minutes = Math.floor(
+    (diff - days * MS_PER_DAY - hours * MS_PER_HOUR) / MS_PER_MINUTE
+  );
+
+  let daysString = "";
+  let hoursString = "";
+  let minutesString = "";
+
+  let suffix = "";
+
+  if (format !== "long") {
+    daysString = days ? `${days}d` : "";
+    hoursString = hours ? `${hours.toString().padStart(2, "0")}h` : "";
+    minutesString = minutes ? `${minutes.toString().padStart(2, "0")}m` : "";
+  } else {
+    if (days >= 1) {
+      daysString = `${days}d`;
+    }
+
+    if (hours >= 1) {
+      hoursString = `${hours.toString()}h`;
+    }
+
+    if (minutes >= 1) {
+      minutesString = `${minutes.toString()}m`;
+    }
+
+    suffix = end < start ? "earlier" : "later";
+  }
+
+  return format !== "long"
+    ? prefix + `${daysString} ${hoursString} ${minutesString}`.trim()
+    : `${daysString} ${hoursString} ${minutesString} ${suffix}`.trim();
+}

--- a/src/lib/isISO8601Duration.ts
+++ b/src/lib/isISO8601Duration.ts
@@ -1,0 +1,6 @@
+export const iso8601DurationRegex =
+  /P(?:([.,\d]+)D)?T(?:([.,\d]+)H)?(?:([.,\d]+)M)?/i;
+
+export const isISO8601Duration = (durationString: string) => {
+  return durationString.match(iso8601DurationRegex);
+};

--- a/src/stories/DuffelOfferSlice.stories.tsx
+++ b/src/stories/DuffelOfferSlice.stories.tsx
@@ -1,0 +1,24 @@
+import type { Meta, StoryObj } from "@storybook/react";
+import {
+  DuffelOfferSlice,
+  DuffelOfferSliceProps,
+} from "../components/DuffelOfferSlice";
+import MOCK_OFFER from "../fixtures/offers/off_0000AUde3KwTztSRK1cznH.json";
+
+export default {
+  title: "DuffelOfferSlice",
+  component: DuffelOfferSlice,
+} as Meta;
+
+type DuffelOfferSliceStory = StoryObj<typeof DuffelOfferSlice>;
+
+const defaultProps: DuffelOfferSliceProps = {
+  slice: MOCK_OFFER.slices[0],
+  isExpanded: true,
+};
+
+export const Default: DuffelOfferSliceStory = { args: defaultProps };
+
+export const WithExpandedView: DuffelOfferSliceStory = {
+  args: { ...defaultProps, variant: "outlined" },
+};

--- a/src/types/Offer.ts
+++ b/src/types/Offer.ts
@@ -623,7 +623,7 @@ export interface OfferSliceSegment {
   /**
    * Additional segment-specific information about the stops, if any, included in the segment
    */
-  stops: OfferSliceSegmentStop[];
+  stops?: OfferSliceSegmentStop[];
 }
 
 export interface OfferConditionModificationAllowed {


### PR DESCRIPTION
WIP ... more info coming soon. 

already quite a lot here, going to break this up:

- [x]  We'll need to add missing types for Order and partial offer. Ideally we could just import from duffel api but some are exposed, some not, some are wrapped with a class, and the module structure is inconsistent. Don't want to interrupt this work to address that right now but we need a better solution for exposing API types (and maybe even generating them) 
- [x]  We’ll need a few helpers to make the component work. Will include the basic ones first
- [x]  We need a helper to get the travel items for the slice view. The travel items are what’s renedered by the component fom top to bottom
- [ ]  We need some supporting components for layout. A more lightweight version of that would be to use the utility classes we have on dashboard. Will port basic ones to fill the gaps for things like vspace.
- [ ]  Move the necessary components from dashboard to duffel components. Should have a working version at that point. that works on the dashboard
- [ ]  Make design changes to component to make it look like the one in Links. If there’s features that are not covered by the Links design, work with product design to cover the gap