### PR TITLE
type=button on ancillaries card

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@duffel/components",
-  "version": "3.1.5",
+  "version": "3.1.6",
   "description": "Component library to build your travel product with Duffel.",
   "keywords": [
     "Duffel",

--- a/src/components/DuffelAncillaries/Card.tsx
+++ b/src/components/DuffelAncillaries/Card.tsx
@@ -29,6 +29,7 @@ export const Card: React.FC<CardProps> = ({
 
   return (
     <button
+      type="button"
       title={buttonTitle}
       {...(onClick && { onClick })}
       disabled={disabled}


### PR DESCRIPTION
__what__

Small fixes to get the ancillaries card to be of `type` `button` to prevent form submissions.