### PR TITLE
Card form custom element

### DIFF
--- a/.yarn/sdks/prettier/package.json
+++ b/.yarn/sdks/prettier/package.json
@@ -1,6 +1,6 @@
 {
   "name": "prettier",
-  "version": "3.2.4-sdk",
+  "version": "3.2.5-sdk",
   "main": "./index.cjs",
   "type": "commonjs",
   "bin": "./bin/prettier.cjs"

--- a/config/esbuild.base.config.js
+++ b/config/esbuild.base.config.js
@@ -9,6 +9,10 @@ module.exports = {
       out: "duffel-payments",
       in: "src/components/DuffelPayments/DuffelPaymentsCustomElement.tsx",
     },
+    {
+      out: "duffel-card-form",
+      in: "src/components/DuffelCardForm/DuffelCardFormCustomElement.tsx",
+    },
     // Created a new custom element wrapper for a components
     // and want to make it available on the CDN? Add it here.
   ],

--- a/examples/card-form-no-react/index.html
+++ b/examples/card-form-no-react/index.html
@@ -1,0 +1,47 @@
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+
+    <title>Card Form integration example</title>
+  </head>
+  <body style="height: 100vh">
+    <h1>Card Form integration example</h1>
+
+    <!-- 1. Add the custom element to your markup -->
+    <duffel-card-form></duffel-card-form>
+
+    <button onclick="createCardForTemporaryUse()">
+      Create card for temporary use
+    </button>
+
+    <button onclick="saveCard()">Save card</button>
+  </body>
+
+  <!-- 2. Load the script -->
+  <script
+    type="text/javascript"
+    src="http://127.0.0.1:8000/duffel-card-form.js"
+  ></script>
+  <!-- Alternatively, if you want to run this example with the live version use the script below instead -->
+  <!-- <script type="text/javascript" src="http://assets.duffel.com/traveller-support/custom-element.js"></script> -->
+
+  <!-- 3. Enable open function once window is loaded -->
+  <script type="text/javascript">
+    window.onload = () => {
+      renderDuffelCardFormCustomElement({
+        clientKey: "__COMPONENT_CLIENT_KEY__",
+        intent: "to-create-card-for-temporary-use",
+      });
+
+      onValidateSuccess(console.info);
+      onValidateFailure(console.error);
+
+      onCreateCardForTemporaryUseSuccess(console.info);
+      onCreateCardForTemporaryUseFailure(console.error);
+
+      onSaveCardSuccess(console.info);
+      onSaveCardFailure(console.error);
+    };
+  </script>
+</html>

--- a/examples/card-form-no-react/server.mjs
+++ b/examples/card-form-no-react/server.mjs
@@ -1,0 +1,81 @@
+import http from "http";
+import { fileURLToPath } from "url";
+import { dirname, resolve } from "path";
+import { readFile } from "fs/promises";
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+
+if (process.env.DUFFEL_API_URL === undefined) {
+  throw new Error(
+    "process.env.DUFFEL_API_URL is required to run this example but one is not present in the environment.\n Make sure to include one in you `.env.local`\n"
+  );
+}
+
+if (process.env.DUFFEL_API_TOKEN === undefined) {
+  throw new Error(
+    "process.env.DUFFEL_API_URL is required to run this example but one is not present in the environment.\n Make sure to include one in you `.env.local`\n"
+  );
+}
+
+if (process.env.DUFFEL_API_URL === "https://localhost:4000") {
+  process.env.NODE_TLS_REJECT_UNAUTHORIZED = "0";
+}
+
+const HTML_FILE_PATH = resolve(__dirname, "./index.html");
+
+async function getComponentClientKey() {
+  const response = await fetch(
+    `${process.env.DUFFEL_API_URL}/identity/component_client_keys`,
+    {
+      method: "POST",
+      headers: {
+        "Duffel-Version": "v1",
+        "Accept-Encoding": "gzip",
+        Accept: "application/json",
+        "Content-Type": "application/json",
+        Authorization: `Bearer ${process.env.DUFFEL_API_TOKEN}`,
+      },
+    }
+  );
+
+  const { data } = await response.json();
+  return data.component_client_key;
+}
+
+async function getHTML() {
+  return await readFile(HTML_FILE_PATH, {
+    encoding: "utf-8",
+  });
+}
+
+const SERVER_ROUTES = {
+  "/": async function (_request, response) {
+    try {
+      const componentClientKey = await getComponentClientKey();
+      const template = await getHTML();
+
+      response.writeHead(200);
+      response.end(
+        template.replace("__COMPONENT_CLIENT_KEY__", componentClientKey)
+      );
+    } catch (error) {
+      console.error(error);
+      response.writeHead(500);
+      response.end(error.message);
+    }
+  },
+};
+
+const PORT = 3000;
+http
+  .createServer(function (request, response) {
+    if (request.url in SERVER_ROUTES) {
+      return SERVER_ROUTES[request.url](request, response);
+    }
+
+    response.writeHead(404);
+    response.end(http.STATUS_CODES[404]);
+  })
+  .listen(PORT);
+
+console.log(`\nServing example on http://localhost:${PORT}`);

--- a/examples/card-form-no-react/server.mjs
+++ b/examples/card-form-no-react/server.mjs
@@ -7,13 +7,13 @@ const __dirname = dirname(fileURLToPath(import.meta.url));
 
 if (process.env.DUFFEL_API_URL === undefined) {
   throw new Error(
-    "process.env.DUFFEL_API_URL is required to run this example but one is not present in the environment.\n Make sure to include one in you `.env.local`\n"
+    "process.env.DUFFEL_API_URL is required to run this example but one is not present in the environment.\n Make sure to include one in you `.env.local`\n",
   );
 }
 
 if (process.env.DUFFEL_API_TOKEN === undefined) {
   throw new Error(
-    "process.env.DUFFEL_API_URL is required to run this example but one is not present in the environment.\n Make sure to include one in you `.env.local`\n"
+    "process.env.DUFFEL_API_URL is required to run this example but one is not present in the environment.\n Make sure to include one in you `.env.local`\n",
   );
 }
 
@@ -35,7 +35,7 @@ async function getComponentClientKey() {
         "Content-Type": "application/json",
         Authorization: `Bearer ${process.env.DUFFEL_API_TOKEN}`,
       },
-    }
+    },
   );
 
   const { data } = await response.json();
@@ -56,7 +56,7 @@ const SERVER_ROUTES = {
 
       response.writeHead(200);
       response.end(
-        template.replace("__COMPONENT_CLIENT_KEY__", componentClientKey)
+        template.replace("__COMPONENT_CLIENT_KEY__", componentClientKey),
       );
     } catch (error) {
       console.error(error);

--- a/src/components/DuffelCardForm/DuffelCardFormCustomElement.tsx
+++ b/src/components/DuffelCardForm/DuffelCardFormCustomElement.tsx
@@ -80,7 +80,7 @@ class DuffelCardFormCustomElement extends HTMLElement {
       withProps.tokenProxyEnvironment,
       withProps.intent,
       withProps.clientKey,
-      withProps.savedCardData
+      withProps.savedCardData,
     );
 
     this.root.render(
@@ -90,14 +90,14 @@ class DuffelCardFormCustomElement extends HTMLElement {
           this.dispatchEvent(
             new CustomEvent("onValidateSuccess", {
               composed: true,
-            })
+            }),
           )
         }
         onValidateFailure={() =>
           this.dispatchEvent(
             new CustomEvent("onValidateFailure", {
               composed: true,
-            })
+            }),
           )
         }
         onSaveCardSuccess={(data) =>
@@ -105,7 +105,7 @@ class DuffelCardFormCustomElement extends HTMLElement {
             new CustomEvent("onSaveCardSuccess", {
               detail: { data },
               composed: true,
-            })
+            }),
           )
         }
         onSaveCardFailure={(error) =>
@@ -113,7 +113,7 @@ class DuffelCardFormCustomElement extends HTMLElement {
             new CustomEvent("onSaveCardFailure", {
               detail: { error },
               composed: true,
-            })
+            }),
           )
         }
         onCreateCardForTemporaryUseSuccess={(data) =>
@@ -121,7 +121,7 @@ class DuffelCardFormCustomElement extends HTMLElement {
             new CustomEvent("onCreateCardForTemporaryUseSuccess", {
               detail: { data },
               composed: true,
-            })
+            }),
           )
         }
         onCreateCardForTemporaryUseFailure={(error) =>
@@ -129,10 +129,10 @@ class DuffelCardFormCustomElement extends HTMLElement {
             new CustomEvent("onCreateCardForTemporaryUseFailure", {
               detail: { error },
               composed: true,
-            })
+            }),
           )
         }
-      />
+      />,
     );
   }
 
@@ -159,14 +159,14 @@ function tryToGetCustomElement(caller: string): DuffelCardFormCustomElement {
     document.querySelector<DuffelCardFormCustomElement>(CUSTOM_ELEMENT_TAG);
   if (!element) {
     throw new Error(
-      `Could not find ${CUSTOM_ELEMENT_TAG} element in the DOM. Maybe you need to call ${caller} after 'window.onload'?`
+      `Could not find ${CUSTOM_ELEMENT_TAG} element in the DOM. Maybe you need to call ${caller} after 'window.onload'?`,
     );
   }
   return element;
 }
 
 export function renderDuffelCardFormCustomElement(
-  props: DuffelCardFormCustomElementRenderArguments
+  props: DuffelCardFormCustomElementRenderArguments,
 ) {
   const element = tryToGetCustomElement("renderDuffelCardFormCustomElement");
   element.render(props);
@@ -194,11 +194,11 @@ type DuffelCardFormPropActions = Pick<
 
 function registerCallbackFactory<T extends keyof DuffelCardFormPropActions>(
   eventPropName: T,
-  eventDetailArgumentName?: string
+  eventDetailArgumentName?: string,
 ) {
   return function (callback: NonNullable<DuffelCardFormPropActions[T]>) {
     const element = tryToGetCustomElement(
-      `registerCallbackFactory(${eventPropName})`
+      `registerCallbackFactory(${eventPropName})`,
     );
 
     element.addEventListener(eventPropName, (event) => {
@@ -220,22 +220,22 @@ export const onValidateFailure = registerCallbackFactory("onValidateFailure");
 
 export const onSaveCardSuccess = registerCallbackFactory(
   "onSaveCardSuccess",
-  "data"
+  "data",
 );
 
 export const onSaveCardFailure = registerCallbackFactory(
   "onSaveCardFailure",
-  "error"
+  "error",
 );
 
 export const onCreateCardForTemporaryUseSuccess = registerCallbackFactory(
   "onCreateCardForTemporaryUseSuccess",
-  "data"
+  "data",
 );
 
 export const onCreateCardForTemporaryUseFailure = registerCallbackFactory(
   "onCreateCardForTemporaryUseFailure",
-  "error"
+  "error",
 );
 
 window.renderDuffelCardFormCustomElement = renderDuffelCardFormCustomElement;

--- a/src/components/DuffelCardForm/DuffelCardFormCustomElement.tsx
+++ b/src/components/DuffelCardForm/DuffelCardFormCustomElement.tsx
@@ -1,0 +1,249 @@
+import * as React from "react";
+import { createRoot, Root } from "react-dom/client";
+import { DuffelCardForm } from "./DuffelCardForm";
+import { DuffelCardFormProps } from "./lib/types";
+import { getIframeURL } from "./lib/getIframeURL";
+import { postMessageToSaveCard } from "./lib/postMessageToSaveCard";
+import { postMessageToCreateCardForTemporaryUse } from "./lib/postMessageToCreateCardForTemporaryUse";
+
+const CUSTOM_ELEMENT_TAG = "duffel-card-form";
+
+type DuffelCardFormCustomElementRenderArguments = Pick<
+  DuffelCardFormProps,
+  "clientKey" | "intent" | "savedCardData" | "styles" | "tokenProxyEnvironment"
+>;
+
+declare global {
+  // eslint-disable-next-line @typescript-eslint/no-namespace
+  namespace JSX {
+    interface IntrinsicElements {
+      [CUSTOM_ELEMENT_TAG]: React.DetailedHTMLProps<
+        React.HTMLAttributes<HTMLElement>,
+        HTMLElement
+      >;
+    }
+  }
+
+  interface Window {
+    renderDuffelCardFormCustomElement: typeof renderDuffelCardFormCustomElement;
+    saveCard: typeof saveCard;
+    createCardForTemporaryUse: typeof createCardForTemporaryUse;
+    onValidateSuccess: typeof onValidateSuccess;
+    onValidateFailure: typeof onValidateFailure;
+    onSaveCardSuccess: typeof onSaveCardSuccess;
+    onSaveCardFailure: typeof onSaveCardFailure;
+    onCreateCardForTemporaryUseSuccess: typeof onCreateCardForTemporaryUseSuccess;
+    onCreateCardForTemporaryUseFailure: typeof onCreateCardForTemporaryUseFailure;
+  }
+}
+
+class DuffelCardFormCustomElement extends HTMLElement {
+  /**
+   * The React root for displaying content inside a browser DOM element.
+   */
+  private root!: Root;
+
+  /**
+   * the shadow root where the component will be rendered
+   */
+  shadowRoot!: ShadowRoot;
+
+  iFrameURL!: URL;
+
+  /**
+   * `connectedCallback` is called to initialise the custom element
+   */
+  connectedCallback() {
+    this.shadowRoot = this.attachShadow({ mode: "open" });
+
+    const container = document.createElement("div");
+    this.shadowRoot.appendChild(container);
+
+    this.root = createRoot(container);
+  }
+
+  private getIframe() {
+    const iframe = this.shadowRoot.querySelector("iframe");
+    return iframe;
+  }
+
+  /**
+   * When this function is called, it will render/re-render
+   * the component with the given props.
+   */
+  public render(withProps: DuffelCardFormCustomElementRenderArguments) {
+    if (!this.root) {
+      throw `It was not possible to render ${CUSTOM_ELEMENT_TAG} because 'this.root' is missing.`;
+    }
+
+    this.iFrameURL = getIframeURL(
+      withProps.tokenProxyEnvironment,
+      withProps.intent,
+      withProps.clientKey,
+      withProps.savedCardData
+    );
+
+    this.root.render(
+      <DuffelCardForm
+        {...withProps}
+        onValidateSuccess={() =>
+          this.dispatchEvent(
+            new CustomEvent("onValidateSuccess", {
+              composed: true,
+            })
+          )
+        }
+        onValidateFailure={() =>
+          this.dispatchEvent(
+            new CustomEvent("onValidateFailure", {
+              composed: true,
+            })
+          )
+        }
+        onSaveCardSuccess={(data) =>
+          this.dispatchEvent(
+            new CustomEvent("onSaveCardSuccess", {
+              detail: { data },
+              composed: true,
+            })
+          )
+        }
+        onSaveCardFailure={(error) =>
+          this.dispatchEvent(
+            new CustomEvent("onSaveCardFailure", {
+              detail: { error },
+              composed: true,
+            })
+          )
+        }
+        onCreateCardForTemporaryUseSuccess={(data) =>
+          this.dispatchEvent(
+            new CustomEvent("onCreateCardForTemporaryUseSuccess", {
+              detail: { data },
+              composed: true,
+            })
+          )
+        }
+        onCreateCardForTemporaryUseFailure={(error) =>
+          this.dispatchEvent(
+            new CustomEvent("onCreateCardForTemporaryUseFailure", {
+              detail: { error },
+              composed: true,
+            })
+          )
+        }
+      />
+    );
+  }
+
+  public saveCard() {
+    const iframe = this.getIframe();
+    if (!iframe) throw new Error("Could not find iframe");
+
+    postMessageToSaveCard({ current: iframe }, this.iFrameURL);
+  }
+
+  public createCardForTemporaryUse() {
+    const iframe = this.getIframe();
+    if (!iframe) throw new Error("Could not find iframe");
+
+    postMessageToCreateCardForTemporaryUse({ current: iframe }, this.iFrameURL);
+  }
+}
+
+window.customElements.get(CUSTOM_ELEMENT_TAG) ||
+  window.customElements.define(CUSTOM_ELEMENT_TAG, DuffelCardFormCustomElement);
+
+function tryToGetCustomElement(caller: string): DuffelCardFormCustomElement {
+  const element =
+    document.querySelector<DuffelCardFormCustomElement>(CUSTOM_ELEMENT_TAG);
+  if (!element) {
+    throw new Error(
+      `Could not find ${CUSTOM_ELEMENT_TAG} element in the DOM. Maybe you need to call ${caller} after 'window.onload'?`
+    );
+  }
+  return element;
+}
+
+export function renderDuffelCardFormCustomElement(
+  props: DuffelCardFormCustomElementRenderArguments
+) {
+  const element = tryToGetCustomElement("renderDuffelCardFormCustomElement");
+  element.render(props);
+}
+
+export function saveCard() {
+  const element = tryToGetCustomElement("saveCard");
+  element.saveCard();
+}
+
+export function createCardForTemporaryUse() {
+  const element = tryToGetCustomElement("createCardForTemporaryUse");
+  element.createCardForTemporaryUse();
+}
+
+type DuffelCardFormPropActions = Pick<
+  DuffelCardFormProps,
+  | "onValidateSuccess"
+  | "onValidateFailure"
+  | "onSaveCardSuccess"
+  | "onSaveCardFailure"
+  | "onCreateCardForTemporaryUseSuccess"
+  | "onCreateCardForTemporaryUseFailure"
+>;
+
+function registerCallbackFactory<T extends keyof DuffelCardFormPropActions>(
+  eventPropName: T,
+  eventDetailArgumentName?: string
+) {
+  return function (callback: NonNullable<DuffelCardFormPropActions[T]>) {
+    const element = tryToGetCustomElement(
+      `registerCallbackFactory(${eventPropName})`
+    );
+
+    element.addEventListener(eventPropName, (event) => {
+      const eventDetail = (event as CustomEvent).detail;
+      if (eventDetailArgumentName) {
+        callback(eventDetail[eventDetailArgumentName]);
+      } else {
+        // Using as never here to reinforce to typescript that
+        // no value will be passed to the callback
+        callback(undefined as never);
+      }
+    });
+  };
+}
+
+export const onValidateSuccess = registerCallbackFactory("onValidateSuccess");
+
+export const onValidateFailure = registerCallbackFactory("onValidateFailure");
+
+export const onSaveCardSuccess = registerCallbackFactory(
+  "onSaveCardSuccess",
+  "data"
+);
+
+export const onSaveCardFailure = registerCallbackFactory(
+  "onSaveCardFailure",
+  "error"
+);
+
+export const onCreateCardForTemporaryUseSuccess = registerCallbackFactory(
+  "onCreateCardForTemporaryUseSuccess",
+  "data"
+);
+
+export const onCreateCardForTemporaryUseFailure = registerCallbackFactory(
+  "onCreateCardForTemporaryUseFailure",
+  "error"
+);
+
+window.renderDuffelCardFormCustomElement = renderDuffelCardFormCustomElement;
+window.saveCard = saveCard;
+window.createCardForTemporaryUse = createCardForTemporaryUse;
+window.onValidateSuccess = onValidateSuccess;
+window.onValidateFailure = onValidateFailure;
+window.onSaveCardSuccess = onSaveCardSuccess;
+window.onSaveCardFailure = onSaveCardFailure;
+window.onCreateCardForTemporaryUseSuccess = onCreateCardForTemporaryUseSuccess;
+window.onCreateCardForTemporaryUseFailure = onCreateCardForTemporaryUseFailure;

--- a/src/components/DuffelCardForm/lib/types.ts
+++ b/src/components/DuffelCardForm/lib/types.ts
@@ -114,7 +114,7 @@ export interface DuffelCardFormProps {
    * `useDuffelCardFormActions` hook.
    */
   onCreateCardForTemporaryUseSuccess?: (
-    data: CreateCardForTemporaryUseData
+    data: CreateCardForTemporaryUseData,
   ) => void;
 
   /**
@@ -126,7 +126,7 @@ export interface DuffelCardFormProps {
    * `useDuffelCardFormActions` hook.
    */
   onCreateCardForTemporaryUseFailure?: (
-    error: CreateCardForTemporaryUseError
+    error: CreateCardForTemporaryUseError,
   ) => void;
 
   /**

--- a/src/components/DuffelCardForm/lib/types.ts
+++ b/src/components/DuffelCardForm/lib/types.ts
@@ -20,8 +20,9 @@ export interface SaveCardData extends CommonCardData {
   unavailable_at: null;
 }
 
-export type SaveCardError = CardActionError;
-export type CreateCardForTemporaryUseError = CardActionError;
+export interface SaveCardError extends CardActionError {}
+
+export interface CreateCardForTemporaryUseError extends CardActionError {}
 
 /**
  * An object where each key value pair is a style to be applied.
@@ -113,7 +114,7 @@ export interface DuffelCardFormProps {
    * `useDuffelCardFormActions` hook.
    */
   onCreateCardForTemporaryUseSuccess?: (
-    data: CreateCardForTemporaryUseData,
+    data: CreateCardForTemporaryUseData
   ) => void;
 
   /**
@@ -125,7 +126,7 @@ export interface DuffelCardFormProps {
    * `useDuffelCardFormActions` hook.
    */
   onCreateCardForTemporaryUseFailure?: (
-    error: CreateCardForTemporaryUseError,
+    error: CreateCardForTemporaryUseError
   ) => void;
 
   /**

--- a/src/custom-elements.ts
+++ b/src/custom-elements.ts
@@ -7,15 +7,24 @@ export {
   renderDuffelAncillariesCustomElement,
 } from "./components/DuffelAncillaries/DuffelAncillariesCustomElement";
 export {
+  createCardForTemporaryUse,
+  onCreateCardForTemporaryUseFailure,
+  onCreateCardForTemporaryUseSuccess,
+  onSaveCardFailure,
+  onSaveCardSuccess,
+  renderDuffelCardFormCustomElement,
+  saveCard,
+} from "./components/DuffelCardForm/DuffelCardFormCustomElement";
+export {
   onDuffelPaymentsFailedPayment,
   onDuffelPaymentsSuccessfulPayment,
   renderDuffelPaymentsCustomElement,
 } from "./components/DuffelPayments/DuffelPaymentsCustomElement";
-export { renderDuffelStaysRatingCustomElement } from "./components/Stays/StaysRatingCustomElement";
-export { renderDuffelStaysAmenitiesCustomElement } from "./components/Stays/StaysAmenitiesCustomElement";
-export { renderDuffelStaysSummaryCustomElement } from "./components/Stays/StaysSummaryCustomElement";
-export { renderDuffelStaysRoomRateCardCustomElement } from "./components/Stays/StaysRoomRateCardCustomElement";
 export {
-  renderMapboxPlacesLookupCustomElement,
   onMapboxPlacesLookupPlaceSelected,
+  renderMapboxPlacesLookupCustomElement,
 } from "./components/MapboxPlacesLookup/MapboxPlacesLookupCustomElement";
+export { renderDuffelStaysAmenitiesCustomElement } from "./components/Stays/StaysAmenitiesCustomElement";
+export { renderDuffelStaysRatingCustomElement } from "./components/Stays/StaysRatingCustomElement";
+export { renderDuffelStaysRoomRateCardCustomElement } from "./components/Stays/StaysRoomRateCardCustomElement";
+export { renderDuffelStaysSummaryCustomElement } from "./components/Stays/StaysSummaryCustomElement";


### PR DESCRIPTION
__what__

This PR exposes the card form as a custom element and a test page for it. 

To run the test page locally use: 

```sh
yarn dev
```
and 
```sh
DUFFEL_API_URL=https://api.duffel.com DUFFEL_API_TOKEN=<token> node examples/card-form-no-react/server.mjs
```

<img width="961" alt="Screenshot 2024-03-11 at 17 35 47" src="https://github.com/duffelhq/duffel-components/assets/2934495/b184264d-f69d-48d8-a9b3-77921abe2058">
