### PR TITLE
Allow passing selection into ancillaries component

### DIFF
--- a/src/components/DuffelAncillaries/DuffelAncillaries.tsx
+++ b/src/components/DuffelAncillaries/DuffelAncillaries.tsx
@@ -101,10 +101,10 @@ export const DuffelAncillaries: React.FC<DuffelAncillariesProps> = (props) => {
 
   const [baggageSelectedServices, setBaggageSelectedServices] = React.useState<
     WithBaggageServiceInformation<CreateOrderService>[]
-  >([]);
+  >(props.defaultBaggageSelectedServices || []);
   const [seatSelectedServices, setSeatSelectedServices] = React.useState<
     WithSeatServiceInformation<CreateOrderService>[]
-  >([]);
+  >(props.defaultSeatSelectedServices || []);
   const [cfarSelectedServices, setCfarSelectedServices] = React.useState<
     WithServiceInformation<CreateOrderService>[]
   >([]);

--- a/src/stories/DuffelAncillaries.stories.tsx
+++ b/src/stories/DuffelAncillaries.stories.tsx
@@ -260,3 +260,73 @@ export const BaggageBehaviourAustrian: StoryFn<
     </pre>
   </>
 );
+
+export const WithPreselectedServices: DuffelAncillariesStory = {
+  args: {
+    defaultBaggageSelectedServices: [
+      {
+        id: "ase_0000AUde3M2LtBE9WNJZYW",
+        quantity: 1,
+        serviceInformation: {
+          segmentIds: ["seg_0000AUde3KwTztSRK1cznF"],
+          passengerIds: ["pas_0000AUde3KY1SptM6ABSfT"],
+          passengerName: "Dorothy Green",
+          total_amount: "20.00",
+          total_currency: "GBP",
+          type: "checked",
+          maximum_weight_kg: 23,
+          maximum_length_cm: null,
+          maximum_height_cm: null,
+          maximum_depth_cm: null,
+        },
+      },
+      {
+        id: "ase_0000AUde3M2LtBE9WNJZYZ",
+        quantity: 1,
+        serviceInformation: {
+          segmentIds: ["seg_0000AUde3KwTztSRK1cznF"],
+          passengerIds: ["pas_0000AUde3KY1SptM6ABSfU"],
+          passengerName: "Mae Jemison",
+          total_amount: "20.00",
+          total_currency: "GBP",
+          type: "checked",
+          maximum_weight_kg: 23,
+          maximum_length_cm: null,
+          maximum_height_cm: null,
+          maximum_depth_cm: null,
+        },
+      },
+    ],
+    defaultSeatSelectedServices: [
+      {
+        quantity: 1,
+        id: "ase_0000AUde3N542xVhxDesRo",
+        serviceInformation: {
+          type: "seat",
+          segmentId: "seg_0000AUde3Kw81DArIvSiF0",
+          passengerId: "pas_0000AUde3KY1SptM6ABSfT",
+          passengerName: "Dorothy Green",
+          designator: "28F",
+          disclosures: [],
+          total_amount: "20.0",
+          total_currency: "GBP",
+        },
+      },
+      {
+        quantity: 1,
+        id: "ase_0000AUde3N67z0MS0W9j78",
+        serviceInformation: {
+          type: "seat",
+          segmentId: "seg_0000AUde3KwTztSRK1cznF",
+          passengerId: "pas_0000AUde3KY1SptM6ABSfU",
+          passengerName: "Mae Jemison",
+          designator: "35H",
+          disclosures: [],
+          total_amount: "20.0",
+          total_currency: "GBP",
+        },
+      },
+    ],
+    ...defaultProps,
+  },
+};

--- a/src/types/DuffelAncillariesProps.ts
+++ b/src/types/DuffelAncillariesProps.ts
@@ -24,6 +24,9 @@ export interface DuffelAncillariesCommonProps {
   markup?: DuffelAncillariesMarkup;
   priceFormatters?: DuffelAncillariesPriceFormatters;
   debug?: boolean;
+
+  defaultBaggageSelectedServices?: WithBaggageServiceInformation<CreateOrderService>[];
+  defaultSeatSelectedServices?: WithSeatServiceInformation<CreateOrderService>[];
 }
 
 export interface DuffelAncillariesPropsWithOfferIdForFixture

--- a/src/types/DuffelAncillariesProps.ts
+++ b/src/types/DuffelAncillariesProps.ts
@@ -25,7 +25,13 @@ export interface DuffelAncillariesCommonProps {
   priceFormatters?: DuffelAncillariesPriceFormatters;
   debug?: boolean;
 
+  /**
+   * If you pass default selected baggage services, they will be used to initiate the state when the component mounts. Any further updates will be ignored.
+   */
   defaultBaggageSelectedServices?: WithBaggageServiceInformation<CreateOrderService>[];
+  /**
+   * If you pass default selected seat services, they will be used to initiate the state when the component mounts. Any further updates will be ignored.
+   */
   defaultSeatSelectedServices?: WithSeatServiceInformation<CreateOrderService>[];
 }
 


### PR DESCRIPTION
It'd make the integration for some customers easier if they can pass in previous state to the component with the way their checkout flow works.

Same change will be done on react native components once we're happy with the interface.

Try it on the new story:
<img width="1200" alt="Screenshot 2025-01-20 at 13 02 46" src="https://github.com/user-attachments/assets/66cba0cb-8a70-4002-bc3e-7ebe3b5944ac" />
