### PR TITLE
test: add tests for recently added date functions from the dashboard

### DIFF
--- a/src/tests/lib/convertDurationToString.test.tsx
+++ b/src/tests/lib/convertDurationToString.test.tsx
@@ -1,0 +1,11 @@
+import { convertDurationToString } from "../../lib/convertDurationToString";
+describe("convertDurationToString", () => {
+  test("returns the duration in the correct display format", () => {
+    expect(convertDurationToString("PT16H30M")).toBe("16h 30m");
+    expect(convertDurationToString("PT09H")).toBe("09h");
+    expect(convertDurationToString("PT10M")).toBe("10m");
+    expect(convertDurationToString("P2DT16H30M")).toBe("2d 16h 30m");
+    expect(convertDurationToString("p2Dt16H30m")).toBe("2d 16h 30m");
+    expect(convertDurationToString("P0DT16H30M")).toBe("16h 30m");
+  });
+});

--- a/src/tests/lib/getDurationString.test.tsx
+++ b/src/tests/lib/getDurationString.test.tsx
@@ -1,0 +1,20 @@
+import { getDurationString } from "../../lib/getDurationString";
+describe("getDurationString", () => {
+  test("returns the duration in the correct format", () => {
+    expect(getDurationString("2020/10/13 10:40", "2020/10/13 19:50")).toBe(
+      "09h 10m"
+    );
+    expect(getDurationString("2020/10/13 10:40", "2020/10/13 19:40")).toBe(
+      "09h"
+    );
+    expect(getDurationString("2020/10/13 10:40", "2020/10/13 10:50")).toBe(
+      "10m"
+    );
+    expect(getDurationString("2020/10/13 10:40", "2020/10/15 19:50")).toBe(
+      "2d 09h 10m"
+    );
+    expect(getDurationString("2022/12/13 18:35", "2022/12/13 14:10")).toBe(
+      "-04h 25m"
+    );
+  });
+});


### PR DESCRIPTION
As per this thread: https://duffel.slack.com/archives/C013XQ3T2J1/p1700039584322359?thread_ts=1700004885.432129&cid=C013XQ3T2J1
We copied in these functions recently from the dashboard code, it makes sense to copy over the tests too.