### PR TITLE
Itinerary helper

### DIFF
--- a/package.json
+++ b/package.json
@@ -69,7 +69,7 @@
     "@babel/preset-env": "7.21.4",
     "@babel/preset-react": "7.18.6",
     "@babel/preset-typescript": "7.21.4",
-    "@duffel/api": "2.5.11",
+    "@duffel/api": "2.5.12",
     "@sentry/cli": "2.21.2",
     "@sentry/esbuild-plugin": "0.7.0",
     "@storybook/addon-essentials": "7.0.2",

--- a/src/components/DuffelAncillaries/DuffelAncillaries.tsx
+++ b/src/components/DuffelAncillaries/DuffelAncillaries.tsx
@@ -26,10 +26,12 @@ import {
 import { BaggageSelectionCard } from "./bags/BaggageSelectionCard";
 import { CfarSelectionCard } from "./cancel_for_any_reason/CfarSelectionCard";
 import { SeatSelectionCard } from "./seats/SeatSelectionCard";
-import { CreateOrder, Offer, OrderService, SeatMap } from "@duffel/api/types";
-
-// TODO(idp): remove this when we merge https://github.com/duffelhq/duffel-api-javascript/pull/843
-type CreateOrderService = Pick<OrderService, "id" | "quantity">;
+import {
+  CreateOrder,
+  CreateOrderService,
+  Offer,
+  SeatMap,
+} from "@duffel/api/types";
 
 const COMPONENT_CDN = process.env.COMPONENT_CDN || "";
 const hrefToComponentStyles = `${COMPONENT_CDN}/global.css`;

--- a/src/components/DuffelAncillaries/bags/BaggageSelectionCard.tsx
+++ b/src/components/DuffelAncillaries/bags/BaggageSelectionCard.tsx
@@ -9,11 +9,8 @@ import { withPlural } from "@lib/withPlural";
 import React from "react";
 import { Card } from "../Card";
 import { BaggageSelectionModal } from "./BaggageSelectionModal";
-import { CreateOrder, Offer, OrderService } from "@duffel/api/types";
+import { CreateOrder, CreateOrderService, Offer } from "@duffel/api/types";
 import { WithServiceInformation } from "src/types";
-
-// TODO(idp): remove this when we merge https://github.com/duffelhq/duffel-api-javascript/pull/843
-type CreateOrderService = Pick<OrderService, "id" | "quantity">;
 
 export interface BaggageSelectionCardProps {
   isLoading: boolean;

--- a/src/components/DuffelAncillaries/bags/BaggageSelectionController.tsx
+++ b/src/components/DuffelAncillaries/bags/BaggageSelectionController.tsx
@@ -1,13 +1,13 @@
-import { OfferAvailableServiceBaggage, OrderService } from "@duffel/api/types";
+import {
+  CreateOrderService,
+  OfferAvailableServiceBaggage,
+} from "@duffel/api/types";
 import { getBaggageServiceDescription } from "@lib/getBaggageServiceDescription";
 import { hasServiceOfSameMetadataTypeAlreadyBeenSelected } from "@lib/hasServiceOfSameMetadataTypeAlreadyBeenSelected";
 import { moneyStringFormatter } from "@lib/moneyStringFormatter";
 import React from "react";
 import { WithServiceInformation } from "src/types";
 import { Counter } from "../Counter";
-
-// TODO(idp): remove this when we merge https://github.com/duffelhq/duffel-api-javascript/pull/843
-type CreateOrderService = Pick<OrderService, "id" | "quantity">;
 
 interface BaggageSelectionControllerProps {
   segmentId: string;

--- a/src/components/DuffelAncillaries/bags/BaggageSelectionModal.tsx
+++ b/src/components/DuffelAncillaries/bags/BaggageSelectionModal.tsx
@@ -8,11 +8,8 @@ import React, { useState } from "react";
 import { BaggageSelectionModalBody } from "./BaggageSelectionModalBody";
 import { BaggageSelectionModalFooter } from "./BaggageSelectionModalFooter";
 import { BaggageSelectionModalHeader } from "./BaggageSelectionModalHeader";
-import { CreateOrder, Offer, OrderService } from "@duffel/api/types";
+import { CreateOrder, CreateOrderService, Offer } from "@duffel/api/types";
 import { WithServiceInformation } from "src/types";
-
-// TODO(idp): remove this when we merge https://github.com/duffelhq/duffel-api-javascript/pull/843
-type CreateOrderService = Pick<OrderService, "id" | "quantity">;
 
 export interface BaggageSelectionModalProps {
   isOpen: boolean;

--- a/src/components/DuffelAncillaries/bags/BaggageSelectionModalBody.tsx
+++ b/src/components/DuffelAncillaries/bags/BaggageSelectionModalBody.tsx
@@ -4,16 +4,13 @@ import React from "react";
 
 import {
   CreateOrderPassenger,
+  CreateOrderService,
   Offer,
   OfferAvailableServiceBaggage,
   OfferSliceSegment,
-  OrderService,
 } from "@duffel/api/types";
 import { WithServiceInformation } from "src/types";
 import { BaggageSelectionModalBodyPassenger } from "./BaggageSelectionModalBodyPassenger";
-
-// TODO(idp): remove this when we merge https://github.com/duffelhq/duffel-api-javascript/pull/843
-type CreateOrderService = Pick<OrderService, "id" | "quantity">;
 
 export interface BaggageSelectionModalBodyProps {
   offer: Offer;

--- a/src/components/DuffelAncillaries/bags/BaggageSelectionModalBodyPassenger.tsx
+++ b/src/components/DuffelAncillaries/bags/BaggageSelectionModalBodyPassenger.tsx
@@ -1,15 +1,12 @@
 import {
+  CreateOrderService,
   OfferAvailableServiceBaggage,
   OfferSliceSegmentPassengerBaggage,
-  OrderService,
 } from "@duffel/api/types";
 import React from "react";
 import { WithServiceInformation } from "src/types";
 import { BaggageSelectionController } from "./BaggageSelectionController";
 import { IncludedBaggageBanner } from "./IncludedBaggageBanner";
-
-// TODO(idp): remove this when we merge https://github.com/duffelhq/duffel-api-javascript/pull/843
-type CreateOrderService = Pick<OrderService, "id" | "quantity">;
 
 export interface BaggageSelectionModalBodyPassengerProps {
   segmentId: string;

--- a/src/components/DuffelAncillaries/cancel_for_any_reason/CfarSelectionCard.tsx
+++ b/src/components/DuffelAncillaries/cancel_for_any_reason/CfarSelectionCard.tsx
@@ -1,6 +1,6 @@
 import { AnimatedLoaderEllipsis } from "@components/shared/AnimatedLoaderEllipsis";
 import { Stamp } from "@components/shared/Stamp";
-import { Offer, OrderService } from "@duffel/api/types";
+import { CreateOrderService, Offer } from "@duffel/api/types";
 import { getCurrencyForServices } from "@lib/getCurrencyForServices";
 import { getTotalAmountForServices } from "@lib/getTotalAmountForServices";
 import { getTotalQuantity } from "@lib/getTotalQuantity";
@@ -11,9 +11,6 @@ import React from "react";
 import { WithServiceInformation } from "src/types";
 import { Card } from "../Card";
 import { CfarSelectionModal } from "./CfarSelectionModal";
-
-// TODO(idp): remove this when we merge https://github.com/duffelhq/duffel-api-javascript/pull/843
-type CreateOrderService = Pick<OrderService, "id" | "quantity">;
 
 export interface CfarSelectionCardProps {
   isLoading: boolean;

--- a/src/components/DuffelAncillaries/cancel_for_any_reason/CfarSelectionModal.tsx
+++ b/src/components/DuffelAncillaries/cancel_for_any_reason/CfarSelectionModal.tsx
@@ -1,17 +1,14 @@
 import { Modal } from "@components/shared/Modal";
 import {
+  CreateOrderService,
   Offer,
   OfferAvailableServiceCFAR,
-  OrderService,
 } from "@duffel/api/types";
 import React from "react";
 import { WithServiceInformation } from "src/types";
 import { CfarSelectionModalBody } from "./CfarSelectionModalBody";
 import { CfarSelectionModalFooter } from "./CfarSelectionModalFooter";
 import { CfarSelectionModalHeader } from "./CfarSelectionModalHeader";
-
-// TODO(idp): remove this when we merge https://github.com/duffelhq/duffel-api-javascript/pull/843
-type CreateOrderService = Pick<OrderService, "id" | "quantity">;
 
 export interface CfarSelectionModalProps {
   isOpen: boolean;

--- a/src/components/DuffelAncillaries/cancel_for_any_reason/CfarSelectionModalFooter.tsx
+++ b/src/components/DuffelAncillaries/cancel_for_any_reason/CfarSelectionModalFooter.tsx
@@ -1,12 +1,12 @@
 import { Button } from "@components/shared/Button";
 import { Icon } from "@components/shared/Icon";
-import { OfferAvailableServiceCFAR, OrderService } from "@duffel/api/types";
+import {
+  CreateOrderService,
+  OfferAvailableServiceCFAR,
+} from "@duffel/api/types";
 import { moneyStringFormatter } from "@lib/moneyStringFormatter";
 import React from "react";
 import { WithServiceInformation } from "src/types";
-
-// TODO(idp): remove this when we merge https://github.com/duffelhq/duffel-api-javascript/pull/843
-type CreateOrderService = Pick<OrderService, "id" | "quantity">;
 
 export interface CfarSelectionModalFooterProps {
   service: OfferAvailableServiceCFAR;

--- a/src/components/DuffelAncillaries/seats/Element.tsx
+++ b/src/components/DuffelAncillaries/seats/Element.tsx
@@ -4,11 +4,11 @@ import { Amenity } from "./Amenity";
 import { EmptyElement } from "./EmptyElement";
 import { ExitElement } from "./ExitElement";
 import { SeatElement } from "./SeatElement";
-import { OrderService, SeatMapCabinRowSectionElement } from "@duffel/api/types";
+import {
+  CreateOrderService,
+  SeatMapCabinRowSectionElement,
+} from "@duffel/api/types";
 import { WithServiceInformation } from "src/types";
-
-// TODO(idp): remove this when we merge https://github.com/duffelhq/duffel-api-javascript/pull/843
-type CreateOrderService = Pick<OrderService, "id" | "quantity">;
 
 interface ElementProps {
   sectionIndex: number;

--- a/src/components/DuffelAncillaries/seats/Row.tsx
+++ b/src/components/DuffelAncillaries/seats/Row.tsx
@@ -1,11 +1,8 @@
 import { getRowNumber } from "@lib/getRowNumber";
 import * as React from "react";
 import { RowSection } from "./RowSection";
-import { OrderService, SeatMapCabinRow } from "@duffel/api/types";
+import { CreateOrderService, SeatMapCabinRow } from "@duffel/api/types";
 import { WithServiceInformation } from "src/types";
-
-// TODO(idp): remove this when we merge https://github.com/duffelhq/duffel-api-javascript/pull/843
-type CreateOrderService = Pick<OrderService, "id" | "quantity">;
 
 export interface RowProps {
   row: SeatMapCabinRow;

--- a/src/components/DuffelAncillaries/seats/RowSection.tsx
+++ b/src/components/DuffelAncillaries/seats/RowSection.tsx
@@ -3,14 +3,11 @@ import * as React from "react";
 import { Element } from "./Element";
 import { EmptyElement } from "./EmptyElement";
 import {
-  OrderService,
+  CreateOrderService,
   SeatMapCabinRow,
   SeatMapCabinRowSection,
 } from "@duffel/api/types";
 import { WithServiceInformation } from "src/types";
-
-// TODO(idp): remove this when we merge https://github.com/duffelhq/duffel-api-javascript/pull/843
-type CreateOrderService = Pick<OrderService, "id" | "quantity">;
 
 interface RowSectionProps {
   row: SeatMapCabinRow;

--- a/src/components/DuffelAncillaries/seats/SeatElement.tsx
+++ b/src/components/DuffelAncillaries/seats/SeatElement.tsx
@@ -1,6 +1,6 @@
 import { Icon } from "@components/shared/Icon";
 import {
-  OrderService,
+  CreateOrderService,
   SeatMapCabinRowSectionElementSeat,
 } from "@duffel/api/types";
 import { getPassengerInitials } from "@lib/getPassengerInitials";
@@ -10,9 +10,6 @@ import * as React from "react";
 import { SeatInfo } from "./SeatInfo";
 import { SeatUnavailable } from "./SeatUnavailable";
 import { WithServiceInformation } from "src/types";
-
-// TODO(idp): remove this when we merge https://github.com/duffelhq/duffel-api-javascript/pull/843
-type CreateOrderService = Pick<OrderService, "id" | "quantity">;
 
 interface SeatElementProps {
   element: SeatMapCabinRowSectionElementSeat;

--- a/src/components/DuffelAncillaries/seats/SeatMap.tsx
+++ b/src/components/DuffelAncillaries/seats/SeatMap.tsx
@@ -3,15 +3,12 @@ import { getSymbols } from "@lib/getSymbols";
 import { hasWings } from "@lib/hasWings";
 import classNames from "classnames";
 import * as React from "react";
-import { OrderService, SeatMap as SeatMapType } from "@duffel/api/types";
+import { CreateOrderService, SeatMap as SeatMapType } from "@duffel/api/types";
 import { DeckSelect } from "./DeckSelect";
 import { Legend } from "./Legend";
 import { Row } from "./Row";
 import { SeatMapUnavailable } from "./SeatMapUnavailable";
 import { WithServiceInformation } from "src/types";
-
-// TODO(idp): remove this when we merge https://github.com/duffelhq/duffel-api-javascript/pull/843
-type CreateOrderService = Pick<OrderService, "id" | "quantity">;
 
 export interface SeatMapProps {
   seatMap: SeatMapType;

--- a/src/components/DuffelAncillaries/seats/SeatSelectionCard.tsx
+++ b/src/components/DuffelAncillaries/seats/SeatSelectionCard.tsx
@@ -8,11 +8,13 @@ import { withPlural } from "@lib/withPlural";
 import React from "react";
 import { Card } from "../Card";
 import { SeatSelectionModal } from "./SeatSelectionModal";
-import { CreateOrder, Offer, OrderService, SeatMap } from "@duffel/api/types";
+import {
+  CreateOrder,
+  CreateOrderService,
+  Offer,
+  SeatMap,
+} from "@duffel/api/types";
 import { WithServiceInformation } from "src/types";
-
-// TODO(idp): remove this when we merge https://github.com/duffelhq/duffel-api-javascript/pull/843
-type CreateOrderService = Pick<OrderService, "id" | "quantity">;
 
 export interface SeatSelectionCardProps {
   isLoading: boolean;

--- a/src/components/DuffelAncillaries/seats/SeatSelectionModal.tsx
+++ b/src/components/DuffelAncillaries/seats/SeatSelectionModal.tsx
@@ -9,11 +9,13 @@ import React from "react";
 import { SeatSelectionModalBody } from "./SeatSelectionModalBody";
 import { SeatSelectionModalFooter } from "./SeatSelectionModalFooter";
 import { SeatSelectionModalHeader } from "./SeatSelectionModalHeader";
-import { CreateOrder, Offer, OrderService, SeatMap } from "@duffel/api/types";
+import {
+  CreateOrder,
+  CreateOrderService,
+  Offer,
+  SeatMap,
+} from "@duffel/api/types";
 import { WithServiceInformation } from "src/types";
-
-// TODO(idp): remove this when we merge https://github.com/duffelhq/duffel-api-javascript/pull/843
-type CreateOrderService = Pick<OrderService, "id" | "quantity">;
 
 type CreateOrderServiceWithInformation =
   WithServiceInformation<CreateOrderService>;

--- a/src/lib/getFareBrandName.ts
+++ b/src/lib/getFareBrandName.ts
@@ -1,0 +1,20 @@
+import { OfferSliceSegment, OrderSliceSegment } from "@duffel/api/types";
+
+const CabinClassMap = {
+  economy: "Economy",
+  premium_economy: "Premium Economy",
+  business: "Business",
+  first: "First",
+  any: "Any",
+};
+
+export const getFareBrandName = (
+  fareBrandName: string | null,
+  forSegment: OfferSliceSegment | OrderSliceSegment
+) =>
+  fareBrandName ||
+  (forSegment.passengers &&
+    forSegment.passengers.length > 0 &&
+    (forSegment.passengers[0].cabin_class_marketing_name ||
+      CabinClassMap[forSegment.passengers[0].cabin_class])) ||
+  "";

--- a/src/lib/getLayoverOriginDestinationKey.ts
+++ b/src/lib/getLayoverOriginDestinationKey.ts
@@ -1,0 +1,5 @@
+export const getLayoverOriginDestinationKey = (
+  from?: string | null,
+  at?: string | null,
+  to?: string | null
+) => from + "-" + at + "-" + to;

--- a/src/lib/getSegmentDates.ts
+++ b/src/lib/getSegmentDates.ts
@@ -1,0 +1,12 @@
+import { OfferSliceSegment, OrderSliceSegment } from "@duffel/api/types";
+
+export const getSegmentDates = (
+  segment: OfferSliceSegment | OrderSliceSegment
+) => {
+  // TODO: remove the fallback once AIC returns arrivingAt and departingAt for AICs as well
+  const arrivingAt =
+    segment.arriving_at ?? (segment as any)["arrival_datetime"];
+  const departingAt =
+    segment.departing_at ?? (segment as any)["departure_datetime"];
+  return { arrivingAt, departingAt };
+};

--- a/src/lib/getSegmentFlightNumber.ts
+++ b/src/lib/getSegmentFlightNumber.ts
@@ -1,0 +1,6 @@
+import { OfferSliceSegment, OrderSliceSegment } from "@duffel/api/types";
+
+export const getSegmentFlightNumber = (
+  segment: OfferSliceSegment | OrderSliceSegment
+) =>
+  `${segment.marketing_carrier.iata_code}${segment.marketing_carrier_flight_number}`;

--- a/src/lib/getSliceDetails.ts
+++ b/src/lib/getSliceDetails.ts
@@ -1,0 +1,149 @@
+import {
+  OfferSlice,
+  OfferSliceSegmentStop,
+  OrderSlice,
+} from "@duffel/api/types";
+import {
+  SliceDetails,
+  SliceItem,
+  TravelDetails,
+} from "src/types/TravelDetails";
+import { convertDurationToString } from "./convertDurationToString";
+import { getDurationString } from "./getDurationString";
+import { getTravelItem } from "./getTravelItem";
+import { getSegmentDates } from "./getSegmentDates";
+import { getLayoverOriginDestinationKey } from "./getLayoverOriginDestinationKey";
+
+export const getSliceDetails = (
+  slice: OfferSlice | OrderSlice | undefined
+): SliceDetails => {
+  if (!slice) return [];
+
+  const numberOfSegments = slice.segments.length;
+  const sliceDetailsStack = new Array<SliceItem>();
+
+  for (let index = 0; index < numberOfSegments; index++) {
+    const currentSegment = slice.segments[index];
+    const lastOnStack = sliceDetailsStack[sliceDetailsStack.length - 1] || {};
+    const fareBrandName =
+      "fare_brand_name" in slice ? slice.fare_brand_name : null;
+    const travelDetails = getTravelItem(currentSegment, fareBrandName);
+
+    const { departingAt } = getSegmentDates(currentSegment);
+    if (lastOnStack.type === "travel") {
+      if (numberOfSegments === 1) break;
+
+      const duration = getDurationString(
+        lastOnStack.travelDetails!.arrivingAt,
+        departingAt!
+      );
+
+      sliceDetailsStack.push({
+        type: "layover",
+        layoverDetails: {
+          airport: lastOnStack.travelDetails!.destination,
+          duration,
+          originDestinationKey: getLayoverOriginDestinationKey(
+            lastOnStack.travelDetails?.origin.iata_code,
+            lastOnStack.travelDetails?.destination.iata_code,
+            currentSegment.destination?.iata_code
+          ),
+        },
+      });
+    }
+
+    // We have to do this in a type-unsafe way for now because this union of offer and order segment
+    // is not collapsible due to the lack of a discriminant field
+    if ("stops" in currentSegment && currentSegment.stops) {
+      const stops: OfferSliceSegmentStop[] = currentSegment.stops;
+      if (stops.length === 0) {
+        sliceDetailsStack.push({
+          type: "travel",
+          id: currentSegment.id || "",
+          travelDetails: travelDetails,
+        });
+      } else {
+        sliceDetailsStack.push(
+          ...splitTravelDetailsWithStops(
+            travelDetails,
+            stops,
+            currentSegment.id
+          )
+        );
+      }
+    } else {
+      sliceDetailsStack.push({
+        type: "travel",
+        id: currentSegment.id || "",
+        travelDetails: travelDetails,
+      });
+    }
+  }
+
+  return sliceDetailsStack;
+};
+
+const splitTravelDetailsWithStops = (
+  travelDetails: TravelDetails<"offer">,
+  stops: OfferSliceSegmentStop[],
+  segmentId: string
+): SliceItem[] => {
+  const items: SliceItem[] = [];
+  // split the travel details by the number of stops
+  let nextOrigin = travelDetails.origin;
+  let nextDepartingAt = travelDetails.departingAt;
+  stops.forEach((stop, index) => {
+    // add a travel item from the origin to this stop
+    items.push({
+      type: "travel",
+      id: segmentId,
+      travelDetails: {
+        ...travelDetails,
+        originDestination: `${nextOrigin.iata_code}-${stop.airport.iata_code}`,
+        departingAt: nextDepartingAt,
+        arrivingAt: stop.arrivingAt,
+        origin: nextOrigin,
+        destination: stop.airport,
+        flightDuration: getDurationString(nextDepartingAt, stop.arrivingAt),
+      },
+    });
+    // show a stop as a layover item
+    items.push({
+      type: "layover",
+      layoverDetails: {
+        airport: stop.airport,
+        duration: convertDurationToString(stop.duration),
+        originDestinationKey: getLayoverOriginDestinationKey(
+          nextOrigin.iata_code,
+          stop.airport.iata_code,
+          travelDetails.destination.iata_code
+        ),
+      },
+    });
+    // the stop becomes the next origin
+    nextOrigin = stop.airport;
+    nextDepartingAt = stop.departingAt;
+
+    // if it's the last stop, add a travel item from the last stop to the segment's destination
+    if (index === stops.length - 1) {
+      items.push({
+        type: "travel",
+        id: segmentId,
+        travelDetails: {
+          ...travelDetails,
+          originDestination: `${stop.airport.iata_code}-${travelDetails.destination.iata_code}`,
+          departingAt: stop.departingAt,
+          arrivingAt: travelDetails.arrivingAt,
+          origin: stop.airport,
+          destination: travelDetails.destination,
+          flightDuration: getDurationString(
+            stop.departingAt,
+            travelDetails.arrivingAt
+          ),
+        },
+      });
+    }
+  });
+
+  return items;
+};

--- a/src/lib/getTravelItem.ts
+++ b/src/lib/getTravelItem.ts
@@ -1,0 +1,54 @@
+import { OfferSliceSegment, OrderSliceSegment } from "@duffel/api/types";
+import { TravelDetails } from "src/types/TravelDetails";
+import { convertDurationToString } from "./convertDurationToString";
+import { getFareBrandName } from "./getFareBrandName";
+import { getSegmentDates } from "./getSegmentDates";
+import { getSegmentFlightNumber } from "./getSegmentFlightNumber";
+import { isISO8601Duration } from "./isISO8601Duration";
+
+export const getTravelItem = (
+  fromSegment: OfferSliceSegment | OrderSliceSegment,
+  fareBrandName: string | null
+): TravelDetails<"order" | "offer"> => {
+  const { origin, destination } = fromSegment;
+  const { arrivingAt, departingAt } = getSegmentDates(fromSegment);
+
+  return {
+    originDestination: `${origin.iata_code}-${destination.iata_code}`,
+    arrivingAt: arrivingAt!,
+    departingAt: departingAt!,
+    origin,
+    destination,
+    fareBrandName: getFareBrandName(fareBrandName, fromSegment),
+    cabinClass:
+      fromSegment.passengers?.length > 0
+        ? fromSegment.passengers[0].cabin_class_marketing_name ||
+          fromSegment.passengers[0].cabin_class
+        : "",
+    flight: getSegmentFlightNumber(fromSegment),
+    aircraft: (fromSegment.aircraft && fromSegment.aircraft.name) || "",
+    flightDuration:
+      fromSegment.duration &&
+      typeof fromSegment.duration === "string" &&
+      isISO8601Duration(fromSegment.duration)
+        ? convertDurationToString(fromSegment.duration)
+        : null,
+
+    airline: fromSegment.marketing_carrier,
+    operatedBy: fromSegment.operating_carrier
+      ? fromSegment.operating_carrier.name
+      : undefined,
+    baggagesIncluded: {
+      // NOTE: need to make passengers optional because order request change offer slice
+      // shares the same type as offer's slice when it shouldn't
+      carryOn: fromSegment.passengers?.[0].baggages?.find(
+        (baggage) => baggage.type === "carry_on"
+      )?.quantity,
+      checked: fromSegment.passengers?.[0].baggages?.find(
+        (baggage) => baggage.type === "checked"
+      )?.quantity,
+    },
+    originTerminal: fromSegment.origin_terminal,
+    destinationTerminal: fromSegment.destination_terminal,
+  };
+};

--- a/src/lib/hasServiceOfSameMetadataTypeAlreadyBeenSelected.ts
+++ b/src/lib/hasServiceOfSameMetadataTypeAlreadyBeenSelected.ts
@@ -1,8 +1,8 @@
-import { OfferAvailableServiceBaggage, OrderService } from "@duffel/api/types";
+import {
+  CreateOrderService,
+  OfferAvailableServiceBaggage,
+} from "@duffel/api/types";
 import { WithServiceInformation } from "src/types";
-
-// TODO(idp): remove this when we merge https://github.com/duffelhq/duffel-api-javascript/pull/843
-type CreateOrderService = Pick<OrderService, "id" | "quantity">;
 
 export const hasServiceOfSameMetadataTypeAlreadyBeenSelected = (
   selectedServices: WithServiceInformation<CreateOrderService>[],

--- a/src/tests/lib/getFareBrandName.test.ts
+++ b/src/tests/lib/getFareBrandName.test.ts
@@ -1,0 +1,31 @@
+import { OfferSliceSegment } from "@duffel/api/types";
+import { getFareBrandName } from "@lib/getFareBrandName";
+
+const segment: OfferSliceSegment = {
+  passengers: [
+    {
+      cabin_class_marketing_name: "Economy class",
+      cabin_class: "economy",
+    },
+  ],
+} as any;
+
+describe("getFareBrandName", () => {
+  test("correctly returns slice fare brand name if present", () => {
+    expect(getFareBrandName("Economy class restrictive", segment)).toBe(
+      "Economy class restrictive"
+    );
+  });
+  test("correctly returns first passenger cabin class marketing name if slice fare brand name not present", () => {
+    expect(getFareBrandName(null, segment)).toBe("Economy class");
+  });
+  test("correctly returns mapped cabin class if neither slice fare brand name nor cabin class marketing name are present", () => {
+    const testSegment: OfferSliceSegment = {
+      passengers: [{ cabin_class: "economy" }],
+    } as any;
+    expect(getFareBrandName(null, testSegment)).toBe("Economy");
+  });
+  test("correctly returns empty string if no relevant information exists", () => {
+    expect(getFareBrandName(null, {} as OfferSliceSegment)).toBe("");
+  });
+});

--- a/src/tests/lib/getLayoverOriginDestinationKey.test.ts
+++ b/src/tests/lib/getLayoverOriginDestinationKey.test.ts
@@ -1,0 +1,22 @@
+import { getLayoverOriginDestinationKey } from "../../lib/getLayoverOriginDestinationKey";
+
+describe("getLayoverOriginDestinationKey", () => {
+  it("should return the correct key when all arguments are provided", () => {
+    const key = getLayoverOriginDestinationKey(
+      "LHR",
+      "2022-01-01T12:00:00Z",
+      "JFK"
+    );
+    expect(key).toEqual("LHR-2022-01-01T12:00:00Z-JFK");
+  });
+
+  it("should return the correct key when some arguments are null", () => {
+    const key = getLayoverOriginDestinationKey("LHR", null, "JFK");
+    expect(key).toEqual("LHR-null-JFK");
+  });
+
+  it("should return the correct key when all arguments are null", () => {
+    const key = getLayoverOriginDestinationKey(null, null, null);
+    expect(key).toEqual("null-null-null");
+  });
+});

--- a/src/tests/lib/getSegmentDates.test.ts
+++ b/src/tests/lib/getSegmentDates.test.ts
@@ -1,0 +1,28 @@
+import { OfferSliceSegment, OrderSliceSegment } from "@duffel/api/types";
+import { getSegmentDates } from "@lib/getSegmentDates";
+
+const departing = "2019-12-05T22:25:20.525883Z";
+const arriving = "2019-12-06T06:25:20.525883Z";
+
+const offerSegment: OfferSliceSegment = {
+  departing_at: departing,
+  arriving_at: arriving,
+} as any;
+
+const orderSegment: OrderSliceSegment = {
+  departing_at: departing,
+  arriving_at: arriving,
+} as any;
+
+describe("getSegmentDates", () => {
+  test("correctly returns dates for offer segment", () => {
+    const { arrivingAt, departingAt } = getSegmentDates(offerSegment);
+    expect(departingAt).toBe(departing);
+    expect(arrivingAt).toBe(arriving);
+  });
+  test("correctly returns dates for order segment", () => {
+    const { arrivingAt, departingAt } = getSegmentDates(orderSegment);
+    expect(departingAt).toBe(departing);
+    expect(arrivingAt).toBe(arriving);
+  });
+});

--- a/src/tests/lib/getSegmentFlightNumber.test.ts
+++ b/src/tests/lib/getSegmentFlightNumber.test.ts
@@ -1,0 +1,15 @@
+import { getSegmentFlightNumber } from "@lib/getSegmentFlightNumber";
+import { OfferSliceSegment, OrderSliceSegment } from "@duffel/api/types";
+
+const segment: OfferSliceSegment | OrderSliceSegment = {
+  marketing_carrier: { iata_code: "AA" },
+  marketing_carrier_flight_number: "101",
+} as any;
+
+describe("getSegmentFlightNumber", () => {
+  it("should return the correct flight number for an OfferSliceSegment", () => {
+    const result = getSegmentFlightNumber(segment);
+
+    expect(result).toEqual("AA101");
+  });
+});

--- a/src/tests/lib/getSliceDetails.test.ts
+++ b/src/tests/lib/getSliceDetails.test.ts
@@ -1,0 +1,204 @@
+import {
+  OfferSlice,
+  OfferSliceSegment,
+  OfferSliceSegmentPassenger,
+} from "@duffel/api/types";
+import { getSliceDetails } from "@lib/getSliceDetails";
+
+const passenger: OfferSliceSegmentPassenger = {
+  cabin_class_marketing_name: "economy",
+  baggages: [
+    {
+      type: "carry_on",
+      quantity: 2,
+    },
+    { type: "checked", quantity: 1 },
+  ],
+} as any;
+const marketingCarrier = { name: "British Airways", iataCode: "BA" } as any;
+const segment1: OfferSliceSegment = {
+  passengers: [passenger],
+  origin: {
+    iata_code: "LHR",
+  },
+  destination: {
+    iata_code: "BOS",
+  },
+  departing_at: "2019-12-05T22:25:20.525883Z",
+  arriving_at: "2019-12-06T06:25:20.525883Z",
+  marketing_carrier: marketingCarrier,
+  duration: "PT08h",
+} as any;
+const segment2: OfferSliceSegment = {
+  passengers: [{ ...passenger, baggages: [{ type: "checked", quantity: 2 }] }],
+  origin: {
+    iata_code: "BOS",
+  },
+  destination: {
+    iata_code: "SAN",
+  },
+  departing_at: "2019-12-06T11:25:20.525883Z",
+  arriving_at: "2019-12-06T13:25:20.525883Z",
+  marketing_carrier: marketingCarrier,
+  duration: "PT02h",
+} as any;
+const segment3: OfferSliceSegment = {
+  passengers: [passenger],
+  origin: {
+    iata_code: "SAN",
+  },
+  destination: {
+    iata_code: "HNL",
+  },
+  departing_at: "2019-12-06T19:25:20.525883Z",
+  arriving_at: "2019-12-07T01:25:20.525883Z",
+  marketing_carrier: marketingCarrier,
+  duration: "PT06h",
+} as any;
+const partialSlice: OfferSlice = { fareBrandName: "Economy" } as any;
+const segmentWithStops: OfferSliceSegment = {
+  passengers: [passenger],
+  origin: {
+    iata_code: "LHR",
+  },
+  destination: {
+    iata_code: "BOS",
+  },
+  departing_at: "2019-12-05T22:25:20.525883Z",
+  arriving_at: "2019-12-06T06:25:20.525883Z",
+  stops: [
+    {
+      airport: {
+        iata_code: "JFK",
+      },
+      arrivingAt: "2019-12-06T01:25:20.525883Z",
+      departingAt: "2019-12-06T02:25:20.525883Z",
+      duration: "PT01h",
+    },
+    {
+      airport: {
+        iata_code: "EWR",
+      },
+      // TODO(idp): this type in incorrect. Should it be snake case?
+      arrivingAt: "2019-12-06T04:25:20.525883Z",
+      departingAt: "2019-12-06T05:25:20.525883Z",
+      duration: "PT01h",
+    },
+  ],
+  marketing_carrier: marketingCarrier,
+  duration: "PT08h",
+} as any;
+
+describe("getSliceDetails", () => {
+  test("correctly returns empty list for no slice", () => {
+    expect(getSliceDetails(undefined)).toEqual([]);
+  });
+  test("correctly returns single travel item for a slice with one segment", () => {
+    const slice: OfferSlice = {
+      ...partialSlice,
+      segments: [segment1],
+    };
+    const sliceDetails = getSliceDetails(slice);
+    expect(sliceDetails).toHaveLength(1);
+    expect(sliceDetails[0].type).toBe("travel");
+    expect(sliceDetails[0].travelDetails?.flightDuration).toBe("08h");
+    expect(sliceDetails[0].travelDetails?.baggagesIncluded).toEqual({
+      carryOn: 2,
+      checked: 1,
+    });
+  });
+  test("correctly returns travel items and layover between them for slice with two segments", () => {
+    const slice: OfferSlice = {
+      ...partialSlice,
+      segments: [segment1, segment2],
+    };
+    const sliceDetails = getSliceDetails(slice);
+    expect(sliceDetails).toHaveLength(3);
+    expect(sliceDetails[0].type).toBe("travel");
+    expect(sliceDetails[1].type).toBe("layover");
+    expect(sliceDetails[2].type).toBe("travel");
+    expect(sliceDetails[0].travelDetails?.flightDuration).toBe("08h");
+    expect(sliceDetails[1].layoverDetails?.duration).toBe("05h");
+    expect(sliceDetails[2].travelDetails?.flightDuration).toBe("02h");
+
+    expect(sliceDetails[0].travelDetails?.baggagesIncluded).toEqual({
+      carryOn: 2,
+      checked: 1,
+    });
+    expect(sliceDetails[2].travelDetails?.baggagesIncluded).toEqual({
+      checked: 2,
+    });
+  });
+  test("correctly returns travel items and layovers between them for slice with multiple segments", () => {
+    const slice: OfferSlice = {
+      ...partialSlice,
+      segments: [segment1, segment2, segment3],
+    };
+    const sliceDetails = getSliceDetails(slice);
+    expect(sliceDetails).toHaveLength(5);
+    expect(sliceDetails[0].type).toBe("travel");
+    expect(sliceDetails[1].type).toBe("layover");
+    expect(sliceDetails[2].type).toBe("travel");
+    expect(sliceDetails[3].type).toBe("layover");
+    expect(sliceDetails[4].type).toBe("travel");
+    expect(sliceDetails[0].travelDetails?.flightDuration).toBe("08h");
+    expect(sliceDetails[1].layoverDetails?.duration).toBe("05h");
+    expect(sliceDetails[2].travelDetails?.flightDuration).toBe("02h");
+    expect(sliceDetails[3].layoverDetails?.duration).toBe("06h");
+    expect(sliceDetails[4].travelDetails?.flightDuration).toBe("06h");
+  });
+
+  test("correctly returns travel items for a slice with one segment and multiple stops", () => {
+    const slice: OfferSlice = {
+      ...partialSlice,
+      segments: [segmentWithStops],
+    } as any;
+    const sliceDetails = getSliceDetails(slice);
+    expect(sliceDetails.map((slice) => slice.type)).toEqual([
+      "travel",
+      "layover",
+      "travel",
+      "layover",
+      "travel",
+    ]);
+    expect(
+      sliceDetails.map(
+        (slice) =>
+          slice.travelDetails?.originDestination ??
+          `layover (${slice.layoverDetails?.originDestinationKey})`
+      )
+    ).toEqual([
+      "LHR-JFK",
+      "layover (LHR-JFK-BOS)", // layover details
+      "JFK-EWR",
+      "layover (JFK-EWR-BOS)", // layover details
+      "EWR-BOS",
+    ]);
+
+    expect(
+      sliceDetails.map((slice) =>
+        slice.travelDetails
+          ? {
+              departingAt: slice.travelDetails?.departingAt,
+              arrivingAt: slice.travelDetails.arrivingAt,
+            }
+          : slice.layoverDetails.duration
+      )
+    ).toEqual([
+      {
+        departingAt: "2019-12-05T22:25:20.525883Z",
+        arrivingAt: "2019-12-06T01:25:20.525883Z",
+      },
+      "01h", // layover details
+      {
+        departingAt: "2019-12-06T02:25:20.525883Z",
+        arrivingAt: "2019-12-06T04:25:20.525883Z",
+      },
+      "01h", // layover details
+      {
+        departingAt: "2019-12-06T05:25:20.525883Z",
+        arrivingAt: "2019-12-06T06:25:20.525883Z",
+      },
+    ]);
+  });
+});

--- a/src/tests/lib/getTravelItem.test.ts
+++ b/src/tests/lib/getTravelItem.test.ts
@@ -1,0 +1,55 @@
+import { getTravelItem } from "../../lib/getTravelItem";
+import { OfferSliceSegment } from "@duffel/api/types";
+
+const segment: OfferSliceSegment = {
+  id: "segment_1",
+  origin: { iata_code: "LHR" },
+  destination: { iata_code: "JFK" },
+  departure_date: "2022-01-01T10:00:00Z",
+  arrival_date: "2022-01-01T18:00:00Z",
+  duration: "PT8H",
+  number_of_stops: 0,
+  airline: "airline_1",
+  operating_airline: "airline_1",
+  flight_number: "123",
+  fare_brand_name: "basic",
+  aircraft: {
+    model: "737",
+    type: "AIRCRAFT_TYPE_A",
+  },
+  marketing_carrier: {
+    iata_code: "LHR",
+  },
+} as any;
+
+describe("getTravelItem", () => {
+  it("should return the correct travel item for a slice segment", () => {
+    const travelItem = getTravelItem(segment, "basic");
+    expect(travelItem).toEqual({
+      aircraft: "",
+      airline: {
+        iata_code: "LHR",
+      },
+      arrivingAt: undefined,
+      baggagesIncluded: {
+        carryOn: undefined,
+        checked: undefined,
+      },
+      cabinClass: "",
+      departingAt: undefined,
+      destination: {
+        iata_code: "JFK",
+      },
+      destinationTerminal: undefined,
+      fareBrandName: "basic",
+      flight: "LHRundefined",
+      flightDuration: "08h",
+      operatedBy: undefined,
+      origin: {
+        iata_code: "LHR",
+      },
+      originDestination: "LHR-JFK",
+      originTerminal: undefined,
+    });
+  });
+});

--- a/src/tests/lib/hasServiceOfSameMetadataTypeAlreadyBeenSelected.test.ts
+++ b/src/tests/lib/hasServiceOfSameMetadataTypeAlreadyBeenSelected.test.ts
@@ -1,4 +1,7 @@
-import { OfferAvailableServiceBaggage, OrderService } from "@duffel/api/types";
+import {
+  CreateOrderService,
+  OfferAvailableServiceBaggage,
+} from "@duffel/api/types";
 import { hasServiceOfSameMetadataTypeAlreadyBeenSelected } from "../../lib/hasServiceOfSameMetadataTypeAlreadyBeenSelected";
 import { WithServiceInformation } from "src/types";
 
@@ -7,9 +10,6 @@ const availableService: OfferAvailableServiceBaggage = {
   metadata: { type: "checked" },
   // using as any because we don't need to test the whole type
 } as any;
-
-// TODO(idp): remove this when we merge https://github.com/duffelhq/duffel-api-javascript/pull/843
-type CreateOrderService = Pick<OrderService, "id" | "quantity">;
 
 const selectedService: WithServiceInformation<CreateOrderService> = {
   id: "selected_service_id",

--- a/src/types/DuffelAncillariesProps.ts
+++ b/src/types/DuffelAncillariesProps.ts
@@ -1,11 +1,11 @@
 import {
   CreateOrder,
+  CreateOrderService,
   Offer,
   OfferAvailableServiceBaggage,
   OfferAvailableServiceBaggageMetadata,
   OfferAvailableServiceCFAR,
   OfferAvailableServiceCFARMetadata,
-  OrderService,
   SeatMap,
   SeatMapCabinRowSectionAvailableService,
 } from "@duffel/api/types";
@@ -94,9 +94,6 @@ export type OnPayloadReady = (
   data: CreateOrder,
   metadata: OnPayloadReadyMetadata
 ) => void;
-
-// TODO(idp): remove this when we merge https://github.com/duffelhq/duffel-api-javascript/pull/843
-type CreateOrderService = Pick<OrderService, "id" | "quantity">;
 
 export interface OnPayloadReadyMetadata {
   offer_total_amount: Offer["total_amount"];

--- a/src/types/TravelDetails.ts
+++ b/src/types/TravelDetails.ts
@@ -1,0 +1,120 @@
+import {
+  Airline,
+  Airport,
+  CreateOrderPassenger,
+  DuffelPassengerGender,
+  DuffelPassengerTitle,
+  Place,
+} from "@duffel/api/types";
+
+export interface TravelDetails<T extends "order" | "offer" | "diff"> {
+  originDestination: string;
+  departingAt: string;
+  origin: T extends "diff" ? string : Airport | Place;
+
+  arrivingAt: string;
+  destination: T extends "diff" ? string : Airport | Place;
+
+  aircraft: string | null;
+  cabinClass: string;
+
+  fareBrandName?: T extends "offer" ? string : never;
+  flightDuration: string | null;
+
+  flight: string;
+
+  // For the diff view of an order, we use the `operatingCarrier` and `marketingCarrier` properties directly
+  airline: T extends "diff" ? null : Airline;
+  operatedBy?: string;
+
+  baggagesIncluded?: {
+    carryOn?: number;
+    checked?: number;
+  };
+
+  originTerminal?: string | null;
+  destinationTerminal?: string | null;
+}
+
+export interface LayoverDetails {
+  airport: Airport | Place;
+  duration: string;
+  originDestinationKey?: string;
+}
+
+export interface SliceTravelItem {
+  type: "travel";
+  travelDetails: TravelDetails<"order" | "offer">;
+  layoverDetails?: never;
+  id: string;
+}
+
+export interface SliceLayoverItem {
+  type: "layover";
+  travelDetails?: never;
+  layoverDetails: LayoverDetails;
+}
+
+export type SliceItem = SliceTravelItem | SliceLayoverItem;
+
+export type SliceDetails = SliceItem[];
+
+export type FilterItems = Record<string, string>;
+
+export type SliceDetailItemChangeStatus =
+  | "no_change"
+  | "added"
+  | "removed"
+  | "changed";
+
+export type ProcessedRequestError = {
+  errorTitle?: string;
+  errorMessage: string;
+  requestId?: string;
+};
+
+export type PropsOrError<T> = Readonly<
+  | ({ error: true } & ProcessedRequestError)
+  | { error: false; props: T }
+  | { redirect: string }
+>;
+
+export type RandomlyGeneratedPassenger = Omit<
+  CreateOrderPassenger,
+  "email" | "identityDocuments" | "infantPassengerId" | "phoneNumber"
+>;
+
+export type ValueOf<T> = Required<T>[keyof T];
+
+export const WebhookEventTypes = [
+  "order.created",
+  "order.airline_initiated_change_detected",
+] as const;
+export type WebhookEventType = (typeof WebhookEventTypes)[number];
+
+export const FilterableWebhookEventTypes = [
+  ...WebhookEventTypes,
+  "ping.triggered",
+] as const;
+
+export type FilterableWebhookEventType =
+  (typeof FilterableWebhookEventTypes)[number];
+
+// we got this from node_modules/unleash-proxy-client/build/index.d.ts:78
+export type UnleashContext = {
+  appName: string;
+  environment?: string;
+  userId?: string;
+  sessionId?: string;
+  remoteAddress?: string;
+  properties?: {
+    [key: string]: string;
+  };
+};
+
+export type RandomlyGeneratedPeople = {
+  title: DuffelPassengerTitle;
+  familyName: string;
+  givenName: string;
+  gender: DuffelPassengerGender;
+};

--- a/src/types/getSegmentDates.ts
+++ b/src/types/getSegmentDates.ts
@@ -1,0 +1,28 @@
+import { OfferSliceSegment, OrderSliceSegment } from "@duffel/api/types";
+import { getSegmentDates } from "@lib/getSegmentDates";
+
+const departing = "2019-12-05T22:25:20.525883Z";
+const arriving = "2019-12-06T06:25:20.525883Z";
+
+const offerSegment: OfferSliceSegment = {
+  departingAt: departing,
+  arrivingAt: arriving,
+} as any;
+
+const orderSegment: OrderSliceSegment = {
+  departingAt: departing,
+  arrivingAt: arriving,
+} as any;
+
+describe("getSegmentDates", () => {
+  test("correctly returns dates for offer segment", () => {
+    const { arrivingAt, departingAt } = getSegmentDates(offerSegment);
+    expect(departingAt).toBe(departing);
+    expect(arrivingAt).toBe(arriving);
+  });
+  test("correctly returns dates for order segment", () => {
+    const { arrivingAt, departingAt } = getSegmentDates(orderSegment);
+    expect(departingAt).toBe(departing);
+    expect(arrivingAt).toBe(arriving);
+  });
+});

--- a/yarn.lock
+++ b/yarn.lock
@@ -2040,14 +2040,14 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@duffel/api@npm:2.5.11":
-  version: 2.5.11
-  resolution: "@duffel/api@npm:2.5.11"
+"@duffel/api@npm:2.5.12":
+  version: 2.5.12
+  resolution: "@duffel/api@npm:2.5.12"
   dependencies:
     "@types/node": "npm:^18.0.0"
     "@types/node-fetch": "npm:^2.6.2"
     node-fetch: "npm:2.7.0"
-  checksum: b1c6686fdd1fc18fb819a558acafbb78fdae85b4634f4b2170edf73e7f7d7c2e94147a305d739add3c3bcdd8b325dcd3328eba55aa0471e01f22621111586a38
+  checksum: 8746b2c331ba5fe13ae0b3f34f8303c43ec951835f33f10ba6265d3335349f30642013ed91ccd4721496352a086f82aa31914d6e15b391ea9f8897697f3afb5a
   languageName: node
   linkType: hard
 
@@ -2060,7 +2060,7 @@ __metadata:
     "@babel/preset-env": "npm:7.21.4"
     "@babel/preset-react": "npm:7.18.6"
     "@babel/preset-typescript": "npm:7.21.4"
-    "@duffel/api": "npm:2.5.11"
+    "@duffel/api": "npm:2.5.12"
     "@sentry/browser": "npm:7.77.0"
     "@sentry/cli": "npm:2.21.2"
     "@sentry/esbuild-plugin": "npm:0.7.0"


### PR DESCRIPTION
__What__

Ahead of adding the component to show slice, this PR adds the helpers to breakdown the slices into travel details. This uses the @duffel/api types. 