### PR TITLE
Make pay now rates by card possible

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@duffel/components",
-  "version": "3.7.14",
+  "version": "3.7.15",
   "description": "Component library to build your travel product with Duffel.",
   "keywords": [
     "Duffel",

--- a/src/components/Stays/StaysRoomRateCard.tsx
+++ b/src/components/Stays/StaysRoomRateCard.tsx
@@ -8,6 +8,7 @@ import {
 } from "./lib/types";
 import { moneyStringFormatter } from "@lib/moneyStringFormatter";
 import { getDateString } from "@lib/getDateString";
+import { getRateLabel } from "./lib/getRateLabel";
 import { HSpace } from "@components/shared/HSpace";
 import { Icon, IconName } from "@components/shared/Icon";
 import { VSpace } from "@components/shared/VSpace";
@@ -109,11 +110,7 @@ export const StaysRoomRateCard: React.FC<StaysRoomRateCardProps> = ({
                 <StayResultRoomRateItem
                   key={paymentMethod}
                   icon={paymentMethod === "card" ? "credit_card" : "wallet"}
-                  label={
-                    paymentMethod === "card"
-                      ? "Card payment at accommodation"
-                      : "Pay now with Duffel Balance"
-                  }
+                  label={getRateLabel(paymentMethod, rate.payment_type)}
                 />
               ))}
 

--- a/src/components/Stays/lib/getRateLabel.ts
+++ b/src/components/Stays/lib/getRateLabel.ts
@@ -1,0 +1,13 @@
+import { StaysRate } from "@duffel/api/types";
+
+export const getRateLabel = (
+  paymentMethod: StaysRate["payment_method"],
+  paymentType: StaysRate["payment_type"],
+): string | undefined => {
+  if (paymentMethod === "card" && paymentType === "pay_now")
+    return "Pay now with card";
+  if (paymentMethod === "card" && paymentType === "guarantee")
+    return "Card payment at accommodation";
+  if (paymentMethod === "balance") return "Pay now with Duffel Balance";
+  if (paymentMethod === "card") return "Pay with card";
+};

--- a/src/stories/StaysRoomRateCard.stories.tsx
+++ b/src/stories/StaysRoomRateCard.stories.tsx
@@ -47,6 +47,32 @@ export const RateWithMinimalInformation = {
   },
 };
 
+export const PayLaterRate = {
+  render: Template,
+  args: {
+    roomRates: [
+      {
+        rate: {
+          ...accommodation.rooms[0].rates[0],
+          available_payment_methods: ["card"],
+          payment_type: "guarantee",
+          source: "bookingcom",
+          id: "rat_0000AiYKQhfXjogdfBkiA4",
+          cancellation_timeline: [
+            {
+              refund_amount: "799.00",
+              currency: "GBP",
+              before: "2025-08-01T00:00:00Z",
+            },
+          ],
+        },
+        numberOfNights: 3,
+        searchNumberOfRooms: 2,
+      },
+    ],
+  },
+};
+
 export const RateWithCompleteInformation = {
   render: Template,
 
@@ -67,6 +93,7 @@ export const RatesCrossComparison = {
   args: {
     roomRates: [
       ...RateWithMinimalInformation.args.roomRates,
+      ...PayLaterRate.args.roomRates,
       ...RateWithCompleteInformation.args.roomRates,
     ],
   },

--- a/src/tests/lib/getRateLabel.spec.ts
+++ b/src/tests/lib/getRateLabel.spec.ts
@@ -19,6 +19,16 @@ describe("getRateLabel", () => {
     expect(label).toEqual("Card payment at accommodation");
   });
 
+  test("returns the right label for a card rate with unknown type", () => {
+    const paymentMethod = "card";
+    const paymentType = "pay_later";
+
+    // @ts-expect-error assuming we receive a new payment type we have not identified yet
+    const label = getRateLabel(paymentMethod, paymentType);
+
+    expect(label).toEqual("Pay with card");
+  });
+
   test("returns the right label for a balance rate", () => {
     const paymentMethod = "balance";
     const paymentType = "pay_now";

--- a/src/tests/lib/getRateLabel.spec.ts
+++ b/src/tests/lib/getRateLabel.spec.ts
@@ -1,0 +1,30 @@
+import { getRateLabel } from "@components/Stays/lib/getRateLabel";
+
+describe("getRateLabel", () => {
+  test("returns the right label for a pay now card rate", () => {
+    const paymentMethod = "card";
+    const paymentType = "pay_now";
+
+    const label = getRateLabel(paymentMethod, paymentType);
+
+    expect(label).toEqual("Pay now with card");
+  });
+
+  test("returns the right label for a guarantee card rate", () => {
+    const paymentMethod = "card";
+    const paymentType = "guarantee";
+
+    const label = getRateLabel(paymentMethod, paymentType);
+
+    expect(label).toEqual("Card payment at accommodation");
+  });
+
+  test("returns the right label for a balance rate", () => {
+    const paymentMethod = "balance";
+    const paymentType = "pay_now";
+
+    const label = getRateLabel(paymentMethod, paymentType);
+
+    expect(label).toEqual("Pay now with Duffel Balance");
+  });
+});


### PR DESCRIPTION
### What's here?

This makes us better able to convey that a rate is payable by card IMMEDIATELY

We then illustrate that this is possible via storybook (See third rate with multiple payment methods for pay_now type)

![image](https://github.com/duffelhq/duffel-components/assets/6396347/51e657a2-0bde-4b27-8699-2af4226b1c55)

