### PR TITLE
Consistent casing for fare brand names in NGS

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@duffel/components",
-  "version": "3.7.12",
+  "version": "3.7.13",
   "description": "Component library to build your travel product with Duffel.",
   "keywords": [
     "Duffel",

--- a/src/components/DuffelNGSView/lib/deduplicate-mapped-offers-by-fare-brand.ts
+++ b/src/components/DuffelNGSView/lib/deduplicate-mapped-offers-by-fare-brand.ts
@@ -5,6 +5,7 @@ import {
 } from "@duffel/api/types";
 import { NGSOfferRow } from "./group-offers-for-ngs-view";
 import { NGS_SHELVES } from ".";
+import { startCase } from "lodash";
 
 // Deduplicate fare brands (only show the cheapest offer within fare brand)
 export const deduplicateMappedOffersByFareBrand = (
@@ -49,9 +50,9 @@ export const getFareBrandNameForOffer = (
       [],
     );
 
-  return (
-    offer.slices[sliceIndex || 0].fare_brand_name || cabinClasses.join("/")
-  );
+  const fareBrandName =
+    offer.slices[sliceIndex || 0].fare_brand_name || cabinClasses.join("/");
+  return startCase(fareBrandName);
 };
 
 export const getCheapestOffer = (offers: OfferRequest["offers"]) =>

--- a/src/stories/NGSSliceFareCard.stories.tsx
+++ b/src/stories/NGSSliceFareCard.stories.tsx
@@ -78,5 +78,23 @@ export const FullList: React.FC = () => (
       sliceIndex={1}
       onSelect={console.log}
     />
+    <NGSSliceFareCard
+      offer={{
+        ...offer,
+        total_amount: 500,
+        slices: [
+          {
+            ...offer.slices[0],
+            fare_brand_name: "premium_economy",
+          },
+          {
+            ...offer.slices[1],
+            fare_brand_name: "premium_economy",
+          },
+        ],
+      }}
+      sliceIndex={1}
+      onSelect={console.log}
+    />
   </div>
 );


### PR DESCRIPTION
Make sure that all fare brand names are title cased and don't have any underscores (e.g. `premium_economy`).
To address comments from https://www.notion.so/NGS-for-Delta-6a67026c68864c3988afe42cbaa04b3b?d=5936b24da11740898c7f328f34479fcc&pvs=4#62db6d750cea4a499a63e224a8dd720a and https://www.notion.so/NGS-for-Delta-6a67026c68864c3988afe42cbaa04b3b?d=74c18a2b5b334eec8fb742801ddcd2f9&pvs=4#3b535cf084554bf59af1dda451047971.

New story screenshot:
<img width="867" alt="Screenshot 2024-05-30 at 09 19 43" src="https://github.com/duffelhq/duffel-components/assets/1416759/1acf74ac-ef61-4db4-ac28-d2280cc1941a">
