### PR TITLE
Make NGS table header sticky

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@duffel/components",
-  "version": "3.7.3",
+  "version": "3.7.4",
   "description": "Component library to build your travel product with Duffel.",
   "keywords": [
     "Duffel",

--- a/src/components/DuffelNGSView/DuffelNGSView.tsx
+++ b/src/components/DuffelNGSView/DuffelNGSView.tsx
@@ -29,8 +29,8 @@ export const DuffelNGSView: React.FC<DuffelNGSViewProps> = ({
       : offerRequest.slices[0];
 
   return (
-    <WithComponentStyles>
-      <div className="duffel-components duffel-ngs-view">
+    <div className="duffel-ngs-view">
+      <WithComponentStyles>
         {currentSlice && (
           <>
             <div className="duffel-ngs-view_breadcrumbs">
@@ -83,7 +83,7 @@ export const DuffelNGSView: React.FC<DuffelNGSViewProps> = ({
             }
           }}
         />
-      </div>
-    </WithComponentStyles>
+      </WithComponentStyles>
+    </div>
   );
 };

--- a/src/components/DuffelNGSView/NGSTable.tsx
+++ b/src/components/DuffelNGSView/NGSTable.tsx
@@ -84,7 +84,7 @@ export const NGSTable: React.FC<NGSTableProps> = ({
       <table className="ngs-table_table">
         <thead>
           <tr className="ngs-table_table-header">
-            <th className="ngs-table_th"></th>
+            <th className="ngs-table_th ngs-table_th--sticky"></th>
             {NGS_SHELVES.map((shelf) => (
               <th
                 key={shelf}
@@ -97,6 +97,7 @@ export const NGSTable: React.FC<NGSTableProps> = ({
                   setSelectedColumn(shelf);
                   setExpandedOffer(null);
                 }}
+                className="ngs-table_th--sticky"
               >
                 <div
                   className={classNames(

--- a/src/styles/components/DuffelNGSView.css
+++ b/src/styles/components/DuffelNGSView.css
@@ -1,7 +1,9 @@
 .duffel-ngs-view {
-  /* To override duffel-components overflow */
-  overflow: auto !important;
   padding-top: 40px;
+}
+
+.duffel-ngs-view .duffel-components {
+  overflow: unset;
 }
 
 .duffel-ngs-view_heading {

--- a/src/styles/components/NGSTable.css
+++ b/src/styles/components/NGSTable.css
@@ -8,6 +8,7 @@
 
   text-align: center;
   cursor: pointer;
+  position: relative;
 }
 
 .ngs-table_table > thead {
@@ -138,7 +139,7 @@
   visibility: hidden;
   position: absolute;
   z-index: 1;
-  top: -140px;
+  top: -150px;
   left: 25px;
   width: 420px;
   text-align: left;
@@ -170,4 +171,11 @@
 
 .ngs-table_th {
   width: 300px;
+}
+
+.ngs-table_th--sticky {
+  position: sticky;
+  top: 0;
+  background-color: var(--GREY-100);
+  z-index: 1;
 }


### PR DESCRIPTION
This is the first part of https://duffel.atlassian.net/browse/UXP-3437?atlOrigin=eyJpIjoiNmMyYTMyZjMwNTY1NDBjZjk1ZTY0MWVkYWZkMzk4NjciLCJwIjoiamlyYS1zbGFjay1pbnQifQ.
It will require more than just a bump on the dashboard, started working on that here: https://github.com/duffelhq/dashboard/pull/4919

Some notes:
Currently the NGS table is structured as an html table. These have some funny [limitations](https://css-tricks.com/position-sticky-and-table-headers/) with sticky positioning, e.g. you have to put it on `th` elements rather than `thead` or `tr`.

More importantly, having any parent with overflow  set can break stickiness. In this case we have a few on the dashboard - on the page, its content, and around the NGS table (we had scrolling issues before). I’ve tried unsetting them but unsurprisingly this results in a bit of a mess, so it'll need a bit more thinking/work. 