### PR TITLE
[UXP-3498] Not showing null atrributes for NGS

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@duffel/components",
-  "version": "3.7.16",
+  "version": "3.7.17",
   "description": "Component library to build your travel product with Duffel.",
   "keywords": [
     "Duffel",

--- a/src/components/DuffelNGSView/NGSSliceFareCard.tsx
+++ b/src/components/DuffelNGSView/NGSSliceFareCard.tsx
@@ -139,38 +139,44 @@ export const NGSSliceFareCard: React.FC<NGSSliceFareCardProps> = ({
             />
             Checked bag
           </div>
-          <div className="ngs-slice-fare-card_item">
-            <Icon
-              name={
-                slice.conditions.advance_seat_selection
-                  ? "check_small"
-                  : "close"
-              }
-              color="--GREY-600"
-              size={20}
-            />
-            Seat selection
-          </div>
-          <div className="ngs-slice-fare-card_item">
-            <Icon
-              name={
-                slice.conditions.priority_boarding ? "check_small" : "close"
-              }
-              color="--GREY-600"
-              size={20}
-            />
-            Priority boarding
-          </div>
-          <div className="ngs-slice-fare-card_item">
-            <Icon
-              name={
-                slice.conditions.priority_check_in ? "check_small" : "close"
-              }
-              color="--GREY-600"
-              size={20}
-            />
-            Priority check-in
-          </div>
+          {slice.conditions.advance_seat_selection !== null && (
+            <div className="ngs-slice-fare-card_item">
+              <Icon
+                name={
+                  slice.conditions.advance_seat_selection
+                    ? "check_small"
+                    : "close"
+                }
+                color="--GREY-600"
+                size={20}
+              />
+              Seat selection
+            </div>
+          )}
+          {slice.conditions.priority_boarding !== null && (
+            <div className="ngs-slice-fare-card_item">
+              <Icon
+                name={
+                  slice.conditions.priority_boarding ? "check_small" : "close"
+                }
+                color="--GREY-600"
+                size={20}
+              />
+              Priority boarding
+            </div>
+          )}
+          {slice.conditions.priority_check_in !== null && (
+            <div className="ngs-slice-fare-card_item">
+              <Icon
+                name={
+                  slice.conditions.priority_check_in ? "check_small" : "close"
+                }
+                color="--GREY-600"
+                size={20}
+              />
+              Priority check-in
+            </div>
+          )}
         </div>
       </div>
       <div className="ngs-slice-fare-card_footer">

--- a/src/components/shared/SliceCarriersTitle.tsx
+++ b/src/components/shared/SliceCarriersTitle.tsx
@@ -52,6 +52,17 @@ export const SliceCarriersTitle: React.FC<SliceCarriersTitleProps> = ({
             {operatingCarriersLabel})
           </span>
         )}
+        <span className="slice-carriers-title__operating-carrier">
+          {" "}
+          ·{" "}
+          {slice.segments
+            .map(
+              (segment) =>
+                segment.marketing_carrier.iata_code +
+                segment.marketing_carrier_flight_number,
+            )
+            .join(", ")}
+        </span>
       </div>
     </HSpace>
   );

--- a/src/fixtures/offer-requests/orq_0000Ab7taNqbK8y5YqW6Zk.json
+++ b/src/fixtures/offer-requests/orq_0000Ab7taNqbK8y5YqW6Zk.json
@@ -191,7 +191,7 @@
                   "conditions": {
                     "priority_boarding": false,
                     "priority_check_in": false,
-                    "advanced_seat_selection": false
+                    "advance_seat_selection": false
                   }
                 }
               ],
@@ -324,7 +324,7 @@
             },
             "priority_boarding": false,
             "priority_check_in": false,
-            "advanced_seat_selection": false
+            "advance_seat_selection": false
           },
           "ngs_shelf": 1
         },
@@ -369,7 +369,7 @@
                   "conditions": {
                     "priority_boarding": false,
                     "priority_check_in": false,
-                    "advanced_seat_selection": false
+                    "advance_seat_selection": false
                   }
                 }
               ],
@@ -502,7 +502,7 @@
             },
             "priority_boarding": true,
             "priority_check_in": true,
-            "advanced_seat_selection": true
+            "advance_seat_selection": true
           },
           "ngs_shelf": 1
         }
@@ -614,7 +614,7 @@
                   "conditions": {
                     "priority_boarding": true,
                     "priority_check_in": false,
-                    "advanced_seat_selection": true
+                    "advance_seat_selection": true
                   }
                 }
               ],
@@ -747,7 +747,7 @@
             },
             "priority_boarding": true,
             "priority_check_in": false,
-            "advanced_seat_selection": true
+            "advance_seat_selection": true
           },
           "ngs_shelf": 2
         },
@@ -792,7 +792,7 @@
                   "conditions": {
                     "priority_boarding": true,
                     "priority_check_in": false,
-                    "advanced_seat_selection": true
+                    "advance_seat_selection": true
                   }
                 }
               ],
@@ -925,7 +925,7 @@
             },
             "priority_boarding": true,
             "priority_check_in": false,
-            "advanced_seat_selection": true
+            "advance_seat_selection": true
           },
           "ngs_shelf": 2
         }
@@ -1036,7 +1036,7 @@
                   "conditions": {
                     "priority_boarding": true,
                     "priority_check_in": true,
-                    "advanced_seat_selection": true
+                    "advance_seat_selection": true
                   }
                 }
               ],
@@ -1169,7 +1169,7 @@
             },
             "priority_boarding": true,
             "priority_check_in": true,
-            "advanced_seat_selection": true
+            "advance_seat_selection": true
           },
           "ngs_shelf": 5
         },
@@ -1214,7 +1214,7 @@
                   "conditions": {
                     "priority_boarding": true,
                     "priority_check_in": false,
-                    "advanced_seat_selection": true
+                    "advance_seat_selection": true
                   }
                 }
               ],
@@ -1347,7 +1347,7 @@
             },
             "priority_boarding": true,
             "priority_check_in": false,
-            "advanced_seat_selection": true
+            "advance_seat_selection": true
           },
           "ngs_shelf": 5
         }

--- a/src/stories/NGSSliceFareCard.stories.tsx
+++ b/src/stories/NGSSliceFareCard.stories.tsx
@@ -85,10 +85,22 @@ export const FullList: React.FC = () => (
         slices: [
           {
             ...offer.slices[0],
+            conditions: {
+              change_before_departure: null,
+              priority_boarding: null,
+              priority_check_in: null,
+              advance_seat_selection: null,
+            },
             fare_brand_name: "premium_economy",
           },
           {
             ...offer.slices[1],
+            conditions: {
+              change_before_departure: null,
+              priority_boarding: null,
+              priority_check_in: null,
+              advance_seat_selection: null,
+            },
             fare_brand_name: "premium_economy",
           },
         ],

--- a/src/styles/components/NGSSliceFareCard.css
+++ b/src/styles/components/NGSSliceFareCard.css
@@ -37,6 +37,7 @@
   align-items: flex-start;
   margin-bottom: 16px;
   flex-grow: 1;
+  max-height: 52px;
 }
 
 .ngs-slice-fare-card_header > svg {

--- a/src/styles/components/SliceCarriersTitle.css
+++ b/src/styles/components/SliceCarriersTitle.css
@@ -4,6 +4,7 @@
   font-style: normal;
   font-weight: 500;
   line-height: 150%; /* 21px */
+  text-align: left;
 }
 
 .slice-carriers-title__operating-carrier {


### PR DESCRIPTION
A couple more things have been requested for NGS:

https://duffel.atlassian.net/browse/UXP-3498 - when the attribute is null, don't display it. Example:
<img width="758" alt="Screenshot 2024-06-14 at 11 43 44" src="https://github.com/duffelhq/duffel-components/assets/1416759/206655de-07da-4539-9262-cb5259a44b2f">
[Context on Slack](https://duffel.slack.com/archives/C06A8HUCDPW/p1718308935457959)

Making the flight numbers more visible ([context on Slack](https://duffel.slack.com/archives/C06A8HUCDPW/p1718355504097939)):
<img width="305" alt="Screenshot 2024-06-14 at 12 06 17" src="https://github.com/duffelhq/duffel-components/assets/1416759/5f960b54-3773-4eb1-bb7e-ecddb526c5bb">
Doesn't look amazing with a long title but we just want to get something done quickly:
<img width="307" alt="Screenshot 2024-06-14 at 13 12 24" src="https://github.com/duffelhq/duffel-components/assets/1416759/f9e90155-725f-4a15-9781-a4df70d1f8a9">
