### PR TITLE
Slice modal fix (hopefully)

### DIFF
--- a/src/components/DuffelNGSView/NGSTable.tsx
+++ b/src/components/DuffelNGSView/NGSTable.tsx
@@ -17,7 +17,7 @@ import { NGSSliceFareCard } from "./NGSSliceFareCard";
 import { NGSShelfInfoCard } from "./NGSShelfInfoCard";
 import { SliceSummary } from "./SliceSummary";
 import { OfferSliceModal } from "@components/OfferSliceModal/OfferSliceModal";
-import { OfferRequest } from "@duffel/api/types";
+import { OfferRequest, OfferSlice } from "@duffel/api/types";
 
 export interface NGSTableProps {
   offers: OfferRequest["offers"];
@@ -47,6 +47,8 @@ export const NGSTable: React.FC<NGSTableProps> = ({
     React.useState<OfferPosition | null>(null);
   const [isOfferSliceModalOpen, setIsOfferSliceModalOpen] =
     React.useState<boolean>(false);
+  const [offerSliceModalSlice, setOfferSliceModalSlice] =
+    React.useState<OfferSlice>(offers[0].slices[sliceIndex]);
 
   React.useEffect(() => {
     setSelectedColumn(null);
@@ -140,16 +142,14 @@ export const NGSTable: React.FC<NGSTableProps> = ({
                   <SliceCarriersTitle slice={row["slice"]} />
                   <SliceSummary slice={row["slice"]} />
                   <button
-                    onClick={() => setIsOfferSliceModalOpen(true)}
+                    onClick={() => {
+                      setOfferSliceModalSlice(row["slice"]);
+                      setIsOfferSliceModalOpen(true);
+                    }}
                     className="ngs-table_slice-details-button"
                   >
                     View details
                   </button>
-                  <OfferSliceModal
-                    slice={row["slice"]}
-                    isOpen={isOfferSliceModalOpen}
-                    onClose={() => setIsOfferSliceModalOpen(false)}
-                  />
                 </td>
                 {NGS_SHELVES.map((shelf) => (
                   <td
@@ -212,6 +212,11 @@ export const NGSTable: React.FC<NGSTableProps> = ({
           ))}
         </tbody>
       </table>
+      <OfferSliceModal
+        slice={offerSliceModalSlice}
+        isOpen={isOfferSliceModalOpen}
+        onClose={() => setIsOfferSliceModalOpen(false)}
+      />
     </div>
   );
 };


### PR DESCRIPTION
On the dashboard we're seeing weird behaviour where the "View details" modal for NGS slices is buggy - it is laggy to click and close, the screen goes black, etc.

I don't see any of that in stories. My current speculative theory is that this could be happening because the tables on the dashboard are much larger than in the examples (hundreds vs a couple), and we were creating one modal per row. This refactors so we only create one modal per table. 

Even if this doesn't fix the problem I still think it's a nice refactor. I would test it locally but it's quite hard with setting up a local dashboard with all the NGS feature flags to then use the local instance of duffel components. So once I've published a (canary) release I'll test that on dashboard staging.