### PR TITLE
Seat map fixes

### DIFF
--- a/src/components/DuffelAncillaries/seats/SeatSelectionCard.tsx
+++ b/src/components/DuffelAncillaries/seats/SeatSelectionCard.tsx
@@ -15,6 +15,7 @@ import {
   SeatMap,
 } from "@duffel/api/types";
 import { WithServiceInformation } from "src/types";
+import { hasAvailableSeatService } from "@lib/hasAvailableSeatService";
 
 export interface SeatSelectionCardProps {
   isLoading: boolean;
@@ -23,7 +24,7 @@ export interface SeatSelectionCardProps {
   passengers: CreateOrder["passengers"];
   selectedServices: WithServiceInformation<CreateOrderService>[];
   setSelectedServices: (
-    selectedServices: WithServiceInformation<CreateOrderService>[],
+    selectedServices: WithServiceInformation<CreateOrderService>[]
   ) => void;
 }
 
@@ -37,14 +38,14 @@ export const SeatSelectionCard: React.FC<SeatSelectionCardProps> = ({
 }) => {
   const [isOpen, setIsOpen] = React.useState(false);
 
-  const containsSeatService = Array.isArray(seatMaps) && seatMaps.length > 0;
+  const containsSeatService = hasAvailableSeatService(seatMaps);
   const totalQuantity = getTotalQuantity(selectedServices);
   const areSeatsAdded = totalQuantity > 0;
 
   const totalAmount = getTotalAmountForServices(
     offer!,
     selectedServices,
-    seatMaps,
+    seatMaps
   );
   let currencyToUse = offer?.base_currency ?? "";
   if (seatMaps) {
@@ -60,7 +61,7 @@ export const SeatSelectionCard: React.FC<SeatSelectionCardProps> = ({
       ? `${withPlural(
           totalQuantity,
           "seat",
-          "seats",
+          "seats"
         )} selected for ${totalAmountFormatted}`
       : "Specify where on the plane you’d like to sit";
 
@@ -73,7 +74,7 @@ export const SeatSelectionCard: React.FC<SeatSelectionCardProps> = ({
         icon="flight_class"
         onClick={containsSeatService ? () => setIsOpen(true) : null}
         isLoading={isLoading}
-        disabled={isLoading && !containsSeatService}
+        disabled={!isLoading && !containsSeatService}
         isSelected={areSeatsAdded}
       >
         {isLoading && (

--- a/src/components/DuffelAncillaries/seats/SeatSelectionCard.tsx
+++ b/src/components/DuffelAncillaries/seats/SeatSelectionCard.tsx
@@ -24,7 +24,7 @@ export interface SeatSelectionCardProps {
   passengers: CreateOrder["passengers"];
   selectedServices: WithServiceInformation<CreateOrderService>[];
   setSelectedServices: (
-    selectedServices: WithServiceInformation<CreateOrderService>[]
+    selectedServices: WithServiceInformation<CreateOrderService>[],
   ) => void;
 }
 
@@ -45,7 +45,7 @@ export const SeatSelectionCard: React.FC<SeatSelectionCardProps> = ({
   const totalAmount = getTotalAmountForServices(
     offer!,
     selectedServices,
-    seatMaps
+    seatMaps,
   );
   let currencyToUse = offer?.base_currency ?? "";
   if (seatMaps) {
@@ -61,7 +61,7 @@ export const SeatSelectionCard: React.FC<SeatSelectionCardProps> = ({
       ? `${withPlural(
           totalQuantity,
           "seat",
-          "seats"
+          "seats",
         )} selected for ${totalAmountFormatted}`
       : "Specify where on the plane you’d like to sit";
 

--- a/src/components/DuffelAncillaries/seats/SeatSelectionCard.tsx
+++ b/src/components/DuffelAncillaries/seats/SeatSelectionCard.tsx
@@ -1,21 +1,21 @@
 import { AnimatedLoaderEllipsis } from "@components/shared/AnimatedLoaderEllipsis";
 import { Stamp } from "@components/shared/Stamp";
-import { getCurrencyForSeatMaps } from "@lib/getCurrencyForSeatMaps";
-import { getTotalAmountForServices } from "@lib/getTotalAmountForServices";
-import { getTotalQuantity } from "@lib/getTotalQuantity";
-import { moneyStringFormatter } from "@lib/moneyStringFormatter";
-import { withPlural } from "@lib/withPlural";
-import React from "react";
-import { Card } from "../Card";
-import { SeatSelectionModal } from "./SeatSelectionModal";
 import {
   CreateOrder,
   CreateOrderService,
   Offer,
   SeatMap,
 } from "@duffel/api/types";
-import { WithServiceInformation } from "src/types";
+import { getCurrencyForSeatMaps } from "@lib/getCurrencyForSeatMaps";
+import { getTotalAmountForServices } from "@lib/getTotalAmountForServices";
+import { getTotalQuantity } from "@lib/getTotalQuantity";
 import { hasAvailableSeatService } from "@lib/hasAvailableSeatService";
+import { moneyStringFormatter } from "@lib/moneyStringFormatter";
+import { withPlural } from "@lib/withPlural";
+import React from "react";
+import { WithServiceInformation } from "src/types";
+import { Card } from "../Card";
+import { SeatSelectionModal } from "./SeatSelectionModal";
 
 export interface SeatSelectionCardProps {
   isLoading: boolean;
@@ -24,7 +24,7 @@ export interface SeatSelectionCardProps {
   passengers: CreateOrder["passengers"];
   selectedServices: WithServiceInformation<CreateOrderService>[];
   setSelectedServices: (
-    selectedServices: WithServiceInformation<CreateOrderService>[],
+    selectedServices: WithServiceInformation<CreateOrderService>[]
   ) => void;
 }
 
@@ -45,7 +45,7 @@ export const SeatSelectionCard: React.FC<SeatSelectionCardProps> = ({
   const totalAmount = getTotalAmountForServices(
     offer!,
     selectedServices,
-    seatMaps,
+    seatMaps
   );
   let currencyToUse = offer?.base_currency ?? "";
   if (seatMaps) {
@@ -61,7 +61,7 @@ export const SeatSelectionCard: React.FC<SeatSelectionCardProps> = ({
       ? `${withPlural(
           totalQuantity,
           "seat",
-          "seats",
+          "seats"
         )} selected for ${totalAmountFormatted}`
       : "Specify where on the plane you’d like to sit";
 

--- a/src/lib/hasAvailableSeatService.ts
+++ b/src/lib/hasAvailableSeatService.ts
@@ -1,0 +1,24 @@
+import { SeatMap } from "@duffel/api/types";
+
+export function hasAvailableSeatService(seatMaps?: SeatMap[]): boolean {
+  if (!Array.isArray(seatMaps) || seatMaps.length === 0) return false;
+
+  for (const seatMap of seatMaps) {
+    for (const cabin of seatMap.cabins) {
+      for (const rows of cabin.rows) {
+        for (const section of rows.sections) {
+          for (const element of section.elements) {
+            if (
+              element.type === "seat" &&
+              element.available_services.length > 0
+            ) {
+              return true;
+            }
+          }
+        }
+      }
+    }
+  }
+
+  return false;
+}

--- a/src/stories/DuffelAncillaries.stories.tsx
+++ b/src/stories/DuffelAncillaries.stories.tsx
@@ -163,3 +163,10 @@ export const WithWhiteAccentColorSet: StoryFn<
     styles={{ accentColor: "255, 255, 255" }}
   />
 );
+
+export const NoSeatMaps: DuffelAncillariesStory = {
+  args: {
+    ...defaultProps,
+    seat_maps: [],
+  },
+};

--- a/src/styles/components/Card.css
+++ b/src/styles/components/Card.css
@@ -1,7 +1,8 @@
 .ancillary-card:disabled {
-  color: inherit;
-  cursor: not-allowed;
-  background-color: var(--GREY-100);
+  /* important needed to take prescedence over default button styles */
+  color: inherit !important;
+  cursor: not-allowed !important;
+  background-color: var(--GREY-100) !important;
 }
 
 .ancillary-card--loading:disabled {

--- a/src/styles/components/Card.css
+++ b/src/styles/components/Card.css
@@ -1,5 +1,5 @@
 .ancillary-card:disabled {
-  /* important needed to take prescedence over default button styles */
+  /* important needed to take precedence over default button styles */
   color: inherit !important;
   cursor: not-allowed !important;
   background-color: var(--GREY-100) !important;

--- a/src/tests/lib/hasAvailableSeatService.test.tsx
+++ b/src/tests/lib/hasAvailableSeatService.test.tsx
@@ -1,0 +1,66 @@
+import { SeatMap } from "@duffel/api/types";
+import { hasAvailableSeatService } from "@lib/hasAvailableSeatService";
+
+describe("hasAvailableSeatService", () => {
+  it("should return false when seatMaps is undefined", () => {
+    expect(hasAvailableSeatService()).toBe(false);
+  });
+
+  it("should return false when seatMaps is an empty array", () => {
+    expect(hasAvailableSeatService([])).toBe(false);
+  });
+
+  it("should return false when seatMaps do not contain any seat with available services", () => {
+    const seatMaps: SeatMap[] = [
+      {
+        cabins: [
+          {
+            rows: [
+              {
+                sections: [
+                  {
+                    elements: [
+                      {
+                        type: "seat",
+                        available_services: [],
+                      },
+                    ],
+                  },
+                ],
+              },
+            ],
+          },
+        ],
+      } as any,
+    ];
+    const result = hasAvailableSeatService(seatMaps);
+    expect(result).toBe(false);
+  });
+
+  it("should return true when seatMaps contain a seat with available services", () => {
+    const seatMaps: SeatMap[] = [
+      {
+        cabins: [
+          {
+            rows: [
+              {
+                sections: [
+                  {
+                    elements: [
+                      {
+                        type: "seat",
+                        available_services: ["service1", "service2"],
+                      },
+                    ],
+                  },
+                ],
+              },
+            ],
+          },
+        ],
+      } as any,
+    ];
+    const result = hasAvailableSeatService(seatMaps);
+    expect(result).toBe(true);
+  });
+});


### PR DESCRIPTION
__what__

This PR corrects the disable state of the seat map card.  

1. It should not show the hover state when the button is disabled. [Reported issue here](https://github.com/duffelhq/duffel-components/issues/214)
2. It should disable the card if there's no available services, even when the seat map is returned. [Reported issue here](https://github.com/duffelhq/duffel-components/issues/213)