### PR TITLE
Configure SWC compiler to import react runtime by default

### DIFF
--- a/.storybook/main.ts
+++ b/.storybook/main.ts
@@ -14,9 +14,23 @@ const config: StorybookConfig = {
   ],
 
   framework: {
-    name: getAbsolutePath("@storybook/react-webpack5"),
-    options: {},
+    name: "@storybook/react-webpack5",
+    options: {
+      builder: {
+        useSWC: true,
+      },
+    },
   },
+
+  swc: () => ({
+    jsc: {
+      transform: {
+        react: {
+          runtime: "automatic",
+        },
+      },
+    },
+  }),
 
   docs: {},
 

--- a/src/stories/AirlineLogo.stories.tsx
+++ b/src/stories/AirlineLogo.stories.tsx
@@ -1,6 +1,5 @@
 import { AirlineLogo } from "@components/shared/AirlineLogo";
 import { Meta } from "@storybook/react";
-import React from "react";
 
 const AIRLINES = [
   ["American Airlines", "AA"],

--- a/src/stories/Button.stories.tsx
+++ b/src/stories/Button.stories.tsx
@@ -1,5 +1,4 @@
 import type { Meta, StoryFn, StoryObj } from "@storybook/react";
-import React from "react";
 import { Button, ButtonProps } from "../components/shared/Button";
 
 export default {

--- a/src/stories/Icon.stories.tsx
+++ b/src/stories/Icon.stories.tsx
@@ -1,5 +1,4 @@
 import { Meta } from "@storybook/react";
-import React from "react";
 import { Icon, ICON_MAP, IconName } from "../components/shared/Icon";
 
 export default {

--- a/src/stories/MapboxPlacesLookup.stories.tsx
+++ b/src/stories/MapboxPlacesLookup.stories.tsx
@@ -1,5 +1,4 @@
 import type { Meta } from "@storybook/react";
-import React from "react";
 import {
   MapboxPlacesLookup,
   MapboxPlacesLookupProps,

--- a/src/stories/NGSSliceFareCard.stories.tsx
+++ b/src/stories/NGSSliceFareCard.stories.tsx
@@ -1,6 +1,5 @@
 import type { Meta } from "@storybook/react";
 import { NGSSliceFareCard } from "../components/DuffelNGSView/NGSSliceFareCard";
-import React from "react";
 
 // eslint-disable-next-line @typescript-eslint/no-var-requires
 const offerRequest = require("../fixtures/offer-requests/orq_0000Ab7taNqbK8y5YqW6Zk.json");

--- a/src/stories/OfferSlice.stories.tsx
+++ b/src/stories/OfferSlice.stories.tsx
@@ -1,7 +1,6 @@
 import { OfferSlice } from "@components/OfferSlice/OfferSlice";
 import { Airport, City, Offer, OfferSliceSegmentStop } from "@duffel/api/types";
 import type { Meta } from "@storybook/react";
-import React from "react";
 
 // Use a require because the fixture is not a module.
 /* eslint-disable @typescript-eslint/no-var-requires */

--- a/src/stories/OfferSliceModal.stories.tsx
+++ b/src/stories/OfferSliceModal.stories.tsx
@@ -1,7 +1,6 @@
 import { OfferSliceModal } from "@components/OfferSliceModal/OfferSliceModal";
 import { Airport, City, Offer, OfferSliceSegmentStop } from "@duffel/api/types";
 import type { Meta } from "@storybook/react";
-import React from "react";
 
 // Use a require because the fixture is not a module.
 /* eslint-disable @typescript-eslint/no-var-requires */

--- a/src/stories/PlacesLookup.stories.tsx
+++ b/src/stories/PlacesLookup.stories.tsx
@@ -1,5 +1,4 @@
 import type { Meta } from "@storybook/react";
-import React from "react";
 import {
   PlacesLookup,
   PlacesLookupProps,

--- a/src/stories/SliceSummary.stories.tsx
+++ b/src/stories/SliceSummary.stories.tsx
@@ -1,7 +1,6 @@
 import { SliceSummary } from "@components/DuffelNGSView/SliceSummary";
 import { Airport, City, Offer, OfferSliceSegmentStop } from "@duffel/api/types";
 import type { Meta } from "@storybook/react";
-import React from "react";
 
 // Use a require because the fixture is not a module.
 /* eslint-disable @typescript-eslint/no-var-requires */


### PR DESCRIPTION
### What's here?

This allows our newer storybook samples to run without having to import React in the file heading

![image](https://github.com/user-attachments/assets/5bb2f74e-e438-4bad-a2fd-0f0ffafc6827)

This also removes the need to import react from older examples

### Weird caveats

NGS Airline Selector does not seem to want to let go of the import even after the update. So I kept it there. Pretty bizaare!

![image](https://github.com/user-attachments/assets/85053264-5cd7-4420-a852-ea7c16e26daa)

This is not the case for all the other components

### References

The revisions applied are taken mostly from the storybook documentation here:

https://storybook.js.org/docs/configure/integration/compilers#the-swc-compiler-doesnt-work-with-react

