### PR TITLE
Update source URL in package manifest

### DIFF
--- a/package.json
+++ b/package.json
@@ -10,13 +10,13 @@
     "baggage",
     "travel"
   ],
-  "homepage": "https://github.com/duffelhq/duffel-checkout#readme",
+  "homepage": "https://github.com/duffelhq/duffel-components#readme",
   "bugs": {
-    "url": "https://github.com/duffelhq/duffel-checkout/issues"
+    "url": "https://github.com/duffelhq/duffel-components/issues"
   },
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/duffelhq/duffel-checkout.git"
+    "url": "git+https://github.com/duffelhq/duffel-components.git"
   },
   "license": "MIT",
   "maintainers": [


### PR DESCRIPTION
💁 A different (perhaps old?) repository name was used as part of https://github.com/duffelhq/duffel-components/pull/166. While that URL correctly redirects to this repository, it could be confusing for future readers.

```
$ curl -I https://github.com/duffelhq/duffel-checkout
HTTP/2 301
server: GitHub.com
date: Mon, 20 May 2024 12:29:59 GMT
content-type: text/html; charset=utf-8
vary: X-PJAX, X-PJAX-Container, Turbo-Visit, Turbo-Frame, Accept-Encoding, Accept, X-Requested-With
location: https://github.com/duffelhq/duffel-components
...
```

This change updates the URL for this repository accordingly.