### PR TITLE
update descriptions for plus, premium and lux shelves

### DIFF
--- a/src/components/DuffelNGSView/lib/index.ts
+++ b/src/components/DuffelNGSView/lib/index.ts
@@ -26,23 +26,23 @@ export const NGS_SHELF_INFO: Record<OfferSlice["ngs_shelf"], ShelfInfo> = {
   },
   3: {
     short_title: "Plus",
-    full_title: "Economy Plus",
+    full_title: "Plus",
     description:
-      "Economy seats with extra leg room that allow seat selection, flexible change and cancellation options and checked baggage.",
+      "Preferred seating that offer more comfort to passengers, such as additional legroom, width or having the middle seat free for the row.",
     icon: "airline_seat_legroom_extra",
   },
   4: {
     short_title: "Premium",
-    full_title: "Premium Economy",
+    full_title: "Premium",
     description:
-      "Premium seats that have a recliner seat type, allow seat selection, flexible change and cancellation options and checked baggage.",
+      "Premium seating with additional legroom and recline. Seats shall be typically situated in the business class cabin or higher.",
     icon: "airline_seat_recline_extra",
   },
   5: {
     short_title: "Luxury",
     full_title: "Luxury",
     description:
-      "A luxury seat with a lie flat bed, seat selection, flexible change and cancellation options and checked baggage.",
+      "Luxury seating with additional legroom and reclines to a lie flat position. Seats shall be typically situated in business class or higher.",
     icon: "airline_seat_flat",
   },
 };

--- a/src/components/DuffelNGSView/lib/index.ts
+++ b/src/components/DuffelNGSView/lib/index.ts
@@ -28,7 +28,7 @@ export const NGS_SHELF_INFO: Record<OfferSlice["ngs_shelf"], ShelfInfo> = {
     short_title: "Plus",
     full_title: "Plus",
     description:
-      "Preferred seating that offer more comfort to passengers, such as additional legroom, width or having the middle seat free for the row.",
+      "Preferred seating that offers more comfort to passengers, such as additional legroom, width or having the middle seat free for the row.",
     icon: "airline_seat_legroom_extra",
   },
   4: {


### PR DESCRIPTION
## Overview

Updates the descriptions of the `plus`, `premium` and `lux` shelves in the NGS view so that they no longer reference economy or advance seat selection / other perks. This is due to how the weird NGS calculation works and while we expect these high value seats to have these perks, we can't guarantee it. 