### PR TITLE
Add fare brand name and trip type

### DIFF
--- a/src/components/DuffelNGSView/NGSTable.tsx
+++ b/src/components/DuffelNGSView/NGSTable.tsx
@@ -18,6 +18,10 @@ import { NGSShelfInfoCard } from "./NGSShelfInfoCard";
 import { SliceSummary } from "./SliceSummary";
 import { OfferSliceModal } from "@components/OfferSliceModal/OfferSliceModal";
 import { OfferRequest, OfferSlice } from "@duffel/api/types";
+import {
+  getCheapestOffer,
+  getFareBrandNameForOffer,
+} from "./lib/deduplicate-mapped-offers-by-fare-brand";
 
 export interface NGSTableProps {
   offers: OfferRequest["offers"];
@@ -65,6 +69,15 @@ export const NGSTable: React.FC<NGSTableProps> = ({
   if (offers.length == 0) {
     return null;
   }
+
+  let tripType = "";
+  if (offers[0].slices.length == 1) tripType = "One-way";
+  if (
+    offers[0].slices.length == 2 &&
+    offers[0].slices[0].origin.iata_code ===
+      offers[0].slices[1].destination.iata_code
+  )
+    tripType = "Roundtrip";
 
   return (
     <div className="ngs-table">
@@ -174,11 +187,25 @@ export const NGSTable: React.FC<NGSTableProps> = ({
                         "ngs-table_table-data--expanded",
                     )}
                   >
-                    {row[shelf]
-                      ? moneyStringFormatter(row[shelf]![0].total_currency)(
-                          getCheapestOfferAmount(row[shelf])!,
-                        )
-                      : "-"}
+                    {row[shelf] ? (
+                      <div>
+                        <p className="ngs-table_table-data--details">
+                          {getFareBrandNameForOffer(
+                            getCheapestOffer(row[shelf]!),
+                          )}
+                        </p>
+                        <p>
+                          {moneyStringFormatter(row[shelf]![0].total_currency)(
+                            getCheapestOfferAmount(row[shelf])!,
+                          )}
+                        </p>
+                        <p className="ngs-table_table-data--details">
+                          {tripType}
+                        </p>
+                      </div>
+                    ) : (
+                      "-"
+                    )}
                   </td>
                 ))}
               </tr>

--- a/src/styles/components/NGSTable.css
+++ b/src/styles/components/NGSTable.css
@@ -74,6 +74,12 @@
   font-weight: 600;
 }
 
+.ngs-table_table-data--details {
+  font-size: 12px;
+  margin-top: 2px;
+  margin-bottom: 12px;
+}
+
 .ngs-table_slice-info {
   padding: 24px 16px 20px 16px;
   width: 300px;


### PR DESCRIPTION
Add fare brand name and trip type: 

<img width="1047" alt="Screenshot 2024-04-15 at 13 49 57" src="https://github.com/duffelhq/duffel-components/assets/1416759/26374ac9-bea7-4670-b772-cd4b5d834b98">

As per https://duffel.slack.com/archives/C06A8HUCDPW/p1713179082461439?thread_ts=1713178517.871889&cid=C06A8HUCDPW