### PR TITLE
Non refundable rate indicator

### DIFF
--- a/src/components/Stays/StaysRoomRateCard.tsx
+++ b/src/components/Stays/StaysRoomRateCard.tsx
@@ -73,7 +73,7 @@ export const StaysRoomRateCard: React.FC<StaysRoomRateCardProps> = ({
               />
             )}
 
-            {earliestCancellation && (
+            {earliestCancellation ? (
               <StayResultRoomRateItem
                 icon="refund"
                 label={
@@ -94,6 +94,8 @@ export const StaysRoomRateCard: React.FC<StaysRoomRateCardProps> = ({
                   )
                 }
               />
+            ) : (
+              <StayResultRoomRateItem icon="close" label="Non-refundable" />
             )}
 
             {rate.available_payment_methods.map((paymentMethod) => (

--- a/src/fixtures/accommodation/acc_0000AWr2VsUNIF1Vl91xg0.json
+++ b/src/fixtures/accommodation/acc_0000AWr2VsUNIF1Vl91xg0.json
@@ -147,7 +147,7 @@
           ],
           "board_type": "all_inclusive",
           "payment_method": "card",
-          "available_payment_methods": ["card"],
+          "available_payment_methods": ["balance", "card"],
           "quantity_available": 1,
           "supported_loyalty_programme": "duffel_hotel_group_rewards"
         }

--- a/src/stories/StaysRoomRateCard.stories.tsx
+++ b/src/stories/StaysRoomRateCard.stories.tsx
@@ -3,7 +3,6 @@ import {
   StaysRoomRateCard,
   StaysRoomRateCardProps,
 } from "@components/Stays/StaysRoomRateCard";
-import { useState } from "react";
 import { StaysAccommodation } from "@duffel/api/types";
 
 /* eslint-disable @typescript-eslint/no-var-requires */
@@ -15,16 +14,14 @@ export default {
   component: StaysRoomRateCard,
 } as Meta;
 
-const Template: StoryFn<StaysRoomRateCardProps> = (args) => {
-  const [selected, setSelected] = useState(false);
+const Template: StoryFn<{ roomRates: StaysRoomRateCardProps[] }> = (args) => {
+  const { roomRates } = args;
 
   return (
-    <div style={{ maxWidth: "400px" }}>
-      <StaysRoomRateCard
-        {...args}
-        selected={selected}
-        onSelectRate={() => setSelected(!selected)}
-      />
+    <div style={{ display: "flex", gap: "16px", height: "300px" }}>
+      {roomRates.map((roomRate) => (
+        <StaysRoomRateCard {...roomRate} key={roomRate.rate.id} />
+      ))}
     </div>
   );
 };
@@ -33,8 +30,12 @@ export const Default = {
   render: Template,
 
   args: {
-    rate: accommodation.rooms[0].rates[0],
-    numberOfNights: 3,
+    roomRates: [
+      {
+        rate: accommodation.rooms[0].rates[0],
+        numberOfNights: 3,
+      },
+    ],
   },
 };
 
@@ -42,9 +43,20 @@ export const Variant = {
   render: Template,
 
   args: {
-    rate: { ...accommodation.rooms[0].rates[1] },
-    numberOfNights: 3,
-    searchNumberOfRooms: 2,
-    selected: true,
+    roomRates: [
+      {
+        rate: accommodation.rooms[0].rates[1],
+        numberOfNights: 3,
+        searchNumberOfRooms: 2,
+      },
+    ],
+  },
+};
+
+export const CrossComparison = {
+  render: Template,
+
+  args: {
+    roomRates: [...Default.args.roomRates, ...Variant.args.roomRates],
   },
 };

--- a/src/stories/StaysRoomRateCard.stories.tsx
+++ b/src/stories/StaysRoomRateCard.stories.tsx
@@ -3,6 +3,7 @@ import {
   StaysRoomRateCard,
   StaysRoomRateCardProps,
 } from "@components/Stays/StaysRoomRateCard";
+import { useState } from "react";
 import { StaysAccommodation } from "@duffel/api/types";
 
 /* eslint-disable @typescript-eslint/no-var-requires */
@@ -17,16 +18,23 @@ export default {
 const Template: StoryFn<{ roomRates: StaysRoomRateCardProps[] }> = (args) => {
   const { roomRates } = args;
 
+  const [selectedRate, setSelectedRate] = useState(roomRates[0].rate.id);
+
   return (
     <div style={{ display: "flex", gap: "16px", height: "300px" }}>
       {roomRates.map((roomRate) => (
-        <StaysRoomRateCard {...roomRate} key={roomRate.rate.id} />
+        <StaysRoomRateCard
+          {...roomRate}
+          key={roomRate.rate.id}
+          selected={roomRate.rate.id === selectedRate}
+          onSelectRate={() => setSelectedRate(roomRate.rate.id)}
+        />
       ))}
     </div>
   );
 };
 
-export const Default = {
+export const RateWithMinimalInformation = {
   render: Template,
 
   args: {
@@ -39,7 +47,7 @@ export const Default = {
   },
 };
 
-export const Variant = {
+export const RateWithCompleteInformation = {
   render: Template,
 
   args: {
@@ -53,10 +61,13 @@ export const Variant = {
   },
 };
 
-export const CrossComparison = {
+export const RatesCrossComparison = {
   render: Template,
 
   args: {
-    roomRates: [...Default.args.roomRates, ...Variant.args.roomRates],
+    roomRates: [
+      ...RateWithMinimalInformation.args.roomRates,
+      ...RateWithCompleteInformation.args.roomRates,
+    ],
   },
 };

--- a/src/styles/components/StaysRoomRateCard.css
+++ b/src/styles/components/StaysRoomRateCard.css
@@ -2,6 +2,7 @@
   display: flex;
   flex-direction: column;
   align-items: stretch;
+  justify-content: space-between;
   min-width: 270px;
   background-color: var(--WHITE);
   border: 1px solid var(--GREY-200);
@@ -31,7 +32,6 @@
 .stays-room-rate-card__content {
   padding: 20px;
   height: 100px;
-  margin-bottom: 40px;
 }
 
 .stays-room-rate-card__footer {


### PR DESCRIPTION
### What's here?

Rates that are non refundable now have a non-refundable indicator

![image](https://github.com/duffelhq/duffel-components/assets/6396347/3add60cf-ed83-4607-b14b-ca77225954a0)

I also threw in some changes to the story book that allows us to see cards side by side. This is because we may have reached the limit at which we can display rate differentiators in these cards, and a redesign will soon be warranted.

To see what this situation looks like, see two different rate cards below. One with fewer properties than the other.

![image](https://github.com/duffelhq/duffel-components/assets/6396347/e34e5b00-4d9f-4d2a-ba06-fea7b83e9152)


To fix this, the contained components' differentiators are now separated by "justify-content: space-between" instead of a fixed 40px margin to allow us to scale with different types of rate cards side by side.

It is important to take note that the parent must have a fixed height in order to accommodate the entirety of the content properly. Maybe we want to move the fixed height to the component itself.

![image](https://github.com/duffelhq/duffel-components/assets/6396347/5f9dcd15-a1ff-43f1-8ebc-3bc56f462313)

### Note

I would prefer to get https://github.com/duffelhq/duffel-components/pull/221 reviewed and merged first so I can add more cards on the side by side comparison and get a fully detailed card with all props loaded in ❤️ 


