### PR TITLE
Update formatAvailableServices to support null available_services

### DIFF
--- a/src/lib/formatAvailableServices.ts
+++ b/src/lib/formatAvailableServices.ts
@@ -31,7 +31,7 @@ const formatAvailableServices = (
     return offer;
   }
 
-  const availableServices = offer.available_services;
+  const availableServices = offer.available_services || [];
 
   const foundCurrencies = new Set<string>();
 


### PR DESCRIPTION
__What__

We have an [issue](https://github.com/duffelhq/duffel-components/issues/184) where the API is returning `null` on for an `offer`'s `available_services`. This should not be the case and needs to be corrected. But to avoid the component crashing in the meantime, we'll add a small guard.   