### PR TITLE
Update links to card implementation guides

### DIFF
--- a/README.md
+++ b/README.md
@@ -134,7 +134,7 @@ If you are not in a node environment and can't rely on npm to install the packag
 ### Are there integration guides?
 
 - [Integrating the ancillaries component into your booking flow](https://duffel.com/docs/guides/ancillaries-component).
-- [Collecting payments with Duffel Payments](https://duffel.com/docs/guides/collecting-customer-card-payments)
+- [Integrating the customer card form into your checkout page](https://duffel.com/docs/guides/paying-with-customer-cards).
 
 More guides are coming soon.
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@duffel/components",
-  "version": "3.7.25",
+  "version": "3.7.26",
   "description": "Component library to build your travel product with Duffel.",
   "keywords": [
     "Duffel",


### PR DESCRIPTION
- Replaces Duffel Payments link with one to the card form implementation guide