### PR TITLE
Adds mixed cabin help popover

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@duffel/components",
-  "version": "3.7.7",
+  "version": "3.7.8",
   "description": "Component library to build your travel product with Duffel.",
   "keywords": [
     "Duffel",

--- a/src/components/DuffelNGSView/NGSSliceFareCard.tsx
+++ b/src/components/DuffelNGSView/NGSSliceFareCard.tsx
@@ -65,6 +65,16 @@ export const NGSSliceFareCard: React.FC<NGSSliceFareCardProps> = ({
               <div className="ngs-slice-fare-card_mixed-cabins margin-t-8">
                 <Icon name="info_outline" size={12} />
                 Multiple cabins
+                <div className="ngs-slice-fare-card_mixed-cabins-popover">
+                  {slice.segments.map((segment, index) => (
+                    <p key={`slice_${index}`}>
+                      {segment.origin.iata_code} →{" "}
+                      {segment.destination.iata_code}
+                      <span className="margin-x-12">|</span>
+                      {segment.passengers[0].cabin_class_marketing_name}
+                    </p>
+                  ))}
+                </div>
               </div>
             )}
           </div>

--- a/src/styles/components/NGSTable.css
+++ b/src/styles/components/NGSTable.css
@@ -94,6 +94,31 @@
   align-items: center;
   align-self: center;
   margin-inline: auto;
+  position: relative;
+  white-space: nowrap;
+  cursor: help;
+}
+
+.ngs-slice-fare-card_mixed-cabins:hover
+  .ngs-slice-fare-card_mixed-cabins-popover {
+  display: grid;
+}
+
+.ngs-slice-fare-card_mixed-cabins-popover {
+  display: none;
+  position: absolute;
+  z-index: 1;
+  background-color: white;
+  border: 2px solid var(--GREY-100);
+  border-radius: 4px;
+  padding: 12px 16px;
+  width: 175px;
+  color: black;
+  top: 30px;
+  right: 0;
+  box-shadow: 0px 4px 8px rgba(0, 0, 0, 0.1);
+  grid-template-columns: 1fr;
+  row-gap: 4px;
 }
 
 .ngs-table_slice-info {

--- a/src/styles/utilities.css
+++ b/src/styles/utilities.css
@@ -93,6 +93,10 @@
   margin-bottom: 12px;
 }
 
+.margin-x-12 {
+  margin-inline: 12px;
+}
+
 /* TEXT */
 .font-size-14 {
   font-size: 14px;


### PR DESCRIPTION
__what__

If you are browsing flights it's easier as a customer to be able to see what are the cabin classes of segments by hovering over the "multiple cabins tag". so you don't need to leave the NGS view. This PR implements that:


https://github.com/duffelhq/duffel-components/assets/2934495/13d84ab4-f92c-43eb-8a70-aa93f117434d

- [Reported on slack ](https://duffel.slack.com/archives/C06A8HUCDPW/p1715092788231169?thread_ts=1714557642.240609&cid=C06A8HUCDPW)