### PR TITLE
Replace lodash with regex for start case in NGS fare brand name

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@duffel/components",
-  "version": "3.7.13",
+  "version": "3.7.14",
   "description": "Component library to build your travel product with Duffel.",
   "keywords": [
     "Duffel",

--- a/src/components/DuffelNGSView/lib/deduplicate-mapped-offers-by-fare-brand.ts
+++ b/src/components/DuffelNGSView/lib/deduplicate-mapped-offers-by-fare-brand.ts
@@ -5,7 +5,6 @@ import {
 } from "@duffel/api/types";
 import { NGSOfferRow } from "./group-offers-for-ngs-view";
 import { NGS_SHELVES } from ".";
-import { startCase } from "lodash";
 
 // Deduplicate fare brands (only show the cheapest offer within fare brand)
 export const deduplicateMappedOffersByFareBrand = (
@@ -52,7 +51,9 @@ export const getFareBrandNameForOffer = (
 
   const fareBrandName =
     offer.slices[sliceIndex || 0].fare_brand_name || cabinClasses.join("/");
-  return startCase(fareBrandName);
+  return fareBrandName
+    .replace(/_/g, " ")
+    .replace(/\b\w/g, (c) => c.toUpperCase());
 };
 
 export const getCheapestOffer = (offers: OfferRequest["offers"]) =>


### PR DESCRIPTION
It seems that using lodash in [this recent PR ](https://github.com/duffelhq/duffel-components/pull/291) breaks the exports for at least some stays components (as seen on [Chromatic builds ](https://www.chromatic.com/build?appId=5f5f5a24adceb80022a613f8&number=16953) when I tried to bump the version in dashboard). I've tried publishing a canary version with lodash and one without (using the `replace` seen here), and the latter works fine: https://github.com/duffelhq/dashboard/pull/4963