### PR TITLE
Verion bump

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@duffel/components",
-  "version": "3.7.15",
+  "version": "3.7.16",
   "description": "Component library to build your travel product with Duffel.",
   "keywords": [
     "Duffel",


### PR DESCRIPTION
I didn't realise 3.7.15 had already been published 5 days ago: https://www.npmjs.com/package/@duffel/components?activeTab=versions