### PR TITLE
Fix segments carrier title condition

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@duffel/components",
-  "version": "3.7.14",
+  "version": "3.7.15",
   "description": "Component library to build your travel product with Duffel.",
   "keywords": [
     "Duffel",

--- a/src/components/shared/SliceCarriersTitle.tsx
+++ b/src/components/shared/SliceCarriersTitle.tsx
@@ -65,8 +65,6 @@ export function getSegmentCarriersTitle(segment: OfferSliceSegment) {
     marketingCarrier.name === operatingCarrier.name;
 
   return `${marketingCarrier.name}${
-    !isOperatedByMarketingCarrier
-      ? ""
-      : ` operated by ${operatingCarrier.name} `
+    isOperatedByMarketingCarrier ? "" : ` operated by ${operatingCarrier.name} `
   }`;
 }


### PR DESCRIPTION
As reported in this thread, our "operated by" text was incorrect. I think the condition should not have been negated.

Now (for the [offer](https://jet.x15.xyz/air/offers/off_0000AiihR5LtcpCV0NGu65/view_api_offer) in the Slack thread):
<img width="653" alt="Screenshot 2024-06-08 at 15 23 12" src="https://github.com/duffelhq/duffel-components/assets/1416759/df1b2aa6-2184-4180-a938-986ae1aadf7c">
