### PR TITLE
Add handler for security policy violations for DuffelCardForm

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@duffel/components",
-  "version": "3.7.11",
+  "version": "3.7.12",
   "description": "Component library to build your travel product with Duffel.",
   "keywords": [
     "Duffel",

--- a/src/components/DuffelCardForm/DuffelCardForm.tsx
+++ b/src/components/DuffelCardForm/DuffelCardForm.tsx
@@ -24,6 +24,7 @@ export const DuffelCardForm = React.forwardRef<
       onCreateCardForTemporaryUseFailure,
       onSaveCardSuccess,
       onSaveCardFailure,
+      onSecurityPolicyViolation,
     },
     ref,
   ) => {
@@ -81,6 +82,7 @@ export const DuffelCardForm = React.forwardRef<
         onCreateCardForTemporaryUseFailure,
         onSaveCardSuccess,
         onSaveCardFailure,
+        onSecurityPolicyViolation,
       });
 
       window.addEventListener("message", iFrameEventListener);

--- a/src/components/DuffelCardForm/DuffelCardFormCustomElement.tsx
+++ b/src/components/DuffelCardForm/DuffelCardFormCustomElement.tsx
@@ -34,6 +34,7 @@ declare global {
     onSaveCardFailure: typeof onSaveCardFailure;
     onCreateCardForTemporaryUseSuccess: typeof onCreateCardForTemporaryUseSuccess;
     onCreateCardForTemporaryUseFailure: typeof onCreateCardForTemporaryUseFailure;
+    onSecurityPolicyViolation: typeof onSecurityPolicyViolation;
   }
 }
 
@@ -132,6 +133,14 @@ class DuffelCardFormCustomElement extends HTMLElement {
             }),
           )
         }
+        onSecurityPolicyViolation={(data) =>
+          this.dispatchEvent(
+            new CustomEvent("onSecurityPolicyViolation", {
+              detail: { data },
+              composed: true,
+            }),
+          )
+        }
       />,
     );
   }
@@ -190,6 +199,7 @@ type DuffelCardFormPropActions = Pick<
   | "onSaveCardFailure"
   | "onCreateCardForTemporaryUseSuccess"
   | "onCreateCardForTemporaryUseFailure"
+  | "onSecurityPolicyViolation"
 >;
 
 function registerCallbackFactory<T extends keyof DuffelCardFormPropActions>(
@@ -238,6 +248,11 @@ export const onCreateCardForTemporaryUseFailure = registerCallbackFactory(
   "error",
 );
 
+export const onSecurityPolicyViolation = registerCallbackFactory(
+  "onSecurityPolicyViolation",
+  "data",
+);
+
 window.renderDuffelCardFormCustomElement = renderDuffelCardFormCustomElement;
 window.saveCard = saveCard;
 window.createCardForTemporaryUse = createCardForTemporaryUse;
@@ -247,3 +262,4 @@ window.onSaveCardSuccess = onSaveCardSuccess;
 window.onSaveCardFailure = onSaveCardFailure;
 window.onCreateCardForTemporaryUseSuccess = onCreateCardForTemporaryUseSuccess;
 window.onCreateCardForTemporaryUseFailure = onCreateCardForTemporaryUseFailure;
+window.onSecurityPolicyViolation = onSecurityPolicyViolation;

--- a/src/components/DuffelCardForm/lib/getIFrameEventListener.ts
+++ b/src/components/DuffelCardForm/lib/getIFrameEventListener.ts
@@ -11,6 +11,7 @@ type Inputs = {
   | "onCreateCardForTemporaryUseFailure"
   | "onSaveCardSuccess"
   | "onSaveCardFailure"
+  | "onSecurityPolicyViolation"
 >;
 
 export function getIFrameEventListener(
@@ -24,6 +25,7 @@ export function getIFrameEventListener(
     onCreateCardForTemporaryUseFailure,
     onSaveCardSuccess,
     onSaveCardFailure,
+    onSecurityPolicyViolation,
   }: Inputs,
 ) {
   return function iFrameEventListener(event: MessageEvent) {
@@ -92,6 +94,17 @@ export function getIFrameEventListener(
         } else {
           console.warn("`onSaveCardFailure` not implemented");
         }
+        return;
+
+      case "security-policy-violation":
+        if (onSecurityPolicyViolation) {
+          onSecurityPolicyViolation(event.data.data);
+        } else {
+          console.warn("`onSecurityPolicyViolation` not implemented");
+        }
+        return;
+
+      case "load":
         return;
 
       default:

--- a/src/components/DuffelCardForm/lib/types.ts
+++ b/src/components/DuffelCardForm/lib/types.ts
@@ -9,6 +9,10 @@ interface CardActionError {
   message: string;
 }
 
+export interface SecurityPolicyViolationData {
+  violated_directive: string;
+}
+
 export interface CreateCardForTemporaryUseData extends CommonCardData {
   saved: false;
   /** The card will no longer be available for use after this time. */
@@ -148,4 +152,9 @@ export interface DuffelCardFormProps {
    * `useDuffelCardFormActions` hook.
    */
   onSaveCardFailure?: (error: SaveCardError) => void;
+
+  /**
+   * This function will be called if a security policy violation is detected.
+   */
+  onSecurityPolicyViolation?: (data: SecurityPolicyViolationData) => void;
 }

--- a/src/custom-elements.ts
+++ b/src/custom-elements.ts
@@ -12,6 +12,7 @@ export {
   onCreateCardForTemporaryUseSuccess,
   onSaveCardFailure,
   onSaveCardSuccess,
+  onSecurityPolicyViolation,
   renderDuffelCardFormCustomElement,
   saveCard,
 } from "./components/DuffelCardForm/DuffelCardFormCustomElement";


### PR DESCRIPTION
For PCI compliance, we need to be able to detect CSP violations wherever we use the card form ([Dashboard](https://duffel.atlassian.net/browse/UXP-3447) and [Links](https://duffel.atlassian.net/browse/UXP-3448)). The initial [plan](https://duffel.slack.com/archives/C013XQ3T2J1/p1714485079430949?thread_ts=1713781035.301879&cid=C013XQ3T2J1) was to do that there using the `securitypolicyviolation event`. I tried to do that but couldn't detect the event on dashboard. I believe it's because the event happens within the iframe and isn't bubbled up to the parent window (similar [StackOverflow](https://stackoverflow.com/questions/44949085/is-there-any-event-fired-when-x-frame-options-content-security-policy-are-viol)). I was able to detect it inside the iframe, so I've added a function [there](https://github.com/duffelhq/token-proxy/pull/363) where the consumer can add a handler to these violations (in our case we'll send them to the respective Sentry instances). You can see its usage on the companion PRs:
- https://github.com/duffelhq/dashboard/pull/4957
- https://github.com/duffelhq/platform/pull/18720

The [token-proxy PR](https://github.com/duffelhq/token-proxy/pull/363) will have to be merged and [deployed](TODO) first for any of the others to work properly, then this one should be released. 