### PR TITLE
Updates seatmap

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@duffel/components",
-  "version": "3.7.24",
+  "version": "3.7.25",
   "description": "Component library to build your travel product with Duffel.",
   "keywords": [
     "Duffel",

--- a/src/styles/components/SeatMap.css
+++ b/src/styles/components/SeatMap.css
@@ -1,6 +1,7 @@
 .seat-map {
   background-color: rgba(var(--WHITE), 1);
   padding: var(--SPACING-SM-3);
+  padding-bottom: 80px; /* To account for the fixed footer */
   display: flex;
   flex-direction: column;
   align-items: center;


### PR DESCRIPTION
To include bottom padding, making sure the last row of the seat map is visible.


| Before | After |
|---|---|
<img width="682" alt="Screenshot 2024-11-04 at 17 19 54" src="https://github.com/user-attachments/assets/73d047d8-78ec-4afb-83d6-570302f34589"> | <img width="718" alt="Screenshot 2024-11-04 at 17 19 48" src="https://github.com/user-attachments/assets/dc962e44-0d6f-45bc-a001-4eea5abe1d8a"> | 


[Reported on slack](https://duffel.slack.com/archives/C013XQ3T2J1/p1730740197878659)