### PR TITLE
Add shadow root to Mapbox places look up

### DIFF
--- a/examples/card-form-no-react/index.html
+++ b/examples/card-form-no-react/index.html
@@ -23,8 +23,6 @@
     type="text/javascript"
     src="http://127.0.0.1:8000/duffel-card-form.js"
   ></script>
-  <!-- Alternatively, if you want to run this example with the live version use the script below instead -->
-  <!-- <script type="text/javascript" src="http://assets.duffel.com/traveller-support/custom-element.js"></script> -->
 
   <!-- 3. Enable open function once window is loaded -->
   <script type="text/javascript">

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@duffel/components",
-  "version": "3.6.5",
+  "version": "3.6.6",
   "description": "Component library to build your travel product with Duffel.",
   "keywords": [
     "Duffel",

--- a/src/components/MapboxPlacesLookup/MapboxPlacesLookupCustomElement.tsx
+++ b/src/components/MapboxPlacesLookup/MapboxPlacesLookupCustomElement.tsx
@@ -35,7 +35,7 @@ class MapboxPlacesLookupCustomElement extends HTMLElement {
    */
   connectedCallback() {
     const container = document.createElement("div");
-    this.appendChild(container);
+    this.attachShadow({ mode: "open" }).appendChild(container);
 
     this.root = createRoot(container);
   }

--- a/src/styles/components/PlacesLookup.css
+++ b/src/styles/components/PlacesLookup.css
@@ -1,13 +1,16 @@
 .places-lookup-input {
-  width: 100%;
+  width: calc(100% - 34px);
+  padding: 12px 16px;
+  border-radius: 4px;
+  border: 1px solid var(--GREY-400);
+  font-size: 16px;
 }
 
 .places-lookup-popover {
   background-color: var(--WHITE);
-  box-shadow: 0px 1px 4px rgba(59, 64, 86, 0.3);
+  box-shadow: 0 1px 4px rgb(59 64 86 / 30%);
   border-radius: 4px;
-  margin-top: 4px;
-  width: 100%;
+  margin: 4px;
   padding: 4px;
   display: flex;
   flex-direction: column;


### PR DESCRIPTION
To prevent styles bleeding (to button in particular).

Includes version bump so I can use it in https://github.com/duffelhq/platform/pull/17902

https://github.com/duffelhq/duffel-components/assets/1416759/51967ead-d75d-48f3-84e9-c4a89932a33a

