### PR TITLE
[STAYS-1271] use available payment methods in stays rate card

### DIFF
--- a/package.json
+++ b/package.json
@@ -49,7 +49,7 @@
     "semver": "7.5.3"
   },
   "dependencies": {
-    "@duffel/api": "2.6.6",
+    "@duffel/api": "2.7.1",
     "@sentry/browser": "7.77.0",
     "@stripe/react-stripe-js": "2.1.0",
     "@stripe/stripe-js": "1.54.0",

--- a/src/components/Stays/StaysRoomRateCard.tsx
+++ b/src/components/Stays/StaysRoomRateCard.tsx
@@ -95,16 +95,18 @@ export const StaysRoomRateCard: React.FC<StaysRoomRateCardProps> = ({
                 }
               />
             )}
-            {rate.payment_method && (
+
+            {rate.available_payment_methods.map((paymentMethod) => (
               <StayResultRoomRateItem
-                icon={rate.payment_method === "card" ? "credit_card" : "wallet"}
+                key={paymentMethod}
+                icon={paymentMethod === "card" ? "credit_card" : "wallet"}
                 label={
-                  rate.payment_method === "card"
+                  paymentMethod === "card"
                     ? "Card payment at accommodation"
                     : "Pay now with Duffel Balance"
                 }
               />
-            )}
+            ))}
 
             {rate.supported_loyalty_programme && (
               <StayResultRoomRateItem

--- a/src/fixtures/accommodation/acc_0000AWr2VsUNIF1Vl91xg0.json
+++ b/src/fixtures/accommodation/acc_0000AWr2VsUNIF1Vl91xg0.json
@@ -110,6 +110,7 @@
           "cancellation_timeline": [],
           "board_type": "room_only",
           "payment_method": "balance",
+          "available_payment_methods": ["balance"],
           "quantity_available": 1,
           "supported_loyalty_programme": null
         },
@@ -146,6 +147,7 @@
           ],
           "board_type": "all_inclusive",
           "payment_method": "card",
+          "available_payment_methods": ["card"],
           "quantity_available": 1,
           "supported_loyalty_programme": "duffel_hotel_group_rewards"
         }

--- a/yarn.lock
+++ b/yarn.lock
@@ -2040,14 +2040,14 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@duffel/api@npm:2.6.6":
-  version: 2.6.6
-  resolution: "@duffel/api@npm:2.6.6"
+"@duffel/api@npm:2.7.1":
+  version: 2.7.1
+  resolution: "@duffel/api@npm:2.7.1"
   dependencies:
     "@types/node": "npm:^18.0.0"
     "@types/node-fetch": "npm:^2.6.2"
     node-fetch: "npm:2.7.0"
-  checksum: 9b8f6903b61a6f39c73bc03d4e07b735cd78f9124e874a9fdb87957b1e697040123d75b84eca8baf852b956a587753b6314876e5c8ff85011e81d399e520d887
+  checksum: e8429f6163373fe489b8ab962ae2816e5376fe6b2a9209d0846057194cddd112f8c8b5951256db97115c529551fd9a8d2c83560557f153f4ca3a8de3233653c6
   languageName: node
   linkType: hard
 
@@ -2060,7 +2060,7 @@ __metadata:
     "@babel/preset-env": "npm:7.21.4"
     "@babel/preset-react": "npm:7.18.6"
     "@babel/preset-typescript": "npm:7.21.4"
-    "@duffel/api": "npm:2.6.6"
+    "@duffel/api": "npm:2.7.1"
     "@sentry/browser": "npm:7.77.0"
     "@sentry/cli": "npm:2.21.2"
     "@sentry/esbuild-plugin": "npm:0.7.2"


### PR DESCRIPTION
We now return an array of available payment methods in the API. We should display all of the options to the customer on the rate card.

We will not actually return multiple payment methods for a rate at this point, so this is mainly futureproofing for later development. 

Also bumps the version of the JS API so we get the correct values from the API.

<img width="371" alt="Screenshot 2024-01-29 at 11 00 24" src="https://github.com/duffelhq/duffel-components/assets/1478292/ead5351e-4c27-4990-83f4-5dbaf5b03c38">