### PR TITLE
Bumps version for rate differentiators

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@duffel/components",
-  "version": "3.4.3",
+  "version": "3.4.4",
   "description": "Component library to build your travel product with Duffel.",
   "keywords": [
     "Duffel",


### PR DESCRIPTION
### What's here?

This bumps package.json to prep a release that includes #221 and #219 