### PR TITLE
[TSP-206] Fixes user agent

### DIFF
--- a/src/functions/createThreeDSecureSession/client.ts
+++ b/src/functions/createThreeDSecureSession/client.ts
@@ -39,7 +39,7 @@ const getAPIHeaders = (clientKey: string) => ({
   "Duffel-Version": "v2",
   "Content-Type": "application/json",
   Authorization: `Bearer ${clientKey}`,
-  "User-Agent": `Duffel/ancillaries-component@${process.env.COMPONENT_VERSION}`,
+  "User-Agent": `Duffel/three-d-secure-function@${process.env.COMPONENT_VERSION}`,
 });
 
 interface Service {


### PR DESCRIPTION
User agent for 3DS was the same as the ancillaries component one, this was a mistake.