### PR TITLE
Fix baggage selection restriction bug

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@duffel/components",
-  "version": "3.4.0",
+  "version": "3.4.1",
   "description": "Component library to build your travel product with Duffel.",
   "keywords": [
     "Duffel",

--- a/src/components/DuffelAncillaries/bags/BaggageSelectionModalBodyPassenger.tsx
+++ b/src/components/DuffelAncillaries/bags/BaggageSelectionModalBodyPassenger.tsx
@@ -54,8 +54,12 @@ export const BaggageSelectionModalBodyPassenger: React.FC<
             availableService={availableService}
             selectedServices={selectedServices}
             quantity={
-              selectedServices.find(({ id }) => id == availableService.id)
-                ?.quantity || 0
+              selectedServices.find(
+                ({ id, serviceInformation }) =>
+                  id == availableService.id &&
+                  serviceInformation.segmentId == segmentId &&
+                  serviceInformation.passengerId == passengerId
+              )?.quantity || 0
             }
             onQuantityChanged={(newQuantity) =>
               onBaggageQuantityChanged(
@@ -94,7 +98,10 @@ const onBaggageQuantityChanged = (
 ) => {
   // check if the service which had its quantity changed is already in the list
   const changedServiceIndex = selectedServices.findIndex(
-    ({ id }) => availableService.id === id
+    ({ id, serviceInformation }) =>
+      availableService.id === id &&
+      serviceInformation.segmentId === segmentId &&
+      serviceInformation.passengerId === passengerId
   );
 
   // create a copy of the existing list of selected services

--- a/src/types/DuffelAncillariesProps.ts
+++ b/src/types/DuffelAncillariesProps.ts
@@ -115,7 +115,7 @@ export type WithServiceInformation<TypeToExtend> = {
 export type ServiceInformation =
   | BaggageServiceInformation
   | SeatServiceInformation
-  | CancelForAnyReasonerviceInformation;
+  | CancelForAnyReasonServiceInformation;
 
 interface BaggageServiceInformation
   extends OfferAvailableServiceBaggageMetadata {
@@ -138,7 +138,7 @@ interface SeatServiceInformation {
   total_currency: string;
 }
 
-interface CancelForAnyReasonerviceInformation
+interface CancelForAnyReasonServiceInformation
   extends OfferAvailableServiceCFARMetadata {
   type: "cancel_for_any_reason";
   segmentId?: undefined;


### PR DESCRIPTION
Context: https://duffel.atlassian.net/browse/UXP-3321

There was a bug where the selected baggage shown wasn't properly tied to the specific segment and passenger ID.
Here's a video of how it works now: 

https://github.com/duffelhq/duffel-components/assets/1416759/ce3977d3-f558-498c-9e5d-2dab11df9cf2

