### PR TITLE
Slice fare card fixes

### DIFF
--- a/src/components/DuffelNGSView/NGSSliceFareCard.tsx
+++ b/src/components/DuffelNGSView/NGSSliceFareCard.tsx
@@ -32,7 +32,7 @@ export const NGSSliceFareCard: React.FC<NGSSliceFareCardProps> = ({
   const slice = offer.slices[sliceIndex];
   const shelfInfo = NGS_SHELF_INFO[slice.ngs_shelf];
 
-  const brandName = getFareBrandNameForOffer(offer);
+  const brandName = getFareBrandNameForOffer(offer, sliceIndex);
 
   // A null property indicates the API can't provide the information for this
   // slice, so we default to using the offer condition.

--- a/src/components/DuffelNGSView/lib/deduplicate-mapped-offers-by-fare-brand.ts
+++ b/src/components/DuffelNGSView/lib/deduplicate-mapped-offers-by-fare-brand.ts
@@ -33,10 +33,11 @@ export const deduplicateMappedOffersByFareBrand = (
 
 export const getFareBrandNameForOffer = (
   offer: Omit<Offer, "available_services">,
+  sliceIndex?: number,
 ): string => {
   // Cabin class can vary within a slice across passengers and segments. Here we
   // make a list of all cabin classes present in the slice.
-  const cabinClasses = offer.slices[0].segments
+  const cabinClasses = offer.slices[sliceIndex || 0].segments
     .flatMap((segment) => segment.passengers)
     .reduce<OfferSliceSegmentPassenger["cabin_class"][]>(
       (cabinClasses, passenger) => {

--- a/src/components/DuffelNGSView/lib/get-max-baggages-for-offer-slice.ts
+++ b/src/components/DuffelNGSView/lib/get-max-baggages-for-offer-slice.ts
@@ -6,7 +6,7 @@ import {
 
 const getBaggagesQuantity = (
   baggages: OfferSliceSegmentPassenger["baggages"],
-  type: OfferAvailableServiceBaggageMetadata["type"],
+  type: OfferAvailableServiceBaggageMetadata["type"]
 ): number => {
   return baggages
     .filter((baggage) => baggage.type === type)
@@ -23,7 +23,7 @@ const getBaggagesQuantity = (
  */
 export const getMaxBaggagesForOfferSlice = (
   offerSlice: OfferSlice,
-  type: OfferAvailableServiceBaggageMetadata["type"],
+  type: OfferAvailableServiceBaggageMetadata["type"]
 ): OfferSliceSegmentPassenger["baggages"] => {
   let maxBaggages = offerSlice.segments[0].passengers[0].baggages;
   let maxBaggagesQuantity = getBaggagesQuantity(maxBaggages, type);

--- a/src/components/DuffelNGSView/lib/get-max-baggages-for-offer-slice.ts
+++ b/src/components/DuffelNGSView/lib/get-max-baggages-for-offer-slice.ts
@@ -6,7 +6,7 @@ import {
 
 const getBaggagesQuantity = (
   baggages: OfferSliceSegmentPassenger["baggages"],
-  type: OfferAvailableServiceBaggageMetadata["type"]
+  type: OfferAvailableServiceBaggageMetadata["type"],
 ): number => {
   return baggages
     .filter((baggage) => baggage.type === type)
@@ -23,9 +23,11 @@ const getBaggagesQuantity = (
  */
 export const getMaxBaggagesForOfferSlice = (
   offerSlice: OfferSlice,
-  type: OfferAvailableServiceBaggageMetadata["type"]
+  type: OfferAvailableServiceBaggageMetadata["type"],
 ): OfferSliceSegmentPassenger["baggages"] => {
-  let maxBaggages = offerSlice.segments[0].passengers[0].baggages;
+  let maxBaggages = offerSlice.segments[0].passengers[0].baggages.filter(
+    (baggage) => baggage.type === type,
+  );
   let maxBaggagesQuantity = getBaggagesQuantity(maxBaggages, type);
 
   offerSlice.segments.forEach((segment) => {

--- a/src/stories/DuffelNGSView.stories.tsx
+++ b/src/stories/DuffelNGSView.stories.tsx
@@ -13,7 +13,11 @@ const offer = offerRequest.offers[0];
 const cheapOffer = {
   ...offer,
   slices: [
-    { ...offer.slices[0], ngs_shelf: 1, fare_brand_name: "Very Basic" },
+    {
+      ...offer.slices[0],
+      ngs_shelf: 1,
+      fare_brand_name: "Very Basic Long Fare Brand Name",
+    },
     offer.slices[1],
   ],
   total_amount: "100",

--- a/src/stories/NGSSliceFareCard.stories.tsx
+++ b/src/stories/NGSSliceFareCard.stories.tsx
@@ -18,25 +18,65 @@ export default {
   ],
 } as Meta;
 
-export const FullList: React.FC = () => {
-  const compareToAmount = 500;
+export const FullList: React.FC = () => (
+  <div
+    style={{
+      display: "flex",
+      alignItems: "stretch",
+      justifyContent: "space-evenly",
+      width: "600px",
+    }}
+  >
+    <NGSSliceFareCard offer={offer} sliceIndex={0} onSelect={console.log} />
+    <NGSSliceFareCard
+      offer={{
+        ...offer,
+        total_amount: 500,
+        slices: [
+          {
+            ...offer.slices[0],
+            fare_brand_name: "Really long fare brand name",
+          },
+          {
+            ...offer.slices[1],
+            fare_brand_name: "Really long fare brand name",
+            conditions: {
+              refund_before_departure: {
+                allowed: true,
+                penalty_amount: 100,
+                penalty_currency: "USD",
+              },
+              change_before_departure: {
+                allowed: true,
+                penalty_amount: 10,
+                penalty_currency: "USD",
+              },
+              priority_check_in: true,
+              priority_boarding: true,
+              advance_seat_selection: true,
+            },
 
-  return (
-    <div
-      style={{
-        display: "flex",
-        alignItems: "flex-start",
-        justifyContent: "space-evenly",
-        width: "600px",
-        height: "400px",
+            segments: [
+              {
+                ...offer.slices[1].segments[0],
+                passengers: [
+                  {
+                    ...offer.slices[1].segments[0].passengers[0],
+                    baggages: [
+                      { quantity: 0, type: "checked" },
+                      { quantity: 1, type: "carry_on" },
+                    ],
+                  },
+                  ...offer.slices[1].segments[0].passengers.slice(1),
+                ],
+              },
+              ...offer.slices[1].segments.slice(1),
+            ],
+          },
+        ],
       }}
-    >
-      <NGSSliceFareCard
-        offer={{ ...offer, total_amount: compareToAmount }}
-        sliceIndex={0}
-        onSelect={console.log}
-      />
-      <NGSSliceFareCard offer={offer} sliceIndex={1} onSelect={console.log} />
-    </div>
-  );
-};
+      sliceIndex={1}
+      onSelect={console.log}
+    />
+  </div>
+);

--- a/src/styles/components/NGSSliceFareCard.css
+++ b/src/styles/components/NGSSliceFareCard.css
@@ -15,17 +15,33 @@
   text-align: left;
 
   width: 190px;
+
+  display: flex;
+  flex-direction: column;
 }
 
 .ngs-slice-fare-card_container > div {
   padding: 16px;
+  width: calc(100% - 32px);
+}
+
+.ngs-slice-fare-card_container > div:first-child {
+  display: flex;
+  flex-direction: column;
+  flex-grow: 1;
 }
 
 .ngs-slice-fare-card_header {
   display: flex;
   justify-content: space-between;
-  align-items: center;
+  align-items: flex-start;
   margin-bottom: 16px;
+  flex-grow: 1;
+}
+
+.ngs-slice-fare-card_header > svg {
+  margin-left: 8px;
+  min-width: 24px;
 }
 
 .ngs-slice-fare-card_title {

--- a/src/styles/components/NGSTable.css
+++ b/src/styles/components/NGSTable.css
@@ -97,12 +97,15 @@
   background-color: var(--GREY-50);
   padding: 32px;
   display: flex;
-  align-items: center;
+  align-items: stretch;
   overflow-x: auto;
 }
 
-.ngs-table_expanded > div > button {
-  margin: auto;
+.ngs-table_expanded > div > button:first-child {
+  margin-left: auto;
+}
+.ngs-table_expanded > div > button:last-child {
+  margin-right: auto;
 }
 
 .ngs-table_table-data--expanded {


### PR DESCRIPTION
This contains a couple slice fare card fixes:
- with long fare brand names, the display would get misaligned (see below)
- we would sometimes show checked baggage as available even though quantity was 0, for example here: https://duffel.slack.com/archives/C06A8HUCDPW/p1711114347885839 (this was because we were missing a filter on the first step)
- includes more thorough stories for the slice fare card

Misaligned display before:
![Screen Shot 2024-03-21 at 1 19 21 PM](https://github.com/duffelhq/duffel-components/assets/1416759/a85d0f73-81de-4220-a698-1a3b01678f6e)

More even alignment when fare brand names have different lengths now (from stories):
<img width="546" alt="Screenshot 2024-03-25 at 12 54 55" src="https://github.com/duffelhq/duffel-components/assets/1416759/ff21f82e-4c06-45e3-8da8-303ccba7007c">

<img width="998" alt="Screenshot 2024-03-25 at 12 47 52" src="https://github.com/duffelhq/duffel-components/assets/1416759/dc1c0abd-227a-4026-9f32-6ffa112dd483">
