### PR TITLE
Make offer slice modal header stick to top

### DIFF
--- a/src/components/OfferSliceModal/OfferSliceModal.tsx
+++ b/src/components/OfferSliceModal/OfferSliceModal.tsx
@@ -14,11 +14,11 @@ export const OfferSliceModal: React.FC<OfferSliceModalProps> = ({
 }) => {
   return (
     <Modal {...modalProps}>
+      <div className="offer-slice-modal-title offer-slice-modal-padding">
+        Flight Details
+      </div>
+      <hr className="offer-slice-modal-divider" />
       <ModalBody tall noPadding>
-        <div className="offer-slice-modal-title offer-slice-modal-padding">
-          Flight Details
-        </div>
-        <hr className="offer-slice-modal-divider" />
         <VSpace space={24} className="offer-slice-modal-padding">
           <SliceCarriersTitle slice={slice} />
           <SliceSummary slice={slice} />


### PR DESCRIPTION
This PR takes the offer slice modal header out of the ModalBody as that is scrollable.

Before:

https://github.com/duffelhq/duffel-components/assets/1416759/3e1cfcbb-a152-441b-a8bb-e2cc2c5c15f0


After:

https://github.com/duffelhq/duffel-components/assets/1416759/873cb5d4-61d6-4805-8cda-278eb8aef555

