### PR TITLE
Change NGS to accept offer request rather than list of offers

### DIFF
--- a/package.json
+++ b/package.json
@@ -49,7 +49,7 @@
     "semver": "7.5.4"
   },
   "dependencies": {
-    "@duffel/api": "2.8.0",
+    "@duffel/api": "2.8.1",
     "@sentry/browser": "7.77.0",
     "@stripe/react-stripe-js": "2.1.0",
     "@stripe/stripe-js": "1.54.2",

--- a/src/components/DuffelNGSView/DuffelNGSView.tsx
+++ b/src/components/DuffelNGSView/DuffelNGSView.tsx
@@ -3,30 +3,30 @@ import { NGSTable } from "./NGSTable";
 import { getDateString } from "@lib/getDateString";
 import { Icon } from "@components/shared/Icon";
 import classNames from "classnames";
-import { Offer } from "@duffel/api/types";
+import { OfferRequest } from "@duffel/api/types";
 import { WithComponentStyles } from "@components/shared/WithComponentStyles";
 
 export interface DuffelNGSViewProps {
-  offers: Offer[];
+  offerRequest: OfferRequest;
   onSelect: (offerId: string) => void;
 }
 
 export const DuffelNGSView: React.FC<DuffelNGSViewProps> = ({
-  offers,
+  offerRequest,
   onSelect,
 }) => {
   const [selectedSliceKeys, setSelectedSliceKeys] = React.useState<string[]>(
     [],
   );
-  if (offers.length == 0) {
+  if (offerRequest.offers.length == 0) {
     return null;
   }
 
-  const numSlices = offers[0].slices.length;
+  const numSlices = offerRequest.slices.length;
   const currentSlice =
     selectedSliceKeys.length > 0
-      ? offers[0].slices[selectedSliceKeys.length]
-      : offers[0].slices[0];
+      ? offerRequest.slices[selectedSliceKeys.length]
+      : offerRequest.slices[0];
 
   return (
     <WithComponentStyles>
@@ -34,7 +34,7 @@ export const DuffelNGSView: React.FC<DuffelNGSViewProps> = ({
         {currentSlice && (
           <>
             <div className="duffel-ngs-view_breadcrumbs">
-              {offers[0].slices.map((slice, index) => (
+              {offerRequest.slices.map((slice, index) => (
                 <>
                   <button
                     key={index}
@@ -63,17 +63,16 @@ export const DuffelNGSView: React.FC<DuffelNGSViewProps> = ({
             </div>
             <h3 className="duffel-ngs-view_heading">
               {numSlices === 2 &&
-                `${selectedSliceKeys.length === 0 ? "Outbound" : "Inbound"} flight to  ${currentSlice.destination.city_name}`}
-              {numSlices !== 2 &&
-                `Flight to ${currentSlice.destination.city_name}`}
+                `${selectedSliceKeys.length === 0 ? "Outbound" : "Inbound"} flight to  ${currentSlice.destination.name}`}
+              {numSlices !== 2 && `Flight to ${currentSlice.destination.name}`}
             </h3>
             <h4 className="duffel-ngs-view_subheading">
-              {getDateString(currentSlice.segments[0].departing_at, "long")}
+              {getDateString(currentSlice.departure_date, "long")}
             </h4>
           </>
         )}
         <NGSTable
-          offers={offers}
+          offers={offerRequest.offers}
           sliceIndex={selectedSliceKeys.length}
           previousSliceKeys={selectedSliceKeys}
           onSelect={(offerId, sliceKey) => {

--- a/src/components/DuffelNGSView/NGSSliceFareCard.tsx
+++ b/src/components/DuffelNGSView/NGSSliceFareCard.tsx
@@ -9,7 +9,7 @@ import classNames from "classnames";
 import { getFareBrandNameForOffer } from "./lib/deduplicate-mapped-offers-by-fare-brand";
 
 export interface NGSSliceFareCardProps {
-  offer: Offer;
+  offer: Omit<Offer, "available_services">;
   sliceIndex: number;
 
   onSelect?: () => void;

--- a/src/components/DuffelNGSView/NGSTable.tsx
+++ b/src/components/DuffelNGSView/NGSTable.tsx
@@ -17,10 +17,10 @@ import { NGSSliceFareCard } from "./NGSSliceFareCard";
 import { NGSShelfInfoCard } from "./NGSShelfInfoCard";
 import { SliceSummary } from "./SliceSummary";
 import { OfferSliceModal } from "@components/OfferSliceModal/OfferSliceModal";
-import { Offer } from "@duffel/api/types";
+import { OfferRequest } from "@duffel/api/types";
 
 export interface NGSTableProps {
-  offers: Offer[];
+  offers: OfferRequest["offers"];
   sliceIndex: number;
   previousSliceKeys: string[]; // For filtering the current set of offers
   onSelect: (offerId: string, sliceKey: string) => void;

--- a/src/components/DuffelNGSView/lib/deduplicate-mapped-offers-by-fare-brand.ts
+++ b/src/components/DuffelNGSView/lib/deduplicate-mapped-offers-by-fare-brand.ts
@@ -1,4 +1,8 @@
-import { Offer, OfferSliceSegmentPassenger } from "@duffel/api/types";
+import {
+  Offer,
+  OfferRequest,
+  OfferSliceSegmentPassenger,
+} from "@duffel/api/types";
 import { NGSOfferRow } from "./group-offers-for-ngs-view";
 import { NGS_SHELVES } from ".";
 
@@ -27,7 +31,9 @@ export const deduplicateMappedOffersByFareBrand = (
   return offersMap;
 };
 
-export const getFareBrandNameForOffer = (offer: Offer): string => {
+export const getFareBrandNameForOffer = (
+  offer: Omit<Offer, "available_services">,
+): string => {
   // Cabin class can vary within a slice across passengers and segments. Here we
   // make a list of all cabin classes present in the slice.
   const cabinClasses = offer.slices[0].segments
@@ -45,25 +51,29 @@ export const getFareBrandNameForOffer = (offer: Offer): string => {
   return offer.slices[0].fare_brand_name || cabinClasses.join("/");
 };
 
-export const getCheapestOffer = (offers: Offer[]) =>
+export const getCheapestOffer = (offers: OfferRequest["offers"]) =>
   offers.find(
     (offer) =>
       +offer.total_amount ==
       Math.min(...offers.map((offer) => +offer.total_amount)),
   )!;
 
-export const groupByFareBrandName = (offers: Offer[]) => {
-  const groupedResult: { [key: string]: Offer[] } = offers.reduce(
-    (previous: { [key: string]: Offer[] }, current: Offer) => {
-      const key = getFareBrandNameForOffer(current);
-      if (!previous[key]) {
-        previous[key] = [];
-      }
+export const groupByFareBrandName = (offers: OfferRequest["offers"]) => {
+  const groupedResult: { [key: string]: OfferRequest["offers"] } =
+    offers.reduce(
+      (
+        previous: { [key: string]: OfferRequest["offers"] },
+        current: Omit<Offer, "available_services">,
+      ) => {
+        const key = getFareBrandNameForOffer(current);
+        if (!previous[key]) {
+          previous[key] = [];
+        }
 
-      previous[key].push(current);
-      return previous;
-    },
-    {},
-  );
+        previous[key].push(current);
+        return previous;
+      },
+      {},
+    );
   return Object.values(groupedResult);
 };

--- a/src/components/DuffelNGSView/lib/group-offers-for-ngs-view.ts
+++ b/src/components/DuffelNGSView/lib/group-offers-for-ngs-view.ts
@@ -1,9 +1,9 @@
-import { Offer, OfferSlice } from "@duffel/api/types";
+import { OfferRequest, OfferSlice } from "@duffel/api/types";
 import { NGSShelf } from ".";
 import { deduplicateMappedOffersByFareBrand } from "./deduplicate-mapped-offers-by-fare-brand";
 
 export type NGSOfferRow = Record<"slice", OfferSlice> &
-  Record<NGSShelf, Offer[] | null>;
+  Record<NGSShelf, OfferRequest["offers"] | null>;
 
 export const getNGSSliceKey = (
   slice: OfferSlice,
@@ -17,7 +17,7 @@ export const getNGSSliceKey = (
 };
 
 const filterOffersThatMatchCurrentSlice = (
-  offers: Offer[],
+  offers: OfferRequest["offers"],
   previousSliceKeys: string[],
 ) => {
   const filteredOffers = previousSliceKeys.length > 0 ? [] : offers;
@@ -42,7 +42,7 @@ const filterOffersThatMatchCurrentSlice = (
 };
 
 export const groupOffersForNGSView = (
-  offers: Offer[],
+  offers: OfferRequest["offers"],
   sliceIndex: number,
   previousSliceKeys: string[],
 ): NGSOfferRow[] => {

--- a/src/components/DuffelNGSView/lib/sort-ngs-rows.ts
+++ b/src/components/DuffelNGSView/lib/sort-ngs-rows.ts
@@ -1,11 +1,12 @@
-import { Offer } from "@duffel/api/types";
+import { OfferRequest } from "@duffel/api/types";
 import { NGSShelf } from ".";
 import { NGSOfferRow } from "./group-offers-for-ngs-view";
 
 export type SortDirection = "asc" | "desc";
 
-export const getCheapestOfferAmount = (offers: Offer[] | null) =>
-  offers ? Math.min(...offers.map((offer) => +offer.total_amount)) : null;
+export const getCheapestOfferAmount = (
+  offers: OfferRequest["offers"] | null,
+) => (offers ? Math.min(...offers.map((offer) => +offer.total_amount)) : null);
 
 export const sortNGSRows = (
   rows: NGSOfferRow[],

--- a/src/stories/DuffelNGSView.stories.tsx
+++ b/src/stories/DuffelNGSView.stories.tsx
@@ -4,6 +4,7 @@ import {
   DuffelNGSViewProps,
 } from "../components/DuffelNGSView/DuffelNGSView";
 import { OfferSlice } from "@duffel/api/types";
+import { NGSShelf } from "@components/DuffelNGSView/lib";
 
 // eslint-disable-next-line @typescript-eslint/no-var-requires
 const offerRequest = require("../fixtures/offer-requests/orq_0000Ab7taNqbK8y5YqW6Zk.json");
@@ -72,13 +73,16 @@ export default {
 } as Meta;
 
 const defaultProps: DuffelNGSViewProps = {
-  offers: [
-    offer,
-    cheapOffer,
-    expensiveOffer,
-    alternativeCheapOffer,
-    alternativeExpensiveOffer,
-  ],
+  offerRequest: {
+    ...offerRequest,
+    offers: [
+      offer,
+      cheapOffer,
+      expensiveOffer,
+      alternativeCheapOffer,
+      alternativeExpensiveOffer,
+    ],
+  },
   onSelect: console.log,
 };
 
@@ -89,7 +93,7 @@ export const Default: StoryFn<DuffelNGSViewProps> = () => (
 const makeSlice = (
   offerIndex: number,
   sliceIndex: number,
-  ngs_shelf: number,
+  ngs_shelf: NGSShelf,
   marketing_carrier_flight_number: string,
 ) => ({
   ...offerRequest.offers[offerIndex].slices[sliceIndex],
@@ -139,6 +143,7 @@ const offer10 = { ...offer, slices: [A1F2, B3F2], total_amount: "100" };
 // Example from https://www.notion.so/duffel/NGS-Technical-Scoping-26df8e8fb8db40e19bd661b748810622?pvs=4#b4db506e7de24815afe3ad4ca13bed89
 // eslint-disable-next-line storybook/prefer-pascal-case
 export const duplicateOffers = [
+  // TODO export from somewhere else as it's not a story
   offer1,
   offer2,
   offer3,
@@ -153,7 +158,7 @@ export const duplicateOffers = [
 
 // Example from https://www.notion.so/duffel/NGS-Technical-Scoping-26df8e8fb8db40e19bd661b748810622?pvs=4#b4db506e7de24815afe3ad4ca13bed89
 const deduplicatedProps: DuffelNGSViewProps = {
-  offers: duplicateOffers,
+  offerRequest: { ...offerRequest, offers: duplicateOffers },
   onSelect: console.log,
 };
 

--- a/src/stories/DuffelNGSView.stories.tsx
+++ b/src/stories/DuffelNGSView.stories.tsx
@@ -143,7 +143,6 @@ const offer10 = { ...offer, slices: [A1F2, B3F2], total_amount: "100" };
 // Example from https://www.notion.so/duffel/NGS-Technical-Scoping-26df8e8fb8db40e19bd661b748810622?pvs=4#b4db506e7de24815afe3ad4ca13bed89
 // eslint-disable-next-line storybook/prefer-pascal-case
 export const duplicateOffers = [
-  // TODO export from somewhere else as it's not a story
   offer1,
   offer2,
   offer3,

--- a/src/stories/OfferSlice.stories.tsx
+++ b/src/stories/OfferSlice.stories.tsx
@@ -16,11 +16,6 @@ const MOCK_CITY: City = {
   iata_country_code: "FR",
   id: "cit_paris",
   name: "Paris",
-  time_zone: "Europe/Paris",
-  latitude: 49.0079,
-  longitude: 2.5508,
-  iata_city_code: "PAR",
-  city_name: "Paris",
 };
 const MOCK_AIRPORT: Airport = {
   city: MOCK_CITY,

--- a/src/stories/OfferSliceModal.stories.tsx
+++ b/src/stories/OfferSliceModal.stories.tsx
@@ -16,11 +16,6 @@ const MOCK_CITY: City = {
   iata_country_code: "FR",
   id: "cit_paris",
   name: "Paris",
-  time_zone: "Europe/Paris",
-  latitude: 49.0079,
-  longitude: 2.5508,
-  iata_city_code: "PAR",
-  city_name: "Paris",
 };
 const MOCK_AIRPORT: Airport = {
   city: MOCK_CITY,

--- a/src/stories/SliceSummary.stories.tsx
+++ b/src/stories/SliceSummary.stories.tsx
@@ -16,11 +16,6 @@ const MOCK_CITY: City = {
   iata_country_code: "FR",
   id: "cit_paris",
   name: "Paris",
-  time_zone: "Europe/Paris",
-  latitude: 49.0079,
-  longitude: 2.5508,
-  iata_city_code: "PAR",
-  city_name: "Paris",
 };
 const MOCK_AIRPORT: Airport = {
   city: MOCK_CITY,

--- a/yarn.lock
+++ b/yarn.lock
@@ -2040,14 +2040,14 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@duffel/api@npm:2.8.0":
-  version: 2.8.0
-  resolution: "@duffel/api@npm:2.8.0"
+"@duffel/api@npm:2.8.1":
+  version: 2.8.1
+  resolution: "@duffel/api@npm:2.8.1"
   dependencies:
     "@types/node": "npm:^18.0.0"
     "@types/node-fetch": "npm:^2.6.2"
     node-fetch: "npm:2.7.0"
-  checksum: 1a0150d5204e07bfef450e7f5cc2d93e31b2ca5be7482bc5e1aaee32a6b0cc85954539ed1af4b9e3f4bfea3e8a0d15806884701e3d7b12291fc9e00f67d52fce
+  checksum: b6cf7d3b58aed04fc5ae71370f052ba0babe9a79365566f09d98a7041f2897bb98c1675845d4100d189261894da1cd8228bb3c63f39febe4a007a2b9a05956d9
   languageName: node
   linkType: hard
 
@@ -2060,7 +2060,7 @@ __metadata:
     "@babel/preset-env": "npm:7.21.4"
     "@babel/preset-react": "npm:7.18.6"
     "@babel/preset-typescript": "npm:7.21.4"
-    "@duffel/api": "npm:2.8.0"
+    "@duffel/api": "npm:2.8.1"
     "@sentry/browser": "npm:7.77.0"
     "@sentry/cli": "npm:2.21.2"
     "@sentry/esbuild-plugin": "npm:0.7.2"


### PR DESCRIPTION
I've got a few NGS fixes to work through today, they'll probably come split in a few PRs and at the end I'll do a release.

For this one, James pointed out that we should be showing the origin & destinations in the breadcrumbs from the offer request, rather than the first offer, since they might have searched for a city rather than airport: https://duffel.slack.com/archives/C06A8HUCDPW/p1711114502922789
This required a slight refactor as the component just took in the list of offers directly before. It now accepts an offer request, and then passes down the list of offers from there. Changing the types touched a lot of files (they're not just "Offer[]" because "available_services" need to be omitted). 

This could be considered a breaking change. As far as I know the only usage of this component is in the dashboard so I think that should be ok? 