### PR TITLE
Adds interface for save card

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -35,13 +35,5 @@ module.exports = {
     "react/react-in-jsx-scope": 0,
     "react/prop-types": 0,
     "react-hooks/exhaustive-deps": 0,
-    "no-restricted-syntax": [
-      "error",
-      {
-        selector: "CallExpression[callee.object.name='console']",
-        message:
-          "Prefer 'log' or 'logGroup' from 'src/lib/logging.ts' instead of 'console'.",
-      },
-    ],
   },
 };

--- a/src/components/DuffelCardForm/DuffelCardForm.tsx
+++ b/src/components/DuffelCardForm/DuffelCardForm.tsx
@@ -1,8 +1,8 @@
 import * as React from "react";
 import { getIFrameEventListener } from "./lib/getIFrameEventListener";
 import { getIframeURL } from "./lib/getIframeURL";
+import { postMessageToCreateCardForTemporaryUse } from "./lib/postMessageToCreateCardForTemporaryUse";
 import { postMessageToSaveCard } from "./lib/postMessageToSaveCard";
-import { postMessageToStoreCardForTemporaryUse } from "./lib/postMessageToStoreCardForTemporaryUse";
 import { postMessageWithStyles } from "./lib/postMessageWithStyles";
 import { DuffelCardFormProps } from "./lib/types";
 
@@ -33,7 +33,7 @@ export const DuffelCardForm: React.FC<DuffelCardFormProps> = ({
   }
   if (!Array.isArray(actions)) {
     throw new Error(
-      "Attempted to render `DuffelCardForm` without an `actions` array. You may set the initial state for actions to `['validate']` or use `action` returned from the `useDuffelCardFormActions` hook."
+      "Attempted to render `DuffelCardForm` without an `actions` array. You may set the initial state for actions to `['validate']` or use `actions` returned from the `useDuffelCardFormActions` hook."
     );
   }
   if (intent == "to-use-saved-card" && !cardId) {
@@ -74,7 +74,7 @@ export const DuffelCardForm: React.FC<DuffelCardFormProps> = ({
 
   React.useEffect(() => {
     if (actions.includes("create-card-for-temporary-use")) {
-      postMessageToStoreCardForTemporaryUse(iFrameReference, iFrameURL);
+      postMessageToCreateCardForTemporaryUse(iFrameReference, iFrameURL);
     }
 
     if (actions.includes("save-card")) {

--- a/src/components/DuffelCardForm/DuffelCardForm.tsx
+++ b/src/components/DuffelCardForm/DuffelCardForm.tsx
@@ -1,108 +1,92 @@
 import * as React from "react";
-import { getTokenFromClientKey } from "./lib/getTokenFromClientKey";
-import { DuffelCardFormProps } from "./lib/types";
 import { getIFrameEventListener } from "./lib/getIFrameEventListener";
+import { getIframeURL } from "./lib/getIframeURL";
+import { postMessageToSaveCard } from "./lib/postMessageToSaveCard";
+import { postMessageToStoreCardForTemporaryUse } from "./lib/postMessageToStoreCardForTemporaryUse";
+import { postMessageWithStyles } from "./lib/postMessageWithStyles";
+import { DuffelCardFormProps } from "./lib/types";
 
 export const DuffelCardForm: React.FC<DuffelCardFormProps> = ({
+  tokenProxyEnvironment = "production",
   clientKey,
   styles,
-  tokenProxyEnvironment = "production",
-
+  intent,
   actions,
-
+  cardId,
   onValidateSuccess,
   onValidateFailure,
-
   onCreateCardForTemporaryUseSuccess,
   onCreateCardForTemporaryUseFailure,
+  onSaveCardSuccess,
+  onSaveCardFailure,
 }) => {
-  let baseUrlString = "https://api.duffel.cards/iframe.html";
-  if (tokenProxyEnvironment === "staging") {
-    baseUrlString = "https://api.staging.duffel.cards/iframe.html";
-  } else if (tokenProxyEnvironment === "development") {
-    baseUrlString = "https://localhost:8000/iframe.html";
+  // Validates required props
+  if (!clientKey) {
+    throw new Error(
+      "Attempted to render `DuffelCardForm` without a clientKey."
+    );
+  }
+  if (!intent) {
+    throw new Error(
+      "Attempted to render `DuffelCardForm` without an `intent`. Make sure your provide one of the following: `create-card-for-temporary-use`, `save-card`, `use-saved-card`."
+    );
+  }
+  if (!Array.isArray(actions)) {
+    throw new Error(
+      "Attempted to render `DuffelCardForm` without an `actions` array. You may set the initial state for actions to `['validate']` or use `action` returned from the `useDuffelCardFormActions` hook."
+    );
+  }
+  if (intent == "to-use-saved-card" && !cardId) {
+    throw new Error(
+      "Attempted to render `DuffelCardForm`to use a saved card but the `cardId` prop is missing. Make sure you provide the id of the saved card you'd like to use."
+    );
   }
 
-  const baseUrl = new URL(baseUrlString);
-
+  // Calls hooks
   const [iFrameHeight, setIFrameHeight] = React.useState("0px");
-
   const iFrameReference = React.useRef<HTMLIFrameElement>(null);
 
-  const iFrameSrc = `${baseUrl}?${new URLSearchParams({
-    token: getTokenFromClientKey(clientKey),
-  }).toString()}`;
+  // Sets the iframe src
+  const iFrameURL = getIframeURL(
+    tokenProxyEnvironment,
+    intent,
+    clientKey,
+    cardId
+  );
 
-  function sendMessageToStoreCardForTemporaryUse() {
-    if (!iFrameReference.current) {
-      throw new Error(
-        "Attempted to call `sendMessageToStoreCardForTemporaryUse` with empty iFrameReference"
-      );
-    }
-
-    const iFrame = iFrameReference.current;
-    if (!iFrame.contentWindow) {
-      throw new Error(
-        "Attempted to call `sendMessageToStoreCardForTemporaryUse` but the iFrame contentWindow is null"
-      );
-    }
-
-    iFrame.contentWindow.postMessage(
-      { type: "create-card-for-temporary-use" },
-      baseUrl.origin
-    );
-  }
-
-  function postMessageWithStyles() {
-    if (!iFrameReference.current) {
-      throw new Error(
-        "Attempted to call `postMessageWithStyles` with empty iFrameReference"
-      );
-    }
-
-    const iFrame = iFrameReference.current;
-    if (!iFrame.contentWindow) {
-      throw new Error(
-        "Attempted to call `postMessageWithStyles` but the iFrame contentWindow is null"
-      );
-    }
-
-    iFrame.contentWindow.postMessage(
-      { type: "apply-styles", styles },
-      baseUrl.origin
-    );
-  }
-
-  /**
-   * useEffect to react to changes on the actions prop.
-   */
+  // Register event listeners to the window to listen to messages from the iframe.
   React.useEffect(() => {
-    if (actions.includes("create-card-for-temporary-use")) {
-      sendMessageToStoreCardForTemporaryUse();
-    }
-  }, [actions]);
-
-  /**
-   * Adds an event listener to the window to listen to messages from the iframe.
-   */
-  React.useEffect(() => {
-    const iFrameEventListener = getIFrameEventListener(baseUrl.origin, {
-      postMessageWithStyles,
+    const iFrameEventListener = getIFrameEventListener(iFrameURL, {
+      postMessageWithStyles: () =>
+        postMessageWithStyles(iFrameReference, iFrameURL, styles),
       setIFrameHeight,
       onValidateSuccess,
       onValidateFailure,
       onCreateCardForTemporaryUseSuccess,
       onCreateCardForTemporaryUseFailure,
+      onSaveCardSuccess,
+      onSaveCardFailure,
     });
+
     window.addEventListener("message", iFrameEventListener);
     return () => window.removeEventListener("message", iFrameEventListener);
   }, []);
+
+  React.useEffect(() => {
+    if (actions.includes("create-card-for-temporary-use")) {
+      postMessageToStoreCardForTemporaryUse(iFrameReference, iFrameURL);
+    }
+
+    if (actions.includes("save-card")) {
+      postMessageToSaveCard(iFrameReference, iFrameURL);
+    }
+  }, [actions]);
 
   return (
     <iframe
       ref={iFrameReference}
       title="Card Payment Form"
-      src={iFrameSrc}
+      src={iFrameURL.href}
       style={{
         width: "100%",
         border: "none",

--- a/src/components/DuffelCardForm/Example.tsx
+++ b/src/components/DuffelCardForm/Example.tsx
@@ -161,7 +161,7 @@ export const OptionallySavingCardOnCheckoutExample = () => {
   const { actions, triggerSaveCard, triggerCreateCardForTemporaryUse } =
     useDuffelCardFormActions();
 
-  const [cardId, setCardId] = React.useState<string>();
+  const [cardId, setCardId] = React.useState<string>(); // 1.create state for cardId
 
   return (
     <body>
@@ -197,9 +197,9 @@ export const OptionallySavingCardOnCheckoutExample = () => {
       </label>
 
       <button
-        disabled={!cardId} //
+        disabled={!cardId} // 6. Only enable button when card is saved
         onClick={() => {
-          console.log("User triggered form submission"); //
+          console.log("User triggered form submission"); // 7. User triggers form submission. use the cardId to crrate booking or order
         }}
       >
         Pay for flight

--- a/src/components/DuffelCardForm/Example.tsx
+++ b/src/components/DuffelCardForm/Example.tsx
@@ -1,0 +1,209 @@
+import React from "react";
+import { DuffelCardForm } from "./DuffelCardForm";
+import { DuffelCardFormProps } from "./lib/types";
+import { useDuffelCardFormActions } from "./lib/useDuffelCardFormActions";
+
+const MOCK_CLIENT_KEY = "fixture_client_key_123";
+const MOCK_CARD_ID = "fixture_card_123";
+
+export const SavingCardExampleWithoutHook = () => {
+  const [cardFormActions, setCardFormActions] = React.useState<
+    DuffelCardFormProps["actions"]
+  >(["validate"]); // 1. wait for validation
+
+  return (
+    <body>
+      <DuffelCardForm
+        clientKey={MOCK_CLIENT_KEY}
+        intent="to-save-card"
+        actions={cardFormActions}
+        onValidateSuccess={() => {
+          console.log("validation ok");
+          setCardFormActions(["validate", "save-card"]); // 2. wait for card to be saved
+        }}
+        onSaveCardSuccess={(data) => {
+          console.log("card saved", data); // 3. get the card data and store it
+        }}
+        onValidateFailure={console.error}
+        onSaveCardFailure={console.error}
+      />
+    </body>
+  );
+};
+
+export const SavingCardExample = () => {
+  const { actions, triggerSaveCard } = useDuffelCardFormActions();
+  return (
+    <body>
+      <DuffelCardForm
+        clientKey={MOCK_CLIENT_KEY}
+        intent="to-save-card"
+        actions={actions}
+        onValidateSuccess={() => {
+          console.log("validation ok");
+          triggerSaveCard(); // 2. wait for card to be saved
+        }}
+        onSaveCardSuccess={(data) => {
+          console.log("card saved", data); // 3. get the card data and store it
+        }}
+        onValidateFailure={console.error}
+        onSaveCardFailure={console.error}
+      />
+    </body>
+  );
+};
+
+export const CreatingTemporaryCardExample = () => {
+  const { actions, triggerCreateCardForTemporaryUse } =
+    useDuffelCardFormActions();
+  return (
+    <body>
+      <DuffelCardForm
+        clientKey={MOCK_CLIENT_KEY}
+        intent="to-create-card-for-temporary-use"
+        actions={actions}
+        onValidateSuccess={() => {
+          console.log("validation ok");
+          triggerCreateCardForTemporaryUse(); // 1. wait for card to be successfully validated
+        }}
+        onCreateCardForTemporaryUseSuccess={(data) => {
+          console.log("card saved", data); // 2. get the card id and use it to create stays booking or flights order
+        }}
+        onValidateFailure={console.error}
+        onCreateCardForTemporaryUseFailure={console.error}
+      />
+    </body>
+  );
+};
+
+export const UsingSavedCardExample = () => {
+  const { actions, triggerCreateCardForTemporaryUse } =
+    useDuffelCardFormActions();
+  return (
+    <body>
+      <DuffelCardForm
+        clientKey={MOCK_CLIENT_KEY}
+        intent="to-use-saved-card"
+        cardId={MOCK_CARD_ID}
+        actions={actions}
+        onValidateSuccess={() => {
+          console.log("validation ok");
+          triggerCreateCardForTemporaryUse(); // 1. wait for card to be successfully validated
+        }}
+        onCreateCardForTemporaryUseSuccess={(data) => {
+          console.log("card saved", data); // 2. get the card id and use it to create stays booking or flights order
+        }}
+        onValidateFailure={console.error}
+        onCreateCardForTemporaryUseFailure={console.error}
+      />
+    </body>
+  );
+};
+
+export const SavingAndUsingCardExampleSync = () => {
+  const { actions, triggerSaveCard, triggerCreateCardForTemporaryUse } =
+    useDuffelCardFormActions();
+  return (
+    <body>
+      <DuffelCardForm
+        clientKey={MOCK_CLIENT_KEY}
+        intent="to-create-card-for-temporary-use"
+        actions={actions}
+        onValidateSuccess={() => {
+          console.log("validation ok");
+          triggerSaveCard(); // 2. wait for card to be saved
+        }}
+        onSaveCardSuccess={(data) => {
+          console.log("card saved", data); // 3. get the card data and store it in your system
+          triggerCreateCardForTemporaryUse(); // 4. create a temporary card
+        }}
+        onCreateCardForTemporaryUseSuccess={(data) => {
+          console.log("temporary card created", data); // 5. get the temporary card data and use it to create stays booking or flights order
+        }}
+        onValidateFailure={console.error}
+        onSaveCardFailure={console.error}
+        onCreateCardForTemporaryUseFailure={console.error}
+      />
+    </body>
+  );
+};
+
+export const SavingAndUsingCardExampleAsync = () => {
+  const { actions, triggerSaveCard, triggerCreateCardForTemporaryUse } =
+    useDuffelCardFormActions();
+
+  return (
+    <body>
+      <DuffelCardForm
+        clientKey={MOCK_CLIENT_KEY}
+        intent="to-create-card-for-temporary-use"
+        actions={actions}
+        onValidateSuccess={() => {
+          console.log("validation ok");
+          triggerSaveCard(); // 2. wait for card to be saved
+          triggerCreateCardForTemporaryUse(); // 2. create a temporary card, happens independently of the save card
+        }}
+        onSaveCardSuccess={(data) => {
+          console.log("card saved", data); // 3. get the card data and store it in your system
+        }}
+        onCreateCardForTemporaryUseSuccess={(data) => {
+          console.log("temporary card created", data); // 3. get the temporary card data and use it to create stays booking or flights order
+        }}
+        onValidateFailure={console.error}
+        onSaveCardFailure={console.error}
+        onCreateCardForTemporaryUseFailure={console.error}
+      />
+    </body>
+  );
+};
+
+export const OptionallySavingCardOnCheckoutExample = () => {
+  const { actions, triggerSaveCard, triggerCreateCardForTemporaryUse } =
+    useDuffelCardFormActions();
+
+  const [cardId, setCardId] = React.useState<string>();
+
+  return (
+    <body>
+      <DuffelCardForm
+        clientKey={MOCK_CLIENT_KEY}
+        intent="to-create-card-for-temporary-use"
+        actions={actions}
+        onValidateSuccess={() => {
+          console.log("validation ok");
+          triggerCreateCardForTemporaryUse(); // 2. create a temporary card, happens independently of the save card
+        }}
+        onSaveCardSuccess={(data) => {
+          console.log("card saved", data); // 3. get the card data and store it in your system
+        }}
+        onCreateCardForTemporaryUseSuccess={(data) => {
+          console.log("temporary card created", data); // 5. get the temporary card data and use it to create stays booking or flights order
+          setCardId(data.id);
+        }}
+        onValidateFailure={console.error}
+        onSaveCardFailure={console.error}
+        onCreateCardForTemporaryUseFailure={console.error}
+      />
+      <label>
+        Save card for later use
+        <input
+          type="checkbox"
+          onChange={(e) => {
+            if (e.target.checked) {
+              triggerSaveCard(); // 4. Trigger save card if box is checked
+            }
+          }}
+        />
+      </label>
+
+      <button
+        disabled={!cardId} //
+        onClick={() => {
+          console.log("User triggered form submission"); //
+        }}
+      >
+        Pay for flight
+      </button>
+    </body>
+  );
+};

--- a/src/components/DuffelCardForm/lib/getIFrameEventListener.ts
+++ b/src/components/DuffelCardForm/lib/getIFrameEventListener.ts
@@ -9,10 +9,12 @@ type Inputs = {
   | "onValidateFailure"
   | "onCreateCardForTemporaryUseSuccess"
   | "onCreateCardForTemporaryUseFailure"
+  | "onSaveCardSuccess"
+  | "onSaveCardFailure"
 >;
 
 export function getIFrameEventListener(
-  baseUrl: string,
+  iFrameURL: URL,
   {
     postMessageWithStyles,
     setIFrameHeight,
@@ -20,10 +22,16 @@ export function getIFrameEventListener(
     onValidateFailure,
     onCreateCardForTemporaryUseSuccess,
     onCreateCardForTemporaryUseFailure,
+    onSaveCardSuccess,
+    onSaveCardFailure,
   }: Inputs
 ) {
   return function iFrameEventListener(event: MessageEvent) {
-    if (!baseUrl?.startsWith(event.origin) || !event.data || !event.data.type) {
+    if (
+      !iFrameURL.origin?.startsWith(event.origin) ||
+      !event.data ||
+      !event.data.type
+    ) {
       return;
     }
 
@@ -39,19 +47,51 @@ export function getIFrameEventListener(
         return;
 
       case "validate-success":
-        onValidateSuccess();
+        if (onValidateSuccess) {
+          onValidateSuccess();
+        } else {
+          console.warn("`onValidateSuccess` not implemented");
+        }
         return;
 
       case "validate-failure":
-        onValidateFailure();
+        if (onValidateFailure) {
+          onValidateFailure();
+        } else {
+          console.warn("`onValidateFailure` not implemented");
+        }
         return;
 
       case "create-card-for-temporary-use-success":
-        onCreateCardForTemporaryUseSuccess(event.data.data);
+        if (onCreateCardForTemporaryUseSuccess) {
+          onCreateCardForTemporaryUseSuccess(event.data.data);
+        } else {
+          console.warn("`onCreateCardForTemporaryUseSuccess` not implemented");
+        }
         return;
 
       case "create-card-for-temporary-use-failure":
-        onCreateCardForTemporaryUseFailure(event.data.error);
+        if (onCreateCardForTemporaryUseFailure) {
+          onCreateCardForTemporaryUseFailure(event.data.error);
+        } else {
+          console.warn("`onCreateCardForTemporaryUseFailure` not implemented");
+        }
+        return;
+
+      case "save-card-success":
+        if (onSaveCardSuccess) {
+          onSaveCardSuccess(event.data.data);
+        } else {
+          console.warn("`onSaveCardSuccess` not implemented");
+        }
+        return;
+
+      case "save-card-failure":
+        if (onSaveCardFailure) {
+          onSaveCardFailure(event.data.error);
+        } else {
+          console.warn("`onSaveCardFailure` not implemented");
+        }
         return;
 
       default:

--- a/src/components/DuffelCardForm/lib/getIFrameOriginForEnvironment.ts
+++ b/src/components/DuffelCardForm/lib/getIFrameOriginForEnvironment.ts
@@ -1,0 +1,14 @@
+import { DuffelCardFormProps } from "./types";
+
+export function getIFrameOriginForEnvironment(
+  tokenProxyEnvironment: DuffelCardFormProps["tokenProxyEnvironment"]
+): string {
+  let origin = "https://api.duffel.cards";
+  if (tokenProxyEnvironment === "staging") {
+    origin = "https://api.staging.duffel.cards";
+  } else if (tokenProxyEnvironment === "development") {
+    origin = "https://localhost:8000";
+  }
+
+  return origin;
+}

--- a/src/components/DuffelCardForm/lib/getIframeURL.ts
+++ b/src/components/DuffelCardForm/lib/getIframeURL.ts
@@ -1,0 +1,24 @@
+import { getIFrameOriginForEnvironment } from "./getIFrameOriginForEnvironment";
+import { getPathnameForIntent } from "./getPathnameForIntent";
+import { getTokenFromClientKey } from "./getTokenFromClientKey";
+import { DuffelCardFormProps } from "./types";
+
+export function getIframeURL(
+  tokenProxyEnvironment: DuffelCardFormProps["tokenProxyEnvironment"],
+  intent: DuffelCardFormProps["intent"],
+  clientKey: DuffelCardFormProps["clientKey"],
+  cardId: DuffelCardFormProps["cardId"]
+) {
+  const iFrameOrigin = getIFrameOriginForEnvironment(tokenProxyEnvironment);
+  const iframeURL = new URL(iFrameOrigin);
+
+  iframeURL.pathname = getPathnameForIntent(intent);
+
+  iframeURL.searchParams.set("token", getTokenFromClientKey(clientKey));
+
+  if (cardId) {
+    iframeURL.searchParams.set("card_id", getTokenFromClientKey(cardId));
+  }
+
+  return iframeURL;
+}

--- a/src/components/DuffelCardForm/lib/getPathnameForIntent.ts
+++ b/src/components/DuffelCardForm/lib/getPathnameForIntent.ts
@@ -1,0 +1,22 @@
+import { DuffelCardFormIntent } from "./types";
+
+export function getPathnameForIntent(intent: DuffelCardFormIntent): string {
+  switch (intent) {
+    case "to-use-saved-card":
+      return `/use_saved_card`;
+    case "to-save-card":
+      return `/save_card`;
+    case "to-create-card-for-temporary-use":
+      return `/create_card_for_temporary_use`;
+    default:
+      if (!intent) {
+        throw new Error(
+          "Attempted to call `getPathnameForIntent` without an intent."
+        );
+      } else {
+        throw new Error(
+          `Attempted to call \`getPathnameForIntent\` but the intent "${intent}" is unknown.`
+        );
+      }
+  }
+}

--- a/src/components/DuffelCardForm/lib/postMessageToCreateCardForTemporaryUse.ts
+++ b/src/components/DuffelCardForm/lib/postMessageToCreateCardForTemporaryUse.ts
@@ -1,4 +1,4 @@
-export function postMessageToStoreCardForTemporaryUse(
+export function postMessageToCreateCardForTemporaryUse(
   iFrameReference: React.RefObject<HTMLIFrameElement>,
   baseUrl: URL
 ) {

--- a/src/components/DuffelCardForm/lib/postMessageToSaveCard.ts
+++ b/src/components/DuffelCardForm/lib/postMessageToSaveCard.ts
@@ -4,14 +4,14 @@ export function postMessageToSaveCard(
 ) {
   if (!iFrameReference.current) {
     throw new Error(
-      "Attempted to call `postMessageWithStyles` with empty iFrameReference"
+      "Attempted to call `postMessageToSaveCard` with empty iFrameReference"
     );
   }
 
   const iFrame = iFrameReference.current;
   if (!iFrame.contentWindow) {
     throw new Error(
-      "Attempted to call `postMessageWithStyles` but the iFrame contentWindow is null"
+      "Attempted to call `postMessageToSaveCard` but the iFrame contentWindow is null"
     );
   }
 

--- a/src/components/DuffelCardForm/lib/postMessageToSaveCard.ts
+++ b/src/components/DuffelCardForm/lib/postMessageToSaveCard.ts
@@ -1,0 +1,19 @@
+export function postMessageToSaveCard(
+  iFrameReference: React.RefObject<HTMLIFrameElement>,
+  baseUrl: URL
+) {
+  if (!iFrameReference.current) {
+    throw new Error(
+      "Attempted to call `postMessageWithStyles` with empty iFrameReference"
+    );
+  }
+
+  const iFrame = iFrameReference.current;
+  if (!iFrame.contentWindow) {
+    throw new Error(
+      "Attempted to call `postMessageWithStyles` but the iFrame contentWindow is null"
+    );
+  }
+
+  iFrame.contentWindow.postMessage({ type: "save-card" }, baseUrl.origin);
+}

--- a/src/components/DuffelCardForm/lib/postMessageToStoreCardForTemporaryUse.ts
+++ b/src/components/DuffelCardForm/lib/postMessageToStoreCardForTemporaryUse.ts
@@ -1,0 +1,22 @@
+export function postMessageToStoreCardForTemporaryUse(
+  iFrameReference: React.RefObject<HTMLIFrameElement>,
+  baseUrl: URL
+) {
+  if (!iFrameReference.current) {
+    throw new Error(
+      "Attempted to call `postMessageToStoreCardForTemporaryUse` with empty iFrameReference"
+    );
+  }
+
+  const iFrame = iFrameReference.current;
+  if (!iFrame.contentWindow) {
+    throw new Error(
+      "Attempted to call `postMessageToStoreCardForTemporaryUse` but the iFrame contentWindow is null"
+    );
+  }
+
+  iFrame.contentWindow.postMessage(
+    { type: "create-card-for-temporary-use" },
+    baseUrl.origin
+  );
+}

--- a/src/components/DuffelCardForm/lib/postMessageWithStyles.ts
+++ b/src/components/DuffelCardForm/lib/postMessageWithStyles.ts
@@ -1,0 +1,25 @@
+import { DuffelCardFormStyles } from "./types";
+
+export function postMessageWithStyles(
+  iFrameReference: React.RefObject<HTMLIFrameElement>,
+  baseUrl: URL,
+  styles: DuffelCardFormStyles | undefined
+) {
+  if (!iFrameReference.current) {
+    throw new Error(
+      "Attempted to call `postMessageWithStyles` with empty iFrameReference"
+    );
+  }
+
+  const iFrame = iFrameReference.current;
+  if (!iFrame.contentWindow) {
+    throw new Error(
+      "Attempted to call `postMessageWithStyles` but the iFrame contentWindow is null"
+    );
+  }
+
+  iFrame.contentWindow.postMessage(
+    { type: "apply-styles", styles },
+    baseUrl.origin
+  );
+}

--- a/src/components/DuffelCardForm/lib/types.ts
+++ b/src/components/DuffelCardForm/lib/types.ts
@@ -88,7 +88,8 @@ export interface DuffelCardFormProps {
    *
    * - `to-create-card-for-temporary-use`: The full form will be shown. You may also use this intent for the use case of using and saving the card.
    * - `to-use-saved-card`: When using this intent also provide the saved card ID. Only a cvv field will be rendered.
-   * - `to-save-card`: The form will be shown without the cvv field.
+   * - `to-save-card`: The form will be shown without the cvv field. This only allows you to save a card for future use,
+   *    but not create an id for immediate, temporary use. For the use case of saving during checkout or save + use, use the `to-create-card-for-temporary-use` intent.
    */
   intent: DuffelCardFormIntent;
 
@@ -127,8 +128,8 @@ export interface DuffelCardFormProps {
    *
    * This callback will only be triggered if the `create-card-for-temporary-use`
    * action is present in the `actions` prop. Alternatively,
-   * you may use the `triggerSaveCard` function from the
-   * `triggerCreateCardForTemporaryUse` hook.
+   * you may use the `triggerCreateCardForTemporaryUse` function from the
+   * `useDuffelCardFormActions` hook.
    */
   onCreateCardForTemporaryUseSuccess?: (
     data: CreateCardForTemporaryUseData
@@ -139,8 +140,8 @@ export interface DuffelCardFormProps {
    *
    * This callback will only be triggered if the `create-card-for-temporary-use`
    * action is present in the `actions` prop. Alternatively,
-   * you may use the `triggerSaveCard` function from the
-   * `triggerCreateCardForTemporaryUse` hook.
+   * you may use the `triggerCreateCardForTemporaryUse` function from the
+   * `useDuffelCardFormActions` hook.
    */
   onCreateCardForTemporaryUseFailure?: (
     error: CreateCardForTemporaryUseError

--- a/src/components/DuffelCardForm/lib/types.ts
+++ b/src/components/DuffelCardForm/lib/types.ts
@@ -66,7 +66,7 @@ export type DuffelCardFormIntent =
 
 export interface DuffelCardFormProps {
   /**
-   * The client key present in the Quote object.
+   * The client key retrieved from the Duffel API.
    */
   clientKey: string;
 
@@ -86,9 +86,9 @@ export interface DuffelCardFormProps {
    * The card intent defines what the form is meant to look like.
    * It can be one of:
    *
-   * - `create-card-for-temporary-use`: The full form will be shown. You may also use this intent for the use case of using and saving the card.
-   * - `use-saved-card`: When using this intent also provide the saved card ID. Only a cvv field will be rendered.
-   * - `save-card`: The form will be shown without the cvv field.
+   * - `to-create-card-for-temporary-use`: The full form will be shown. You may also use this intent for the use case of using and saving the card.
+   * - `to-use-saved-card`: When using this intent also provide the saved card ID. Only a cvv field will be rendered.
+   * - `to-save-card`: The form will be shown without the cvv field.
    */
   intent: DuffelCardFormIntent;
 
@@ -98,7 +98,9 @@ export interface DuffelCardFormProps {
    * This prop is a dependecy of a useEffect hook in the component
    * and so when it's changed it will perform the action you specify.
    *
-   * The action `create-card-for-temporary-use` will only happen once `validate` has been successful.
+   * The `create-card-for-temporary-use` and `save-card` actions will only happen once `validate` has been successful.
+   *
+   * We recommend using the `useDuffelCardFormActions` hook for a simpler, more readable interface to manage the actions array.
    *
    */
   actions: DuffelCardFormActions[];
@@ -124,7 +126,9 @@ export interface DuffelCardFormProps {
    * This function will be called when the card has been created for temporary use.
    *
    * This callback will only be triggered if the `create-card-for-temporary-use`
-   * action is present in the `actions` prop.
+   * action is present in the `actions` prop. Alternatively,
+   * you may use the `triggerSaveCard` function from the
+   * `triggerCreateCardForTemporaryUse` hook.
    */
   onCreateCardForTemporaryUseSuccess?: (
     data: CreateCardForTemporaryUseData
@@ -134,25 +138,31 @@ export interface DuffelCardFormProps {
    * This function will be called when the component has failed to create the card for temporary use.
    *
    * This callback will only be triggered if the `create-card-for-temporary-use`
-   * action is present in the `actions` prop.
+   * action is present in the `actions` prop. Alternatively,
+   * you may use the `triggerSaveCard` function from the
+   * `triggerCreateCardForTemporaryUse` hook.
    */
   onCreateCardForTemporaryUseFailure?: (
     error: CreateCardForTemporaryUseError
   ) => void;
 
   /**
-   * This function will be called when the card has been created for temporary use.
+   * This function will be called when the card has been saved.
    *
-   * This callback will only be triggered if the `create-card-for-temporary-use`
-   * action is present in the `actions` prop.
+   * This callback will only be triggered if the `save-card`
+   * action is present in the `actions` prop. Alternatively,
+   * you may use the `triggerSaveCard` function from the
+   * `useDuffelCardFormActions` hook.
    */
   onSaveCardSuccess?: (data: SaveCardData) => void;
 
   /**
-   * This function will be called when the component has failed to create the card for temporary use.
+   * This function will be called when saving the card has failed.
    *
-   * This callback will only be triggered if the `create-card-for-temporary-use`
-   * action is present in the `actions` prop.
+   * This callback will only be triggered if the `save-card`
+   * action is present in the `actions` prop. Alternatively,
+   * you may use the `triggerSaveCard` function from the
+   * `useDuffelCardFormActions` hook.
    */
   onSaveCardFailure?: (error: SaveCardError) => void;
 }

--- a/src/components/DuffelCardForm/lib/types.ts
+++ b/src/components/DuffelCardForm/lib/types.ts
@@ -3,9 +3,30 @@ export interface CreateCardForTemporaryUseData {
   live_mode: false;
 }
 
-export interface CreateCardForTemporaryUseError {
+export type CreateCardForTemporaryUseError = {
   status: number;
   message: string;
+};
+
+export type SaveCardError = {
+  status: number;
+  message: string;
+};
+
+export interface SaveCardData {
+  id: string;
+  live_mode: boolean;
+  last_4_digits: string;
+  bin: string;
+  expiry_month: number;
+  expiry_year: number;
+  brand: string;
+  cardholder_name: string;
+
+  /**
+   * The card will no longer be available for use after this time.
+   */
+  unavailable_at: string;
 }
 
 /**
@@ -35,7 +56,13 @@ export interface DuffelCardFormStyles {
 
 export type DuffelCardFormActions =
   | "validate"
+  | "save-card"
   | "create-card-for-temporary-use";
+
+export type DuffelCardFormIntent =
+  | "to-create-card-for-temporary-use"
+  | "to-use-saved-card"
+  | "to-save-card";
 
 export interface DuffelCardFormProps {
   /**
@@ -56,6 +83,16 @@ export interface DuffelCardFormProps {
   tokenProxyEnvironment?: "development" | "staging" | "production";
 
   /**
+   * The card intent defines what the form is meant to look like.
+   * It can be one of:
+   *
+   * - `create-card-for-temporary-use`: The full form will be shown. You may also use this intent for the use case of using and saving the card.
+   * - `use-saved-card`: When using this intent also provide the saved card ID. Only a cvv field will be rendered.
+   * - `save-card`: The form will be shown without the cvv field.
+   */
+  intent: DuffelCardFormIntent;
+
+  /**
    * The actions you'd like the component to perform.
    *
    * This prop is a dependecy of a useEffect hook in the component
@@ -67,15 +104,21 @@ export interface DuffelCardFormProps {
   actions: DuffelCardFormActions[];
 
   /**
+   * Once a card is saved, in order to use it, travellers need to enter its cvv.
+   * When using the `use-saved-card` intent, you must provide the card ID.
+   */
+  cardId?: string;
+
+  /**
    * This function will be called when the card form validation has been successful.
    */
-  onValidateSuccess: () => void;
+  onValidateSuccess?: () => void;
 
   /**
    * If the card form validation is successful but data is changed afterwards,
    * making it invalid, this function will be called.
    */
-  onValidateFailure: () => void;
+  onValidateFailure?: () => void;
 
   /**
    * This function will be called when the card has been created for temporary use.
@@ -83,7 +126,7 @@ export interface DuffelCardFormProps {
    * This callback will only be triggered if the `create-card-for-temporary-use`
    * action is present in the `actions` prop.
    */
-  onCreateCardForTemporaryUseSuccess: (
+  onCreateCardForTemporaryUseSuccess?: (
     data: CreateCardForTemporaryUseData
   ) => void;
 
@@ -93,7 +136,23 @@ export interface DuffelCardFormProps {
    * This callback will only be triggered if the `create-card-for-temporary-use`
    * action is present in the `actions` prop.
    */
-  onCreateCardForTemporaryUseFailure: (
+  onCreateCardForTemporaryUseFailure?: (
     error: CreateCardForTemporaryUseError
   ) => void;
+
+  /**
+   * This function will be called when the card has been created for temporary use.
+   *
+   * This callback will only be triggered if the `create-card-for-temporary-use`
+   * action is present in the `actions` prop.
+   */
+  onSaveCardSuccess?: (data: SaveCardData) => void;
+
+  /**
+   * This function will be called when the component has failed to create the card for temporary use.
+   *
+   * This callback will only be triggered if the `create-card-for-temporary-use`
+   * action is present in the `actions` prop.
+   */
+  onSaveCardFailure?: (error: SaveCardError) => void;
 }

--- a/src/components/DuffelCardForm/lib/useDuffelCardFormActions.ts
+++ b/src/components/DuffelCardForm/lib/useDuffelCardFormActions.ts
@@ -3,7 +3,8 @@ import { DuffelCardFormProps } from "./types";
 
 export interface UseDuffelCardFormActionsHook {
   /**
-   *  The actions array that should be passed to the `actions` prop of the `DuffelCardForm` component.
+   * The actions array that should be passed to the `actions` prop of the `DuffelCardForm` component.
+   * You do not have have to modify this array directly, instead rely on `triggerSaveCard` and `triggerCreateCardForTemporaryUse` to update the array.
    */
   actions: DuffelCardFormProps["actions"];
 
@@ -20,7 +21,7 @@ export interface UseDuffelCardFormActionsHook {
 
 /**
  * This hook gives you convinient helpers to read and reason through the DuffelCardForm integration.
- * Add `actions` to the `DuffelCardForm` actiosn prop and call the functions to trigger the actions you'd like.
+ * Add `actions` to the `DuffelCardForm` actions prop and call the functions to trigger the actions you'd like.
  *
  * In the background, this hook is setting the state on actions prop and the component's useEffect hook will trigger the action.
  */

--- a/src/components/DuffelCardForm/lib/useDuffelCardFormActions.ts
+++ b/src/components/DuffelCardForm/lib/useDuffelCardFormActions.ts
@@ -1,0 +1,29 @@
+import React from "react";
+import { DuffelCardFormProps } from "./types";
+
+/**
+ * This hook gives you convinient helpers to read and reason through the DuffelCardForm integration.
+ * Add `actions` to the `DuffelCardForm` actiosn prop and call the functions to trigger the actions you'd like.
+ *
+ * In the background, this hook is setting the state on actions prop and the component's useEffect hook will trigger the action.
+ */
+
+export function useDuffelCardFormActions() {
+  const [cardFormActions, setCardFormActions] = React.useState<
+    DuffelCardFormProps["actions"]
+  >(["validate"]);
+
+  function triggerSaveCard() {
+    setCardFormActions([...cardFormActions, "save-card"]);
+  }
+
+  function triggerCreateCardForTemporaryUse() {
+    setCardFormActions([...cardFormActions, "create-card-for-temporary-use"]);
+  }
+
+  return {
+    actions: cardFormActions,
+    triggerSaveCard,
+    triggerCreateCardForTemporaryUse,
+  };
+}

--- a/src/components/DuffelCardForm/lib/useDuffelCardFormActions.ts
+++ b/src/components/DuffelCardForm/lib/useDuffelCardFormActions.ts
@@ -1,14 +1,30 @@
 import React from "react";
 import { DuffelCardFormProps } from "./types";
 
+export interface UseDuffelCardFormActionsHook {
+  /**
+   *  The actions array that should be passed to the `actions` prop of the `DuffelCardForm` component.
+   */
+  actions: DuffelCardFormProps["actions"];
+
+  /**
+   *  Call this function to tell the component to save the card.
+   */
+  triggerSaveCard: () => void;
+
+  /**
+   *  Call this function to tell the component to create a card for temporary use.
+   */
+  triggerCreateCardForTemporaryUse: () => void;
+}
+
 /**
  * This hook gives you convinient helpers to read and reason through the DuffelCardForm integration.
  * Add `actions` to the `DuffelCardForm` actiosn prop and call the functions to trigger the actions you'd like.
  *
  * In the background, this hook is setting the state on actions prop and the component's useEffect hook will trigger the action.
  */
-
-export function useDuffelCardFormActions() {
+export function useDuffelCardFormActions(): UseDuffelCardFormActionsHook {
   const [cardFormActions, setCardFormActions] = React.useState<
     DuffelCardFormProps["actions"]
   >(["validate"]);

--- a/src/stories/DuffelCardForm.stories.tsx
+++ b/src/stories/DuffelCardForm.stories.tsx
@@ -12,6 +12,7 @@ type DuffelCardFormStory = StoryObj<typeof DuffelCardForm>;
 const defaultProps: DuffelCardFormProps = {
   clientKey:
     "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJ0b2tlbiI6IkVOQ1JZUFRFRF9UT0tFTiJ9.qP-zHSkMn-O9VGSj4wkh_A4VDOIrzpgRxh1xgLZ51rk",
+  intent: "to-create-card-for-temporary-use",
   tokenProxyEnvironment: "development",
   actions: ["validate"],
   onValidateSuccess: console.log,


### PR DESCRIPTION
__What__

We want to support the ability for merchants to save cards as well as use saved cards. This updates the interface to allow them to do so. More documentation on how this works with the token proxy is coming soon.