### PR TITLE
Mapbox component updates

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@duffel/components",
-  "version": "3.6.9",
+  "version": "3.6.10",
   "description": "Component library to build your travel product with Duffel.",
   "keywords": [
     "Duffel",

--- a/src/components/MapboxPlacesLookup/MapboxPlacesLookup.tsx
+++ b/src/components/MapboxPlacesLookup/MapboxPlacesLookup.tsx
@@ -1,17 +1,17 @@
-import classNames from "classnames";
 import { debounce } from "lodash";
 import React from "react";
 import {
   Place,
   getPlacesFromMapboxClient,
 } from "./lib/getPlacesFromMapboxClient";
-import { WithComponentStyles } from "@components/shared/WithComponentStyles";
 
 export interface MapboxPlacesLookupProps {
   mapboxPublicKey: string;
   onPlaceSelected: (selection: Place) => void;
   placeholder?: string;
   inputClassName?: string;
+  popupClassName?: string;
+  inputValue?: string;
 }
 
 export const MapboxPlacesLookup: React.FC<MapboxPlacesLookupProps> = ({
@@ -19,10 +19,12 @@ export const MapboxPlacesLookup: React.FC<MapboxPlacesLookupProps> = ({
   onPlaceSelected,
   placeholder = "Look up city or airport",
   inputClassName,
+  popupClassName,
+  inputValue: inputValueProp = "",
 }) => {
   const [shouldShowPopover, setShouldShowPopover] =
     React.useState<boolean>(true);
-  const [inputValue, setInputValue] = React.useState<string>("");
+  const [inputValue, setInputValue] = React.useState<string>(inputValueProp);
   const [lookupResults, setLookupResults] = React.useState<Place[]>([]);
 
   const getPlacesFromMapbox = getPlacesFromMapboxClient(mapboxPublicKey);
@@ -32,41 +34,39 @@ export const MapboxPlacesLookup: React.FC<MapboxPlacesLookupProps> = ({
   }, 300);
 
   return (
-    <WithComponentStyles>
-      <div className="places-lookup">
-        <input
-          className={classNames("places-lookup-input", inputClassName)}
-          placeholder={placeholder}
-          type="text"
-          value={inputValue}
-          onChange={(e) => {
-            if (!shouldShowPopover) setShouldShowPopover(true);
-            setInputValue(e.target.value);
-            runLookup(e.target.value);
-          }}
-        />
-        {shouldShowPopover &&
-          inputValue.length > 0 &&
-          lookupResults.length > 0 && (
-            <div className="places-lookup-popover">
-              {lookupResults.map((place) => (
-                <button
-                  className="places-lookup-popover__item"
-                  key={place.shortName}
-                  onClick={() => {
-                    setShouldShowPopover(false);
-                    onPlaceSelected(place);
-                    setInputValue(place.name);
-                  }}
-                >
-                  <span className="places-lookup-popover__icon-and-name-container">
-                    {place.name}
-                  </span>
-                </button>
-              ))}
-            </div>
-          )}
-      </div>
-    </WithComponentStyles>
+    <div className="places-lookup">
+      <input
+        className={inputClassName}
+        placeholder={placeholder}
+        type="text"
+        value={inputValue}
+        onChange={(e) => {
+          if (!shouldShowPopover) setShouldShowPopover(true);
+          setInputValue(e.target.value);
+          runLookup(e.target.value);
+        }}
+      />
+      {shouldShowPopover &&
+        inputValue.length > 0 &&
+        lookupResults.length > 0 && (
+          <div className={popupClassName}>
+            {lookupResults.map((place) => (
+              <button
+                className="places-lookup-popover__item"
+                key={place.shortName}
+                onClick={() => {
+                  setShouldShowPopover(false);
+                  onPlaceSelected(place);
+                  setInputValue(place.name);
+                }}
+              >
+                <span className="places-lookup-popover__icon-and-name-container">
+                  {place.name}
+                </span>
+              </button>
+            ))}
+          </div>
+        )}
+    </div>
   );
 };

--- a/src/components/MapboxPlacesLookup/MapboxPlacesLookupCustomElement.tsx
+++ b/src/components/MapboxPlacesLookup/MapboxPlacesLookupCustomElement.tsx
@@ -57,10 +57,10 @@ class MapboxPlacesLookupCustomElement extends HTMLElement {
             new CustomEvent("onPlaceSelected", {
               composed: true,
               detail: { place },
-            })
+            }),
           );
         }}
-      />
+      />,
     );
   }
 }
@@ -68,27 +68,27 @@ class MapboxPlacesLookupCustomElement extends HTMLElement {
 window.customElements.get(CUSTOM_ELEMENT_TAG) ||
   window.customElements.define(
     CUSTOM_ELEMENT_TAG,
-    MapboxPlacesLookupCustomElement
+    MapboxPlacesLookupCustomElement,
   );
 
 function tryToGetCustomElement(
-  caller: string
+  caller: string,
 ): MapboxPlacesLookupCustomElement {
   const element =
     document.querySelector<MapboxPlacesLookupCustomElement>(CUSTOM_ELEMENT_TAG);
   if (!element) {
     throw new Error(
-      `Could not find ${CUSTOM_ELEMENT_TAG} element in the DOM. Maybe you need to call ${caller} after 'window.onload'?`
+      `Could not find ${CUSTOM_ELEMENT_TAG} element in the DOM. Maybe you need to call ${caller} after 'window.onload'?`,
     );
   }
   return element;
 }
 
 export function renderMapboxPlacesLookupCustomElement(
-  props: MapboxPlacesLookupCustomElementRenderArguments
+  props: MapboxPlacesLookupCustomElementRenderArguments,
 ) {
   const element = tryToGetCustomElement(
-    "renderMapboxPlacesLookupCustomElement"
+    "renderMapboxPlacesLookupCustomElement",
   );
   element.render(props);
 }
@@ -98,7 +98,7 @@ type OnPlaceSelectedCustomEvent = CustomEvent<{
 }>;
 
 export function onMapboxPlacesLookupPlaceSelected(
-  onPlaceSelected: MapboxPlacesLookupProps["onPlaceSelected"]
+  onPlaceSelected: MapboxPlacesLookupProps["onPlaceSelected"],
 ) {
   const element = tryToGetCustomElement("onDuffelAncillariesPayloadReady");
   const eventListener = (event: OnPlaceSelectedCustomEvent) => {

--- a/src/components/MapboxPlacesLookup/MapboxPlacesLookupCustomElement.tsx
+++ b/src/components/MapboxPlacesLookup/MapboxPlacesLookupCustomElement.tsx
@@ -35,7 +35,7 @@ class MapboxPlacesLookupCustomElement extends HTMLElement {
    */
   connectedCallback() {
     const container = document.createElement("div");
-    this.attachShadow({ mode: "open" }).appendChild(container);
+    this.appendChild(container);
 
     this.root = createRoot(container);
   }
@@ -57,10 +57,10 @@ class MapboxPlacesLookupCustomElement extends HTMLElement {
             new CustomEvent("onPlaceSelected", {
               composed: true,
               detail: { place },
-            }),
+            })
           );
         }}
-      />,
+      />
     );
   }
 }
@@ -68,27 +68,27 @@ class MapboxPlacesLookupCustomElement extends HTMLElement {
 window.customElements.get(CUSTOM_ELEMENT_TAG) ||
   window.customElements.define(
     CUSTOM_ELEMENT_TAG,
-    MapboxPlacesLookupCustomElement,
+    MapboxPlacesLookupCustomElement
   );
 
 function tryToGetCustomElement(
-  caller: string,
+  caller: string
 ): MapboxPlacesLookupCustomElement {
   const element =
     document.querySelector<MapboxPlacesLookupCustomElement>(CUSTOM_ELEMENT_TAG);
   if (!element) {
     throw new Error(
-      `Could not find ${CUSTOM_ELEMENT_TAG} element in the DOM. Maybe you need to call ${caller} after 'window.onload'?`,
+      `Could not find ${CUSTOM_ELEMENT_TAG} element in the DOM. Maybe you need to call ${caller} after 'window.onload'?`
     );
   }
   return element;
 }
 
 export function renderMapboxPlacesLookupCustomElement(
-  props: MapboxPlacesLookupCustomElementRenderArguments,
+  props: MapboxPlacesLookupCustomElementRenderArguments
 ) {
   const element = tryToGetCustomElement(
-    "renderMapboxPlacesLookupCustomElement",
+    "renderMapboxPlacesLookupCustomElement"
   );
   element.render(props);
 }
@@ -98,7 +98,7 @@ type OnPlaceSelectedCustomEvent = CustomEvent<{
 }>;
 
 export function onMapboxPlacesLookupPlaceSelected(
-  onPlaceSelected: MapboxPlacesLookupProps["onPlaceSelected"],
+  onPlaceSelected: MapboxPlacesLookupProps["onPlaceSelected"]
 ) {
   const element = tryToGetCustomElement("onDuffelAncillariesPayloadReady");
   const eventListener = (event: OnPlaceSelectedCustomEvent) => {

--- a/src/styles/global.css
+++ b/src/styles/global.css
@@ -28,7 +28,6 @@
 @import "./components/OfferSliceDetailTravelItem.css";
 @import "./components/PassengerSelect.css";
 @import "./components/PassengersLayout.css";
-@import "./components/PlacesLookup.css";
 @import "./components/RadioButton.css";
 @import "./components/Row.css";
 @import "./components/Seat.css";


### PR DESCRIPTION
__what__

We want to enable an initial input value on the component. This PR exposes that prop. 

Also, this is a very atomic component which's styles must align with what the integrator wants. So, this PR removes all styling from the component, removes the shadow root to enable to enable customisation through 2 classes: one for the input and one for the popup. 