### PR TITLE
[UXP-3349] Detailed offer comparison for NGS

### DIFF
--- a/src/components/DuffelNGSView/DuffelNGSView.tsx
+++ b/src/components/DuffelNGSView/DuffelNGSView.tsx
@@ -53,7 +53,7 @@ const getNextShelf = (shelf: NGSShelf): NGSShelf | null => {
 
 const getPreviousOffer = (
   rows: NGSOfferRow[],
-  expandedOffer: OfferPosition
+  expandedOffer: OfferPosition,
 ): OfferWithNGS | null => {
   const previousShelf = getPreviousShelf(expandedOffer.shelf);
   if (!previousShelf) {
@@ -71,7 +71,7 @@ const getPreviousOffer = (
 
 const getNextOffer = (
   rows: NGSOfferRow[],
-  expandedOffer: OfferPosition
+  expandedOffer: OfferPosition,
 ): OfferWithNGS | null => {
   const nextShelf = getNextShelf(expandedOffer.shelf);
   if (!nextShelf) {
@@ -89,13 +89,13 @@ export const DuffelNGSView: React.FC<DuffelNGSViewProps> = ({
   sliceIndex,
 }) => {
   const [selectedColumn, setSelectedColumn] = React.useState<NGSShelf | null>(
-    null
+    null,
   );
   const [sortShelf, setSortShelf] = React.useState<NGSShelf | null>(null);
   const [sortDirection, setSortDirection] =
     React.useState<SortDirection>("asc");
   const [rows, setRows] = React.useState<NGSOfferRow[]>(
-    groupOffersForNGSView(offers, sliceIndex)
+    groupOffersForNGSView(offers, sliceIndex),
   );
   const [expandedOffer, setExpandedOffer] =
     React.useState<OfferPosition | null>(null);
@@ -134,7 +134,7 @@ export const DuffelNGSView: React.FC<DuffelNGSViewProps> = ({
                   className={classNames(
                     "duffel-ngs-view_column-header",
                     selectedColumn === shelf &&
-                      "duffel-ngs-view_column-header--selected"
+                      "duffel-ngs-view_column-header--selected",
                   )}
                 >
                   <Icon
@@ -199,12 +199,12 @@ export const DuffelNGSView: React.FC<DuffelNGSViewProps> = ({
                         "duffel-ngs-view_table-data--selected",
                       expandedOffer?.row === index &&
                         expandedOffer?.shelf === shelf &&
-                        "duffel-ngs-view_table-data--expanded"
+                        "duffel-ngs-view_table-data--expanded",
                     )}
                   >
                     {row[shelf]
                       ? moneyStringFormatter(row[shelf]!.total_currency)(
-                          +row[shelf]!.total_amount
+                          +row[shelf]!.total_amount,
                         )
                       : "-"}
                   </td>

--- a/src/components/DuffelNGSView/DuffelNGSView.tsx
+++ b/src/components/DuffelNGSView/DuffelNGSView.tsx
@@ -21,35 +21,15 @@ type OfferPosition = {
   shelf: NGSShelf;
 };
 
-const getPreviousShelf = (shelf: NGSShelf): NGSShelf | null => {
-  switch (shelf) {
-    case "1":
-      return null;
-    case "2":
-      return "1";
-    case "3":
-      return "2";
-    case "4":
-      return "3";
-    case "5":
-      return "4";
-  }
-};
+function getPreviousShelf(shelf: NGSShelf): NGSShelf | null {
+  const previousShelf = +shelf - 1;
+  return previousShelf === 0 ? null : (previousShelf.toString() as NGSShelf);
+}
 
-const getNextShelf = (shelf: NGSShelf): NGSShelf | null => {
-  switch (shelf) {
-    case "1":
-      return "2";
-    case "2":
-      return "3";
-    case "3":
-      return "4";
-    case "4":
-      return "5";
-    case "5":
-      return null;
-  }
-};
+function getNextShelf(shelf: NGSShelf): NGSShelf | null {
+  const nextShelf = +shelf + 1;
+  return nextShelf > 5 ? null : (nextShelf.toString() as NGSShelf);
+}
 
 const getPreviousOffer = (
   rows: NGSOfferRow[],

--- a/src/components/DuffelNGSView/NGSSliceFareCard.tsx
+++ b/src/components/DuffelNGSView/NGSSliceFareCard.tsx
@@ -15,6 +15,8 @@ export interface NGSSliceFareCardProps {
   selected?: boolean;
   onSelect?: () => void;
   compareToAmount?: number;
+
+  className?: string;
 }
 
 export const NGSSliceFareCard: React.FC<NGSSliceFareCardProps> = ({
@@ -23,6 +25,7 @@ export const NGSSliceFareCard: React.FC<NGSSliceFareCardProps> = ({
   selected,
   onSelect,
   compareToAmount,
+  className,
 }) => {
   if (sliceIndex >= offer.slices.length) {
     throw new Error(
@@ -78,7 +81,7 @@ export const NGSSliceFareCard: React.FC<NGSSliceFareCardProps> = ({
 
   return (
     <button
-      className="ngs-slice-fare-card_container"
+      className={classNames("ngs-slice-fare-card_container", className)}
       onClick={() => {
         onSelect && onSelect();
       }}

--- a/src/fixtures/offers/off_0000Adw9MD7yDHXIXxdjfG.json
+++ b/src/fixtures/offers/off_0000Adw9MD7yDHXIXxdjfG.json
@@ -85,7 +85,7 @@
     {
       "destination_type": "airport",
       "origin_type": "airport",
-      "fare_brand_name": "Basic",
+      "fare_brand_name": "Standard",
       "conditions": {
         "change_before_departure": {
           "penalty_currency": null,

--- a/src/lib/colors.ts
+++ b/src/lib/colors.ts
@@ -1,4 +1,5 @@
 export const colors = {
+  "--GREY-50": "#fbfbfd",
   "--GREY-100": "#f7f5f9",
   "--GREY-200": "#e2e2e8",
   "--GREY-300": "#e2e8f0",

--- a/src/stories/DuffelNGSView.stories.tsx
+++ b/src/stories/DuffelNGSView.stories.tsx
@@ -8,12 +8,18 @@ import {
 const offer = require("../fixtures/offers/off_0000Adw9MD7yDHXIXxdjfG.json");
 const cheapOffer = {
   ...offer,
-  slices: [{ ...offer.slices[0], ngs_shelf: 1 }, ...offer.slices.slice(1)],
+  slices: [
+    { ...offer.slices[0], ngs_shelf: 1, fare_brand_name: "Very Basic" },
+    ...offer.slices.slice(1),
+  ],
   total_amount: "100",
 };
 const expensiveOffer = {
   ...offer,
-  slices: [{ ...offer.slices[0], ngs_shelf: 5 }, ...offer.slices.slice(1)],
+  slices: [
+    { ...offer.slices[0], ngs_shelf: 5, fare_brand_name: "Business" },
+    ...offer.slices.slice(1),
+  ],
   total_amount: "10000",
 };
 const alternativeCheapOffer = {
@@ -29,6 +35,7 @@ const alternativeCheapOffer = {
         ...offer.slices[0].segments.slice(1),
       ],
       ngs_shelf: 1,
+      fare_brand_name: "Economy",
     },
     ...offer.slices.slice(1),
   ],
@@ -47,6 +54,7 @@ const alternativeExpensiveOffer = {
         ...offer.slices[0].segments.slice(1),
       ],
       ngs_shelf: 5,
+      fare_brand_name: "First",
     },
   ],
   total_amount: "20000",

--- a/src/styles/colors.css
+++ b/src/styles/colors.css
@@ -1,4 +1,5 @@
 .duffel-components {
+  --GREY-50: #fbfbfd;
   --GREY-100: #f7f5f9;
   --GREY-200: #e2e2e8;
   --GREY-300: #e2e8f0;

--- a/src/styles/components/DuffelNGSView.css
+++ b/src/styles/components/DuffelNGSView.css
@@ -78,3 +78,39 @@
 .duffel-ngs-view_slice-info > div:first-child {
   margin-bottom: 16px;
 }
+
+.duffel-ngs-view_expanded {
+  padding: 0;
+}
+
+.duffel-ngs-view_expanded > div {
+  background-color: var(--GREY-50);
+  padding: 32px;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+}
+
+.duffel-ngs-view_table-data--expanded {
+  background-color: var(--GREY-50);
+}
+
+.duffel-ngs-view_expanded .ngs-slice-fare-card_container {
+  background-color: white;
+}
+
+.duffel-ngs-view_expanded
+  .ngs-slice-fare-card_container
+  + .ngs-slice-fare-card_container {
+  margin-left: 32px;
+}
+
+.duffel-ngs-view_card--selected {
+  align-self: stretch;
+}
+
+/* Added important here to overwrite the slice card styles */
+.duffel-ngs-view_card--alternative {
+  margin-top: 8px !important;
+  margin-bottom: 8px !important;
+}


### PR DESCRIPTION
Adds slice fare card components to the table view to allow more detailed offer comparison:
<img width="1241" alt="Screenshot 2024-01-26 at 14 47 10" src="https://github.com/duffelhq/duffel-components/assets/1416759/363e9ff6-0238-44b5-b9b8-a39cab123b00">
<img width="1248" alt="Screenshot 2024-01-26 at 14 47 22" src="https://github.com/duffelhq/duffel-components/assets/1416759/1ad20eec-e0e3-460e-8fea-e4f78182d396">
