### PR TITLE
UXP-3321 Another attempt at a fix for the baggage restriction bug

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@duffel/components",
-  "version": "3.4.2",
+  "version": "3.4.3",
   "description": "Component library to build your travel product with Duffel.",
   "keywords": [
     "Duffel",

--- a/src/lib/hasServiceOfSameMetadataTypeAlreadyBeenSelected.ts
+++ b/src/lib/hasServiceOfSameMetadataTypeAlreadyBeenSelected.ts
@@ -11,6 +11,14 @@ export const hasServiceOfSameMetadataTypeAlreadyBeenSelected = (
   availableService: OfferAvailableServiceBaggage
 ) =>
   selectedServices.some((selectedService) => {
+    const isOnDifferentSegment =
+      selectedService.serviceInformation?.segmentId !== segmentId;
+    const doesAvailableServiceApplyToSegment =
+      availableService.segment_ids?.includes(segmentId);
+    const hasSameBaggageType =
+      selectedService.serviceInformation?.type ===
+      availableService.metadata.type;
+
     if (selectedService.id === availableService.id) {
       // if the selected service is the one on the counter, don't disable it
       // the max quantity will be availableService.maximum_quantity
@@ -20,21 +28,10 @@ export const hasServiceOfSameMetadataTypeAlreadyBeenSelected = (
       selectedService.serviceInformation?.type !== "checked"
     ) {
       return false;
-    } else if (
-      selectedService.serviceInformation?.segmentId !== segmentId &&
-      !availableService.segment_ids?.includes(
-        selectedService.serviceInformation?.segmentId
-      )
-    ) {
+    } else if (isOnDifferentSegment) {
       // if the selected service doesn't belong to the same segment, don't disable it
-      // eslint-disable-next-line no-restricted-syntax
-      console.log(
-        "test",
-        segmentId,
-        selectedService.serviceInformation?.segmentId,
-        availableService.segment_ids
-      );
-      return false;
+      // unless the service applies to both segments
+      return hasSameBaggageType && doesAvailableServiceApplyToSegment;
     } else if (
       // if the selected service doesn't belong to the same passenger, don't disable it
       selectedService.serviceInformation?.passengerId !== passengerId

--- a/src/lib/hasServiceOfSameMetadataTypeAlreadyBeenSelected.ts
+++ b/src/lib/hasServiceOfSameMetadataTypeAlreadyBeenSelected.ts
@@ -20,8 +20,20 @@ export const hasServiceOfSameMetadataTypeAlreadyBeenSelected = (
       selectedService.serviceInformation?.type !== "checked"
     ) {
       return false;
-    } else if (selectedService.serviceInformation?.segmentId !== segmentId) {
+    } else if (
+      selectedService.serviceInformation?.segmentId !== segmentId &&
+      !availableService.segment_ids?.includes(
+        selectedService.serviceInformation?.segmentId
+      )
+    ) {
       // if the selected service doesn't belong to the same segment, don't disable it
+      // eslint-disable-next-line no-restricted-syntax
+      console.log(
+        "test",
+        segmentId,
+        selectedService.serviceInformation?.segmentId,
+        availableService.segment_ids
+      );
       return false;
     } else if (
       // if the selected service doesn't belong to the same passenger, don't disable it

--- a/src/tests/lib/hasServiceOfSameMetadataTypeAlreadyBeenSelected.test.ts
+++ b/src/tests/lib/hasServiceOfSameMetadataTypeAlreadyBeenSelected.test.ts
@@ -83,6 +83,19 @@ describe("hasServiceOfSameMetadataTypeAlreadyBeenSelected", () => {
         }
       )
     ).toBe(true);
+
+    expect(
+      hasServiceOfSameMetadataTypeAlreadyBeenSelected(
+        [selectedService],
+        "segment_id_wont_match",
+        "passenger_id",
+        {
+          ...availableService,
+          metadata: { ...availableService.metadata, type: "carry_on" },
+          segment_ids: ["segment_id", "segment_id_wont_match"],
+        }
+      )
+    ).toBe(false);
   });
 
   it("Should return false if service selected is of different type", () => {

--- a/src/tests/lib/hasServiceOfSameMetadataTypeAlreadyBeenSelected.test.ts
+++ b/src/tests/lib/hasServiceOfSameMetadataTypeAlreadyBeenSelected.test.ts
@@ -62,7 +62,7 @@ describe("hasServiceOfSameMetadataTypeAlreadyBeenSelected", () => {
     ).toBe(false);
   });
 
-  it("Should return false if service selected are for different segment", () => {
+  it("Should return false if service selected are for different segment unless the service applies to both segments", () => {
     expect(
       hasServiceOfSameMetadataTypeAlreadyBeenSelected(
         [selectedService],
@@ -71,6 +71,18 @@ describe("hasServiceOfSameMetadataTypeAlreadyBeenSelected", () => {
         availableService
       )
     ).toBe(false);
+
+    expect(
+      hasServiceOfSameMetadataTypeAlreadyBeenSelected(
+        [selectedService],
+        "segment_id_wont_match",
+        "passenger_id",
+        {
+          ...availableService,
+          segment_ids: ["segment_id", "segment_id_wont_match"],
+        }
+      )
+    ).toBe(true);
   });
 
   it("Should return false if service selected is of different type", () => {

--- a/src/types/DuffelAncillariesProps.ts
+++ b/src/types/DuffelAncillariesProps.ts
@@ -115,7 +115,7 @@ export type WithServiceInformation<TypeToExtend> = {
 export type ServiceInformation =
   | BaggageServiceInformation
   | SeatServiceInformation
-  | CancelForAnyReasonerviceInformation;
+  | CancelForAnyReasonServiceInformation;
 
 interface BaggageServiceInformation
   extends OfferAvailableServiceBaggageMetadata {
@@ -138,7 +138,7 @@ interface SeatServiceInformation {
   total_currency: string;
 }
 
-interface CancelForAnyReasonerviceInformation
+interface CancelForAnyReasonServiceInformation
   extends OfferAvailableServiceCFARMetadata {
   type: "cancel_for_any_reason";
   segmentId?: undefined;


### PR DESCRIPTION
This PR contains a different way of addressing the baggage restriction bug reported in https://duffel.atlassian.net/browse/UXP-3321. I think we aren't taking into account that services can apply to [multiple segments ](https://duffel.com/docs/api/v1/offers/schema#offers-schema-available-services-available-services-segment-ids) correctly but please let me know if I misunderstood something. Added a test and a video of the new behaviour here:

https://github.com/duffelhq/duffel-components/assets/1416759/714e3ece-1eda-438e-87ab-f92d9cd9a6cb

