### PR TITLE
Foundation for desktop table view

### DIFF
--- a/src/components/DuffelNGSView/DuffelNGSView.tsx
+++ b/src/components/DuffelNGSView/DuffelNGSView.tsx
@@ -1,14 +1,110 @@
 import * as React from "react";
-import { OfferWithNGS } from "./lib";
+import {
+  NGSShelf,
+  NGS_SHELF_INFO,
+  NGS_SHELVES,
+  OfferWithNGS,
+  OfferSliceWithNGS,
+} from "./lib";
+import { Icon } from "@components/shared/Icon";
+import { moneyStringFormatter } from "@lib/moneyStringFormatter";
+import classNames from "classnames";
 
 export interface DuffelNGSViewProps {
   offers: OfferWithNGS[];
+  sliceIndex: number;
 }
 
-export const DuffelNGSView: React.FC<DuffelNGSViewProps> = ({ offers }) => {
+type NGSOfferRow = Record<"slice", OfferSliceWithNGS> &
+  Record<NGSShelf, OfferWithNGS | null>;
+
+export const DuffelNGSView: React.FC<DuffelNGSViewProps> = ({
+  offers,
+  sliceIndex,
+}) => {
+  const [selectedColumn, setSelectedColumn] = React.useState<NGSShelf | null>(
+    null
+  );
+
   if (offers.length == 0) {
     return null;
   }
 
-  return <div>TODO</div>;
+  // TODO Group offers by carrier, find offers per carrier for each shelf
+  const rows: NGSOfferRow[] = [
+    {
+      slice: offers[0].slices[sliceIndex],
+      "1": null,
+      "2": null,
+      "3": offers[0],
+      "4": null,
+      "5": null,
+    },
+    {
+      slice: offers[0].slices[sliceIndex],
+      "1": null,
+      "2": offers[0],
+      "3": offers[0],
+      "4": offers[0],
+      "5": offers[0],
+    },
+  ];
+
+  return (
+    <div className="duffel-ngs-view duffel-components">
+      <table className="duffel-ngs-view_table">
+        <thead>
+          <tr className="duffel-ngs-view_table-header?">
+            <th className="duffel-ngs-view_th"></th>
+            {NGS_SHELVES.map((shelf) => (
+              <th key={shelf} onClick={() => setSelectedColumn(shelf)}>
+                <div
+                  className={classNames(
+                    "duffel-ngs-view_column-header",
+                    selectedColumn === shelf &&
+                      "duffel-ngs-view_column-header--selected"
+                  )}
+                >
+                  <Icon
+                    name={NGS_SHELF_INFO[shelf].icon}
+                    size={16}
+                    color={
+                      selectedColumn === shelf ? "--GREY-900" : "--GREY-500"
+                    }
+                    className="duffel-ngs-view_shelf-icon"
+                  />
+                  {NGS_SHELF_INFO[shelf].short_title}
+                </div>
+              </th>
+            ))}
+          </tr>
+        </thead>
+        <tbody>
+          {rows.map((row, index) => (
+            <tr key={index}>
+              <td>
+                {row["slice"].id} TODO Carriers, Flight Summary, View Details
+              </td>
+              {NGS_SHELVES.map((shelf) => (
+                <td
+                  key={shelf}
+                  onClick={() => setSelectedColumn(shelf)}
+                  className={classNames("duffel-ngs-view_table-data", {
+                    "duffel-ngs-view_table-data--selected":
+                      selectedColumn === shelf,
+                  })}
+                >
+                  {row[shelf]
+                    ? moneyStringFormatter(row[shelf]!.total_currency)(
+                        +row[shelf]!.total_amount
+                      )
+                    : "-"}
+                </td>
+              ))}
+            </tr>
+          ))}
+        </tbody>
+      </table>
+    </div>
+  );
 };

--- a/src/components/DuffelNGSView/DuffelNGSView.tsx
+++ b/src/components/DuffelNGSView/DuffelNGSView.tsx
@@ -9,6 +9,7 @@ import {
 import { Icon } from "@components/shared/Icon";
 import { moneyStringFormatter } from "@lib/moneyStringFormatter";
 import classNames from "classnames";
+import { SliceCarriersTitle } from "@components/shared/SliceCarriersTitle";
 
 export interface DuffelNGSViewProps {
   offers: OfferWithNGS[];
@@ -30,7 +31,8 @@ export const DuffelNGSView: React.FC<DuffelNGSViewProps> = ({
     return null;
   }
 
-  // TODO Group offers by carrier, find offers per carrier for each shelf
+  // TODO Group offers by carrier and time
+  // find offers per carrier for each shelf
   const rows: NGSOfferRow[] = [
     {
       slice: offers[0].slices[sliceIndex],
@@ -82,8 +84,9 @@ export const DuffelNGSView: React.FC<DuffelNGSViewProps> = ({
         <tbody>
           {rows.map((row, index) => (
             <tr key={index}>
-              <td>
-                {row["slice"].id} TODO Carriers, Flight Summary, View Details
+              <td className="duffel-ngs-view_slice-info">
+                <SliceCarriersTitle slice={row["slice"]} />
+                <div>TODO Flight Summary</div>
               </td>
               {NGS_SHELVES.map((shelf) => (
                 <td

--- a/src/components/DuffelNGSView/lib/index.ts
+++ b/src/components/DuffelNGSView/lib/index.ts
@@ -6,7 +6,7 @@ import {
   OfferSliceSegmentPassenger,
 } from "@duffel/api/types";
 
-export const NGS_SHELVES = ["1", "2", "3", "4", "5", "6"] as const;
+export const NGS_SHELVES = ["1", "2", "3", "4", "5"] as const;
 export type NGSShelf = (typeof NGS_SHELVES)[number];
 
 // TODO([@andrejak)](https://github.com/andrejak)) These types are temporary until this is in the official API
@@ -29,7 +29,7 @@ type OfferSliceSegmentPassengerWithNGS = OfferSliceSegmentPassenger & {
 export type OfferSliceSegmentWithNGS = OfferSliceSegment & {
   passengers: OfferSliceSegmentPassengerWithNGS[];
 };
-type OfferSliceWithNGS = OfferSlice & {
+export type OfferSliceWithNGS = OfferSlice & {
   segments: OfferSliceSegmentWithNGS[];
   ngs_shelf: NGSShelf;
 };
@@ -121,19 +121,5 @@ export const NGS_SHELF_INFO: Record<NGSShelf, ShelfInfo> = {
     checked_bag: true,
     seat_selection: true,
     icon: "airline_seat_flat",
-  },
-  // We might not include the Ultra shelf in the API currently
-  "6": {
-    short_title: "Ultra",
-    full_title: "Ultra-Lux",
-    description:
-      "A luxury seat with a lie flat pod, seat selection, flexible change and cancellation options and checked baggage.",
-    seat: {
-      description: "Lie flat suite",
-      icon: SEAT_ICONS_MAP["Lie flat suite"],
-    },
-    checked_bag: true,
-    seat_selection: true,
-    icon: "airline_seat_individual_suite",
   },
 };

--- a/src/stories/DuffelNGSView.stories.tsx
+++ b/src/stories/DuffelNGSView.stories.tsx
@@ -15,7 +15,8 @@ export default {
 type DuffelNGSViewStory = StoryObj<typeof DuffelNGSView>;
 
 const defaultProps: DuffelNGSViewProps = {
-  offers: [offer], // TODO: generate a few more offers with realistic data for comparison
+  offers: [offer],
+  sliceIndex: 0, // TODO: generate a few more offers with realistic data for comparison
 };
 
 export const Default: DuffelNGSViewStory = {

--- a/src/styles/components/DuffelNGSView.css
+++ b/src/styles/components/DuffelNGSView.css
@@ -1,0 +1,66 @@
+.duffel-ngs-view_table {
+  border-radius: 4px;
+  border: 1px solid var(--GREY-100);
+  display: table;
+  border-collapse: collapse;
+
+  text-align: center;
+  cursor: pointer;
+}
+
+.duffel-ngs-view_table > thead {
+  color: var(--GREY-500);
+  background-color: var(--GREY-100);
+  font-size: 12px;
+  font-weight: 500;
+  height: 40px;
+}
+
+.duffel-ngs-view_table th:first-of-type {
+  border-top-left-radius: 4px;
+  border-left: 1px solid var(--GREY-100);
+}
+
+.duffel-ngs-view_table th:last-of-type {
+  border-top-right-radius: 4px;
+  border-right: 1px solid var(--GREY-100);
+}
+
+.duffel-ngs-view_table tbody:last-child tr:last-child td:first-child {
+  border-bottom-left-radius: 4px;
+}
+
+.duffel-ngs-view_table tbody:last-child tr:last-child td:last-child {
+  border-bottom-right-radius: 4px;
+}
+
+.duffel-ngs-view_table > tbody > tr {
+  border-top: 1px solid var(--GREY-100) !important;
+}
+
+.duffel-ngs-view_shelf-icon {
+  margin-right: 4px;
+}
+.duffel-ngs-view_column-header {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  padding: 0 16px;
+}
+
+.duffel-ngs-view_column-header--selected {
+  color: var(--GREY-900);
+  font-weight: 500;
+}
+
+.duffel-ngs-view_table-data {
+  padding: 16px;
+  font-size: 16px;
+  color: var(--GREY-500);
+  width: 115px;
+}
+
+.duffel-ngs-view_table-data--selected {
+  color: var(--GREY-900);
+  font-weight: 600;
+}

--- a/src/styles/components/DuffelNGSView.css
+++ b/src/styles/components/DuffelNGSView.css
@@ -41,6 +41,7 @@
 .duffel-ngs-view_shelf-icon {
   margin-right: 4px;
 }
+
 .duffel-ngs-view_column-header {
   display: flex;
   align-items: center;
@@ -63,4 +64,13 @@
 .duffel-ngs-view_table-data--selected {
   color: var(--GREY-900);
   font-weight: 600;
+}
+
+.duffel-ngs-view_slice-info {
+  padding: 24px 16px 20px 16px;
+  width: 300px;
+}
+
+.duffel-ngs-view_slice-info > div:first-child {
+  margin-bottom: 16px;
 }

--- a/src/styles/global.css
+++ b/src/styles/global.css
@@ -13,6 +13,7 @@
 @import "./components/CfarSelectionModal.css";
 @import "./components/Card.css";
 @import "./components/Counter.css";
+@import "./components/DuffelNGSView.css";
 @import "./components/DuffelPayments.css";
 @import "./components/IconButton.css";
 @import "./components/Legend.css";


### PR DESCRIPTION
This sets the foundation for the table view for desktop.

Currently using some fake tabular data while I'm waiting for some answers on the data structure. We could merge this as is to allow us to branch of and develop in parallel, or wait for that and sort out the offers structure in here before merging.

I've included column highlighting, but no sorting just yet. I've also left the first column as a TODO as the new components (carrier title, flight summary, whatever goes into "View details") will slot in there. 

<img width="971" alt="Screenshot 2024-01-25 at 13 46 15" src="https://github.com/duffelhq/duffel-components/assets/1416759/3f9adc80-a9d0-4dca-a9ba-4c4c1d6deaef">
<img width="976" alt="Screenshot 2024-01-25 at 13 46 30" src="https://github.com/duffelhq/duffel-components/assets/1416759/e867ebec-0908-44c2-95e1-0046f694589d">
