### PR TITLE
Make cardholder present optional if exception is passed

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@duffel/components",
-  "version": "3.7.27",
+  "version": "3.7.28",
   "description": "Component library to build your travel product with Duffel.",
   "keywords": [
     "Duffel",

--- a/src/functions/createThreeDSecureSession/client.ts
+++ b/src/functions/createThreeDSecureSession/client.ts
@@ -51,8 +51,8 @@ interface create3DSSessionPayload {
   card_id: string;
   resource_id: string;
   services?: Array<Service>;
-  cardholder_present: boolean;
-  exception: string;
+  cardholder_present?: boolean;
+  exception?: string;
 }
 
 export const createClient = (duffelUrl: string, clientKey: string) => {

--- a/src/functions/createThreeDSecureSession/createThreeDSecureSession.ts
+++ b/src/functions/createThreeDSecureSession/createThreeDSecureSession.ts
@@ -56,15 +56,28 @@ export const createThreeDSecureSession: CreateThreeDSecureSessionFn = async (
 
   return new Promise((resolve, reject) => {
     const client = createClient(env.duffelUrl, clientKey);
+    let payload;
 
-    client
-      .create3DSSessionInDuffelAPI({
+    if (exception) {
+      // Ignore cardholder present param if exception is set
+      payload = {
+        card_id: cardId,
+        resource_id: resourceId,
+        services: services,
+        exception: exception,
+      }
+    } else {
+      payload = {
         card_id: cardId,
         resource_id: resourceId,
         services: services,
         cardholder_present: cardholderPresent,
         exception: exception,
-      })
+      }
+    }
+
+    client
+      .create3DSSessionInDuffelAPI(payload)
       .then((threeDSSession) => {
         if (!threeDSSession) {
           reject(new Error(GENERIC_ERROR_MESSAGE));


### PR DESCRIPTION
We don't need to pass the cardholder present param to the API if exception is set.