### PR TITLE
Fix sorting when empty values are present

### DIFF
--- a/src/components/DuffelNGSView/lib/sort-ngs-rows.ts
+++ b/src/components/DuffelNGSView/lib/sort-ngs-rows.ts
@@ -19,6 +19,8 @@ export const sortNGSRows = (
     if (aAmount && bAmount) {
       return sortDirection === "asc" ? aAmount - bAmount : bAmount - aAmount;
     }
+    if (aAmount) return -1;
+    if (bAmount) return 1;
     return 0;
   });
 

--- a/src/stories/DuffelNGSView.stories.tsx
+++ b/src/stories/DuffelNGSView.stories.tsx
@@ -26,6 +26,45 @@ const expensiveOffer = {
   ],
   total_amount: "10000",
 };
+const mediumOffer = {
+  ...offer,
+  slices: [
+    {
+      ...offer.slices[0],
+      segments: [
+        {
+          ...offer.slices[0].segments[0],
+          marketing_carrier: { name: "British Airways", iata_code: "BA" },
+          marketing_carrier_flight_number: "BA123",
+        },
+        ...offer.slices[0].segments.slice(1),
+      ],
+      ngs_shelf: 3,
+    },
+    offer.slices[1],
+  ],
+  total_amount: "500",
+};
+const alternativeMediumOffer = {
+  ...offer,
+  slices: [
+    {
+      ...offer.slices[0],
+      segments: [
+        {
+          ...offer.slices[0].segments[0],
+          marketing_carrier: { name: "British Airways", iata_code: "BA" },
+          operating_carrier: { name: "British Airways", iata_code: "BA" },
+          marketing_carrier_flight_number: "BA456",
+        },
+        ...offer.slices[0].segments.slice(1),
+      ],
+      ngs_shelf: 3,
+    },
+    offer.slices[1],
+  ],
+  total_amount: "400",
+};
 const alternativeCheapOffer = {
   ...offer,
   slices: [
@@ -78,6 +117,8 @@ const defaultProps: DuffelNGSViewProps = {
     offers: [
       offer,
       cheapOffer,
+      mediumOffer,
+      alternativeMediumOffer,
       expensiveOffer,
       alternativeCheapOffer,
       alternativeExpensiveOffer,


### PR DESCRIPTION
I thought I had handled this case but I hadn't, so sorting didn't apply properly when there were empty values in a column (which is very often). It should work better now, and I've expanded the story to demonstrate:

https://github.com/duffelhq/duffel-components/assets/1416759/3bda041b-ab5b-4da4-8bd6-920977878aff

