### PR TITLE
Don't break styles

### DIFF
--- a/config/esbuild.dev.config.js
+++ b/config/esbuild.dev.config.js
@@ -43,5 +43,5 @@ const COMPONENT_CDN = `https://localhost:${PORT}`;
   await esbuildContext.watch();
 
   // eslint-disable-next-line
-  console.log(`\n🐄 Serving component on https://${host}:${port}`);
+  console.log(`\n🐄 Serving component on https://localhost:${port}`);
 })();

--- a/config/esbuild.dev.config.js
+++ b/config/esbuild.dev.config.js
@@ -33,7 +33,7 @@ const COMPONENT_CDN = `https://localhost:${PORT}`;
     ],
   });
 
-  let { host, port } = await esbuildContext.serve({
+  let { port } = await esbuildContext.serve({
     host: "localhost",
     servedir: "cdn-dist",
     port: PORT,

--- a/examples/using-cdn/index.html
+++ b/examples/using-cdn/index.html
@@ -17,7 +17,7 @@
       This command builds the components, and sets up a watcher and server for the output. 
       To ensure the styles work correctly, add `COMPONENT_CDN=http://localhost:8000` to your `.env.local` file.
       After doing so, you can link to the local version of the script using: 
-      <script src="http://127.0.0.1:8000/duffel-ancillaries.js"></script>
+      <script src="https://localhost:3200/duffel-ancillaries.js"></script>
     -->
   </head>
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@duffel/components",
-  "version": "3.7.32",
+  "version": "4.0.0",
   "description": "Component library to build your travel product with Duffel.",
   "keywords": [
     "Duffel",

--- a/src/styles/components/AirlineSelector.css
+++ b/src/styles/components/AirlineSelector.css
@@ -1,4 +1,4 @@
-.airline-selector__option {
+.duffel-components .airline-selector__option {
   /*  important is used to take prescedence over .filter-control__option */
   grid-template-columns: 16px auto 24px !important;
 }

--- a/src/styles/components/Amenity.css
+++ b/src/styles/components/Amenity.css
@@ -1,4 +1,4 @@
-.map-element--amenity {
+.duffel-components .map-element--amenity {
   width: 100%;
   height: var(--SPACING-LG-1);
   color: var(--GREY-600);
@@ -9,14 +9,14 @@
 }
 
 @media only screen and (min-width: 768px) {
-  .map-element--amenity {
+  .duffel-components .map-element--amenity {
     width: 100%;
     height: var(--SPACING-LG-3);
     font-size: var(--FONT-SIZES-C2);
   }
 }
 
-.map-element--wrapped {
+.duffel-components .map-element--wrapped {
   background-color: var(--GREY-100);
   border-radius: 8px;
   border: 2px solid var(--GREY-200);

--- a/src/styles/components/BaggageDisplay.css
+++ b/src/styles/components/BaggageDisplay.css
@@ -1,24 +1,24 @@
-.baggage-display {
+.duffel-components .baggage-display {
   display: flex;
   align-items: center;
 }
 
-.baggage-display__content {
+.duffel-components .baggage-display__content {
   margin-left: var(--SPACING-SM-1);
 }
 
-.baggage-display__label {
+.duffel-components .baggage-display__label {
   color: var(--grey-900);
   font-size: var(--FONT-SIZES-C2);
 }
 
-.baggage-display__price {
+.duffel-components .baggage-display__price {
   font-size: var(--FONT-SIZES-C2);
   color: var(--GREY-600);
   margin-left: var(--SPACING-XS-2);
 }
 
-.baggage-display__specs {
+.duffel-components .baggage-display__specs {
   margin-top: var(--SPACING-XS-2);
   font-size: var(--FONT-SIZES-C3);
   color: var(--GREY-600);

--- a/src/styles/components/Button.css
+++ b/src/styles/components/Button.css
@@ -2,7 +2,7 @@
  * 1. Change the font styles in all browsers.
  * 2. Remove the margin in Firefox and Safari.
  */
-button {
+.duffel-components button {
   font-family: inherit; /* 1 */
   font-size: 100%; /* 1 */
   line-height: 1.15; /* 1 */
@@ -13,7 +13,7 @@ button {
  * Show the overflow in IE.
  * 1. Show the overflow in Edge.
  */
-button {
+.duffel-components button {
   /* 1 */
   overflow: visible;
 }
@@ -23,7 +23,7 @@ button {
  * 1. Remove the inheritance of text transform in Firefox.
  */
 
-button {
+.duffel-components button {
   /* 1 */
   text-transform: none;
 }
@@ -32,7 +32,7 @@ button {
  * Correct the inability to style clickable types in iOS and Safari.
  */
 
-button,
+.duffel-components button,
 [type="button"],
 [type="reset"],
 [type="submit"] {
@@ -43,7 +43,7 @@ button,
 /**
  * Remove the inner border and padding in Firefox.
  */
-button::-moz-focus-inner,
+.duffel-components button::-moz-focus-inner,
 [type="button"]::-moz-focus-inner,
 [type="reset"]::-moz-focus-inner,
 [type="submit"]::-moz-focus-inner {
@@ -54,14 +54,14 @@ button::-moz-focus-inner,
 /**
  * Restore the focus styles unset by the previous rule.
  */
-button:-moz-focusring,
+.duffel-components button:-moz-focusring,
 [type="button"]:-moz-focusring,
 [type="reset"]:-moz-focusring,
 [type="submit"]:-moz-focusring {
   outline: 1px dotted ButtonText;
 }
 
-.button {
+.duffel-components .button {
   --button-color: var(--SECONDARY, white);
 
   box-sizing: border-box;
@@ -90,7 +90,7 @@ button:-moz-focusring,
     color 0.3s var(--TRANSITION-CUBIC-BEZIER);
 }
 
-.button--32 {
+.duffel-components .button--32 {
   height: 32px;
   font-size: 14px;
   font-weight: 600;
@@ -98,7 +98,7 @@ button:-moz-focusring,
   padding-inline: 16px;
 }
 
-.button--40 {
+.duffel-components .button--40 {
   height: 40px;
   font-size: 14px;
   font-weight: 600;
@@ -106,7 +106,7 @@ button:-moz-focusring,
   padding-inline: 24px;
 }
 
-.button--48 {
+.duffel-components .button--48 {
   height: 48px;
   font-size: 16px;
   font-weight: 600;
@@ -114,7 +114,7 @@ button:-moz-focusring,
   padding-inline: 32px;
 }
 
-.button svg {
+.duffel-components .button svg {
   /* Using important to take precedence over inline styles on icon */
   display: inline !important;
   height: 20px;
@@ -122,18 +122,18 @@ button:-moz-focusring,
   margin-left: -4px;
 }
 
-.button:not(:disabled):hover {
+.duffel-components .button:not(:disabled):hover {
   box-shadow:
     0px 0px 0px 2px #e9e9eb,
     0px 2px 4px 1px #00000026;
 }
 
-.button:disabled {
+.duffel-components .button:disabled {
   cursor: not-allowed;
   opacity: 0.4;
 }
 
-.button--primary:not(:disabled):hover {
+.duffel-components .button--primary:not(:disabled):hover {
   background-color: rgba(var(--ACCENT), var(--ACCENT-LIGHT-800));
   border-color: (
     var(--SECONDARY),
@@ -144,7 +144,7 @@ button:-moz-focusring,
     0px 0px 0px 2px #e9e9eb;
 }
 
-.button--primary:not(:disabled):active {
+.duffel-components .button--primary:not(:disabled):active {
   background-color: rgba(var(--ACCENT), var(--ACCENT-LIGHT-1000));
   border-color: (
     var(--SECONDARY),
@@ -155,24 +155,24 @@ button:-moz-focusring,
     0px 0px 0px 1px #dcdcde;
 }
 
-.button--destructive,
-.button--outlined {
+.duffel-components .button--destructive,
+.duffel-components .button--outlined {
   border: 1px solid #ccccd4;
   color: var(--GREY-900);
   background-color: rgb(var(--WHITE));
 }
 
-.button--outlined:not(:disabled):hover,
-.button--destructive:not(:disabled):hover {
+.duffel-components .button--outlined:not(:disabled):hover,
+.duffel-components .button--destructive:not(:disabled):hover {
   border: 1px solid #ababb4;
   background-color: #fbfbfd;
 }
 
-.button--outlined:not(:disabled):active,
-.button--destructive:not(:disabled):active {
+.duffel-components .button--outlined:not(:disabled):active,
+.duffel-components .button--destructive:not(:disabled):active {
   background-color: var(--GREY-100);
 }
 
-.button--destructive {
+.duffel-components .button--destructive {
   color: var(--RED);
 }

--- a/src/styles/components/Card.css
+++ b/src/styles/components/Card.css
@@ -1,15 +1,15 @@
-.ancillary-card:disabled {
+.duffel-components .ancillary-card:disabled {
   /* important needed to take precedence over default button styles */
   color: inherit !important;
   cursor: not-allowed !important;
   background-color: var(--GREY-100) !important;
 }
 
-.ancillary-card--loading:disabled {
+.duffel-components .ancillary-card--loading:disabled {
   cursor: progress;
 }
 
-.ancillary-card__expand-icon {
+.duffel-components .ancillary-card__expand-icon {
   color: var(--GREY-400);
   transition:
     color 0.3s var(--TRANSITION-CUBIC-BEZIER),
@@ -17,7 +17,7 @@
   transform: scale(1);
 }
 
-.ancillary-card__children {
+.duffel-components .ancillary-card__children {
   text-align: start;
   font-weight: 400;
   font-size: 16px;
@@ -28,24 +28,29 @@
   align-items: center;
 }
 
-.ancillary-card:not(:disabled):not(.ancillary-card--loading):focus {
+.duffel-components
+  .ancillary-card:not(:disabled):not(.ancillary-card--loading):focus {
   outline: none;
 }
 
-.ancillary-card:not(:disabled):not(.ancillary-card--loading):hover,
-.ancillary-card:not(:disabled):not(.ancillary-card--loading):focus-visible {
+.duffel-components
+  .ancillary-card:not(:disabled):not(.ancillary-card--loading):hover,
+.duffel-components
+  .ancillary-card:not(:disabled):not(.ancillary-card--loading):focus-visible {
   /* important is needed here to override the inline border style from Card.tsx */
   border-color: var(--SECONDARY, rgb(var(--ACCENT))) !important;
 }
 
-.ancillary-card:not(:disabled):not(.ancillary-card--loading):hover
+.duffel-components
+  .ancillary-card:not(:disabled):not(.ancillary-card--loading):hover
   .ancillary-card__expand-icon,
-.ancillary-card:not(:disabled):not(.ancillary-card--loading):focus-visible
+.duffel-components
+  .ancillary-card:not(:disabled):not(.ancillary-card--loading):focus-visible
   .ancillary-card__expand-icon {
   color: var(--SECONDARY, rgb(var(--ACCENT)));
 }
 
-.ancillary-card__selected-icon {
+.duffel-components .ancillary-card__selected-icon {
   background-color: var(--SECONDARY, rgb(var(--ACCENT)));
   border-radius: 20px;
   color: rgb(var(--WHITE));

--- a/src/styles/components/CfarSelectionModal.css
+++ b/src/styles/components/CfarSelectionModal.css
@@ -1,4 +1,4 @@
-.cfar-modal-footer {
+.duffel-components .cfar-modal-footer {
   margin-top: 16px;
   padding: 16px 24px 24px;
   display: grid;
@@ -8,7 +8,7 @@
   grid-template-rows: repeat(2, 1fr);
 }
 
-.cfar-modal-list-item {
+.duffel-components .cfar-modal-list-item {
   margin: 0;
   padding: 0;
   display: flex;
@@ -16,18 +16,18 @@
   column-gap: 8px;
 }
 
-.cfar-modal-list-item > svg {
+.duffel-components .cfar-modal-list-item > svg {
   color: var(--SECONDARY, rgb(var(--ACCENT)));
 }
 
-.cfar-modal-list-item > p {
+.duffel-components .cfar-modal-list-item > p {
   margin: 0;
   padding: 0;
 }
 
 /* tablet or greater  */
 @media (min-width: 768px) {
-  .cfar-modal-footer {
+  .duffel-components .cfar-modal-footer {
     grid-template-columns: repeat(2, 1fr);
     grid-template-rows: 1fr;
   }

--- a/src/styles/components/Counter.css
+++ b/src/styles/components/Counter.css
@@ -1,9 +1,9 @@
-.counter {
+.duffel-components .counter {
   display: flex;
   align-items: center;
 }
 
-.counter__count-label {
+.duffel-components .counter__count-label {
   font-size: var(--FONT-SIZES-C2);
   text-align: center;
   align-self: center;
@@ -12,7 +12,7 @@
 }
 
 @media screen and (min-width: 768px) {
-  .counter__count-label {
+  .duffel-components .counter__count-label {
     width: var(--SPACING-LG-1);
   }
 }

--- a/src/styles/components/DuffelPayments.css
+++ b/src/styles/components/DuffelPayments.css
@@ -1,4 +1,4 @@
-.card-payment__container {
+.duffel-components .card-payment__container {
   width: 480px;
   height: auto;
   max-width: 480px;
@@ -6,17 +6,17 @@
   margin: var(--SPACING-XS-3);
 }
 
-.card-payment__container--invalid {
+.duffel-components .card-payment__container--invalid {
   margin-top: var(--SPACING-SM-1);
   font-size: var(--FONT-SIZES-C2);
   color: var(--RED);
 }
 
-.card-payment__container--invalid {
+.duffel-components .card-payment__container--invalid {
   height: 16px;
 }
 
-.card-details {
+.duffel-components .card-details {
   background-color: rgb(var(--WHITE));
   border: 1px solid var(--GREY-200);
   border-radius: 5px;
@@ -24,16 +24,16 @@
   width: auto;
 }
 
-.card-details.StripeElement--invalid {
+.duffel-components .card-details.StripeElement--invalid {
   border: 1px solid var(--RED);
 }
 
-.card-payment__pay-button {
+.duffel-components .card-payment__pay-button {
   width: 100%;
   margin-top: var(--SPACING-SM-3);
 }
 
-.card-payment--in-progress {
+.duffel-components .card-payment--in-progress {
   display: block;
   z-index: 3;
   width: 100vw;

--- a/src/styles/components/FilterControl.css
+++ b/src/styles/components/FilterControl.css
@@ -1,8 +1,8 @@
-.filter-control {
+.duffel-components .filter-control {
   position: relative;
 }
 
-.filter-control__target {
+.duffel-components .filter-control__target {
   color: var(--GREY-800);
   fill: var(--GREY-800);
   border: solid 1px var(--GREY-200);
@@ -24,21 +24,21 @@
   white-space: nowrap;
 }
 
-.filter-control__target svg {
+.duffel-components .filter-control__target svg {
   position: absolute;
   right: 2px;
 }
 
-.filter-control__target:hover {
+.duffel-components .filter-control__target:hover {
   border-color: var(--GREY-400);
 }
 
-.filter-control__target:disabled {
+.duffel-components .filter-control__target:disabled {
   opacity: 0.5;
   cursor: not-allowed;
 }
 
-.filter-control__backdrop {
+.duffel-components .filter-control__backdrop {
   z-index: 99;
   opacity: 0;
   top: 0;
@@ -48,7 +48,7 @@
   position: fixed;
 }
 
-.filter-control__popover {
+.duffel-components .filter-control__popover {
   background-color: white;
   border: solid 1px var(--GREY-200);
   position: absolute;
@@ -65,7 +65,7 @@
   user-select: none; /* Standard syntax */
 }
 
-.filter-control__option {
+.duffel-components .filter-control__option {
   display: grid;
   padding: 2px 12px;
   border-radius: 4px;
@@ -80,22 +80,22 @@
   transition: border-color 0.3s linear;
 }
 
-.filter-control__option:hover {
+.duffel-components .filter-control__option:hover {
   background-color: var(--GREY-100);
 }
 
-.filter-control__option:active {
+.duffel-components .filter-control__option:active {
   opacity: 1;
 }
 
-.filter-control__option--selected {
+.duffel-components .filter-control__option--selected {
   background: var(--GREY-100);
 }
 
-.filter-control__option:not(:last-child) {
+.duffel-components .filter-control__option:not(:last-child) {
   margin-bottom: 4px;
 }
 
-.filter-control__option > * {
+.duffel-components .filter-control__option > * {
   align-self: center;
 }

--- a/src/styles/components/IconButton.css
+++ b/src/styles/components/IconButton.css
@@ -1,8 +1,8 @@
-.icon-button {
+.duffel-components .icon-button {
   color: red;
 }
 
-.icon-button {
+.duffel-components .icon-button {
   --button-color: white;
 
   box-sizing: border-box;
@@ -26,39 +26,39 @@
     opacity 0.3s var(--TRANSITION-CUBIC-BEZIER);
 }
 
-.icon-button svg {
+.duffel-components .icon-button svg {
   /* Using important to take precedence over inline styles on icon */
   display: inline !important;
   height: 20px;
   vertical-align: bottom;
 }
 
-.icon-button:disabled {
+.duffel-components .icon-button:disabled {
   cursor: not-allowed;
   opacity: 0.4;
 }
 
-.icon-button--primary:not(:disabled):hover {
+.duffel-components .icon-button--primary:not(:disabled):hover {
   color: var(--GREY-500);
   background-color: var(--GREY-100);
 }
 
-.icon-button--primary:not(:disabled):active {
+.duffel-components .icon-button--primary:not(:disabled):active {
   color: var(--GREY-700);
   background-color: var(--GREY-200);
 }
 
-.icon-button--outlined {
+.duffel-components .icon-button--outlined {
   border: 1px solid #ccccd4;
   color: var(--GREY-900);
   background-color: rgb(var(--WHITE));
 }
 
-.icon-button--outlined:not(:disabled):hover {
+.duffel-components .icon-button--outlined:not(:disabled):hover {
   border: 1px solid #ababb4;
   background-color: #fbfbfd;
 }
 
-.icon-button--outlined:not(:disabled):active {
+.duffel-components .icon-button--outlined:not(:disabled):active {
   background-color: var(--GREY-100);
 }

--- a/src/styles/components/Legend.css
+++ b/src/styles/components/Legend.css
@@ -1,4 +1,4 @@
-.seat-map__legend {
+.duffel-components .seat-map__legend {
   width: calc(100% + var(--SPACING-MD-3));
   min-height: fit-content;
   margin: calc(var(--SPACING-SM-1) * -1) calc(var(--SPACING-SM-2) * -1);
@@ -11,7 +11,7 @@
   font-weight: 400;
 }
 
-.seat-map__legend-item {
+.duffel-components .seat-map__legend-item {
   display: flex;
   align-items: center;
   text-transform: capitalize;
@@ -19,11 +19,11 @@
   color: var(--GREY-700);
 }
 
-.seat-map__legend-item--symbol .ff-icon {
+.duffel-components .seat-map__legend-item--symbol .ff-icon {
   margin-right: var(--SPACING-XS-3);
 }
 
-.seat-map__legend-seat {
+.duffel-components .seat-map__legend-seat {
   width: var(--SPACING-MD-1);
   height: var(--SPACING-MD-1);
   border-radius: 5px;
@@ -36,26 +36,26 @@
   margin-right: var(--SPACING-SM-1);
 }
 
-.seat-map__legend-seat--fee-payable {
+.duffel-components .seat-map__legend-seat--fee-payable {
   background-color: rgba(var(--ACCENT), var(--ACCENT-LIGHT-100));
   border: 2px solid
     var(--TERTIARY, rgba(var(--ACCENT), var(--ACCENT-LIGHT-200)));
 }
 
-.seat-map__legend-seat--fee-payable-indicator {
+.duffel-components .seat-map__legend-seat--fee-payable-indicator {
   position: relative;
   top: var(--SPACING-XS-2);
   left: var(--SPACING-XS-2);
   color: var(--TERTIARY, rgba(var(--ACCENT), var(--ACCENT-LIGHT-300)));
 }
 
-.seat-map__legend-seat--included {
+.duffel-components .seat-map__legend-seat--included {
   background-color: rgba(var(--ACCENT), var(--ACCENT-LIGHT-100));
   border: 2px solid
     var(--TERTIARY, rgba(var(--ACCENT), var(--ACCENT-LIGHT-200)));
 }
 
-.seat-map__legend-seat--selected {
+.duffel-components .seat-map__legend-seat--selected {
   background-color: rgba(var(--ACCENT), var(--ACCENT-LIGHT-1000));
   border: 2px solid
     var(--SECONDARY, rgba(var(--ACCENT), var(--ACCENT-LIGHT-1000)));

--- a/src/styles/components/Loader.css
+++ b/src/styles/components/Loader.css
@@ -20,7 +20,7 @@
   }
 }
 
-.textual-loading-indicator::after {
+.duffel-components .textual-loading-indicator::after {
   display: inline-block;
   text-align: start;
   animation: loading-dots 1s infinite 1s;

--- a/src/styles/components/LoadingState.css
+++ b/src/styles/components/LoadingState.css
@@ -1,4 +1,4 @@
-.loading-state__container {
+.duffel-components .loading-state__container {
   display: flex;
   flex-direction: column;
   align-content: center;
@@ -12,14 +12,14 @@
   line-height: var(--SPACING-MD-1);
 }
 
-.loading-state__message {
+.duffel-components .loading-state__message {
   font-size: var(--FONT-SIZES-C3);
   text-transform: uppercase;
   color: var(--GREY-400);
   letter-spacing: 0.02rem;
 }
 
-.loading-state__progress-indicator {
+.duffel-components .loading-state__progress-indicator {
   height: var(--SPACING-XS-2);
   margin: var(--SPACING-SM-3) 0;
   border-radius: 999px;
@@ -32,7 +32,7 @@
   transition: var(--TRANSITIONS-CUBIC-BEZIER);
 }
 
-.loading-state__progress-indicator--status {
+.duffel-components .loading-state__progress-indicator--status {
   display: block;
   height: 100%;
   border-radius: 999px;
@@ -61,7 +61,7 @@
   }
 }
 
-.loading-state__segment {
+.duffel-components .loading-state__segment {
   display: flex;
   flex-direction: row;
   margin: var(--SPACING-XS-2) 0;
@@ -69,8 +69,8 @@
   text-transform: uppercase;
 }
 
-.loading-state__segment--origin,
-.loading-state__segment--destination {
+.duffel-components .loading-state__segment--origin,
+.duffel-components .loading-state__segment--destination {
   font-weight: 600;
   font-size: var(--FONT-SIZES-C1);
   color: var(--GREY-900);
@@ -78,7 +78,7 @@
   text-transform: uppercase;
 }
 
-.loading-state__segment__duration {
+.duffel-components .loading-state__segment__duration {
   color: var(--GREY-400);
   font-size: var(--FONT-SIZES-C3);
   letter-spacing: 0.02rem;

--- a/src/styles/components/Modal.css
+++ b/src/styles/components/Modal.css
@@ -1,4 +1,4 @@
-.modal {
+.duffel-components .modal {
   top: 0;
   left: 0;
   position: fixed;
@@ -13,7 +13,7 @@
   transition: all 0.3s var(--TRANSITION-CUBIC-BEZIER);
 }
 
-.modal--content {
+.duffel-components .modal--content {
   border-top-left-radius: 12px;
   border-top-right-radius: 12px;
   position: fixed;
@@ -25,14 +25,14 @@
   transition: opacity 0.3s var(--TRANSITION-CUBIC-BEZIER);
 }
 
-.modal--open,
-.modal--open .modal--content {
+.duffel-components .modal--open,
+.duffel-components .modal--open .modal--content {
   /* important needed to override inline style */
   opacity: 1 !important;
   pointer-events: all;
 }
 
-.modal-body {
+.duffel-components .modal-body {
   max-height: 250px;
   padding: 0px 24px 24px;
   overflow: scroll;
@@ -41,40 +41,40 @@
   -ms-overflow-style: none; /* IE and Edge */
 }
 
-.modal-body::-webkit-scrollbar {
+.duffel-components .modal-body::-webkit-scrollbar {
   display: none; /* Hide the scroll bar for Chrome, Safari, and Opera */
 }
 
-.modal-body--tall {
+.duffel-components .modal-body--tall {
   max-height: 560px;
 }
 
-.modal-body--no-padding {
+.duffel-components .modal-body--no-padding {
   padding: 0;
 }
 
 /* 667px is the height of https://www.ios-resolution.com/iphone-se-3rd-gen/ */
 @media (min-height: 667px) {
-  .modal-body {
+  .duffel-components .modal-body {
     max-height: 350px;
   }
 }
 
 /* 812px is the height of https://www.ios-resolution.com/iphone-13-mini/ */
 @media (min-height: 812px) {
-  .modal-body {
+  .duffel-components .modal-body {
     max-height: 500px;
   }
 }
 
 /* 900px is the size of https://blisk.io/devices/details/macbook-air */
 @media (min-height: 900px) {
-  .modal-body {
+  .duffel-components .modal-body {
     max-height: 65vh;
   }
 }
 
-.modal--close-button {
+.duffel-components .modal--close-button {
   position: absolute;
   top: 16px;
   right: 12px;
@@ -82,14 +82,14 @@
 
 /* tablet or greater  */
 @media (min-width: 768px) {
-  .modal {
+  .duffel-components .modal {
     padding: 24px 12px;
     display: flex;
     align-items: center;
     justify-content: center;
   }
 
-  .modal--content {
+  .duffel-components .modal--content {
     position: relative;
     border-radius: 12px;
     max-width: 640px;

--- a/src/styles/components/NGSShelfInfoCard.css
+++ b/src/styles/components/NGSShelfInfoCard.css
@@ -1,11 +1,11 @@
-.ngs-shelf-info-card_container {
+.duffel-components .ngs-shelf-info-card_container {
   padding: 16px;
   border-radius: 4px;
   background-color: white;
   box-shadow: 0px 1px 8px 0px rgba(0, 0, 0, 0.1);
 }
 
-.ngs-shelf-info-card_title {
+.duffel-components .ngs-shelf-info-card_title {
   font-size: 14px;
   color: var(--GREY-900);
   font-weight: 600;
@@ -13,7 +13,7 @@
   margin-top: 12px;
 }
 
-.ngs-shelf-info-card_text {
+.duffel-components .ngs-shelf-info-card_text {
   font-size: 12px;
   color: var(--GREY-600);
   font-weight: 400;

--- a/src/styles/components/NGSSliceFareCard.css
+++ b/src/styles/components/NGSSliceFareCard.css
@@ -1,4 +1,4 @@
-.ngs-slice-fare-card_container {
+.duffel-components .ngs-slice-fare-card_container {
   appearance: none;
   margin: 0;
   padding: 0;
@@ -20,18 +20,18 @@
   flex-direction: column;
 }
 
-.ngs-slice-fare-card_container > div {
+.duffel-components .ngs-slice-fare-card_container > div {
   padding: 16px;
   width: calc(100% - 32px);
 }
 
-.ngs-slice-fare-card_container > div:first-child {
+.duffel-components .ngs-slice-fare-card_container > div:first-child {
   display: flex;
   flex-direction: column;
   flex-grow: 1;
 }
 
-.ngs-slice-fare-card_header {
+.duffel-components .ngs-slice-fare-card_header {
   display: flex;
   justify-content: space-between;
   align-items: flex-start;
@@ -45,27 +45,27 @@
   min-width: 24px;
 }
 
-.ngs-slice-fare-card_title {
+.duffel-components .ngs-slice-fare-card_title {
   font-size: 14px;
   margin-top: 2px;
   color: var(--GREY-900);
   font-weight: 600;
 }
 
-.ngs-slice-fare-card_item {
+.duffel-components .ngs-slice-fare-card_item {
   display: flex;
   align-items: center;
 }
 
-.ngs-slice-fare-card_item + .ngs-slice-fare-card_item {
+.duffel-components .ngs-slice-fare-card_item + .ngs-slice-fare-card_item {
   margin-top: 8px;
 }
 
-.ngs-slice-fare-card_item > svg {
+.duffel-components .ngs-slice-fare-card_item > svg {
   margin-right: 4px;
 }
 
-.ngs-slice-fare-card_footer {
+.duffel-components .ngs-slice-fare-card_footer {
   display: flex;
   justify-content: space-between;
   align-items: center;
@@ -74,41 +74,41 @@
   min-height: 32px;
 }
 
-.ngs-slice-fare-card_price {
+.duffel-components .ngs-slice-fare-card_price {
   color: var(--GREY-900);
   font-size: 16px;
   font-weight: 600;
   padding-right: 8px;
 }
 
-.ngs-slice-fare-card_radio {
+.duffel-components .ngs-slice-fare-card_radio {
   display: inline;
 }
 
-.ngs-slice-fare-card_button {
+.duffel-components .ngs-slice-fare-card_button {
   display: none;
 }
 
 /* tablet or greater  */
 @media (min-width: 768px) {
-  .ngs-slice-fare-card_container {
+  .duffel-components .ngs-slice-fare-card_container {
     width: 260px;
   }
 
-  .ngs-slice-fare-card_radio {
+  .duffel-components .ngs-slice-fare-card_radio {
     display: none;
   }
 
-  .ngs-slice-fare-card_button {
+  .duffel-components .ngs-slice-fare-card_button {
     display: inline;
   }
 
-  .ngs-slice-fare-card_title {
+  .duffel-components .ngs-slice-fare-card_title {
     color: var(--GREY-900);
     font-size: 16px;
   }
 
-  .ngs-slice-fare-card_price {
+  .duffel-components .ngs-slice-fare-card_price {
     color: var(--GREY-900);
     font-size: 20px;
   }

--- a/src/styles/components/NGSTable.css
+++ b/src/styles/components/NGSTable.css
@@ -1,4 +1,4 @@
-.ngs-table_table {
+.duffel-components .ngs-table_table {
   border-radius: 4px;
   border: 1px solid var(--GREY-100);
   display: table;
@@ -11,7 +11,7 @@
   position: relative;
 }
 
-.ngs-table_table > thead {
+.duffel-components .ngs-table_table > thead {
   color: var(--GREY-500);
   background-color: var(--GREY-100);
   font-size: 12px;
@@ -19,37 +19,45 @@
   height: 40px;
 }
 
-.ngs-table_table th:first-of-type {
+.duffel-components .ngs-table_table th:first-of-type {
   border-top-left-radius: 4px;
   border-left: 1px solid var(--GREY-100);
 }
 
-.ngs-table_table th:last-of-type {
+.duffel-components .ngs-table_table th:last-of-type {
   border-top-right-radius: 4px;
   border-right: 1px solid var(--GREY-100);
 }
 
-.ngs-table_table tbody:last-child tr:last-child td:first-child {
+.duffel-components
+  .ngs-table_table
+  tbody:last-child
+  tr:last-child
+  td:first-child {
   border-bottom-left-radius: 4px;
 }
 
-.ngs-table_table tbody:last-child tr:last-child td:last-child {
+.duffel-components
+  .ngs-table_table
+  tbody:last-child
+  tr:last-child
+  td:last-child {
   border-bottom-right-radius: 4px;
 }
 
-.ngs-table_table > tbody > tr {
+.duffel-components .ngs-table_table > tbody > tr {
   border-top: 1px solid var(--GREY-100) !important;
 }
 
-.ngs-table_shelf-icon {
+.duffel-components .ngs-table_shelf-icon {
   margin-right: 4px;
 }
 
-.ngs-table_sort-icon {
+.duffel-components .ngs-table_sort-icon {
   margin-left: 4px;
 }
 
-.ngs-table_column-header {
+.duffel-components .ngs-table_column-header {
   display: flex;
   align-items: center;
   justify-content: center;
@@ -58,24 +66,24 @@
   position: relative;
 }
 
-.ngs-table_column-header--selected {
+.duffel-components .ngs-table_column-header--selected {
   color: var(--GREY-900);
   font-weight: 500;
 }
 
-.ngs-table_table-data {
+.duffel-components .ngs-table_table-data {
   padding: 16px;
   font-size: 16px;
   color: var(--GREY-500);
   width: 115px;
 }
 
-.ngs-table_table-data--selected {
+.duffel-components .ngs-table_table-data--selected {
   color: black;
   font-weight: 500;
 }
 
-.ngs-table_table-data--details {
+.duffel-components .ngs-table_table-data--details {
   font-size: 12px;
   margin-top: 2px;
   margin-bottom: 12px;
@@ -99,12 +107,13 @@
   cursor: help;
 }
 
-.ngs-slice-fare-card_mixed-cabins:hover
+.duffel-components
+  .ngs-slice-fare-card_mixed-cabins:hover
   .ngs-slice-fare-card_mixed-cabins-popover {
   display: grid;
 }
 
-.ngs-slice-fare-card_mixed-cabins-popover {
+.duffel-components .ngs-slice-fare-card_mixed-cabins-popover {
   display: none;
   position: absolute;
   z-index: 1;
@@ -121,7 +130,7 @@
   row-gap: 4px;
 }
 
-.ngs-table_slice-info {
+.duffel-components .ngs-table_slice-info {
   padding: 24px 16px 20px 16px;
   width: 300px;
   display: flex;
@@ -130,17 +139,17 @@
   cursor: auto;
 }
 
-.ngs-table_slice-info > div:first-child {
+.duffel-components .ngs-table_slice-info > div:first-child {
   margin-bottom: 16px;
 }
 
-.ngs-table_expanded {
+.duffel-components .ngs-table_expanded {
   padding: 0;
   cursor: auto;
   max-width: 1280px;
 }
 
-.ngs-table_expanded > div {
+.duffel-components .ngs-table_expanded > div {
   background-color: var(--GREY-50);
   padding: 32px;
   display: flex;
@@ -148,34 +157,35 @@
   overflow-x: auto;
 }
 
-.ngs-table_expanded > div > button:first-child {
+.duffel-components .ngs-table_expanded > div > button:first-child {
   margin-left: auto;
 }
-.ngs-table_expanded > div > button:last-child {
+.duffel-components .ngs-table_expanded > div > button:last-child {
   margin-right: auto;
 }
 
-.ngs-table_table-data--expanded {
+.duffel-components .ngs-table_table-data--expanded {
   background-color: var(--GREY-50);
 }
 
-.ngs-table_expanded .ngs-slice-fare-card_container {
+.duffel-components .ngs-table_expanded .ngs-slice-fare-card_container {
   background-color: white;
 }
 
-.ngs-table_expanded
+.duffel-components
+  .ngs-table_expanded
   .ngs-slice-fare-card_container
   + .ngs-slice-fare-card_container {
   margin-left: 32px;
 }
 
 /* Added important here to overwrite the slice card styles */
-.ngs-table_card--alternative {
+.duffel-components .ngs-table_card--alternative {
   margin-top: 8px !important;
   margin-bottom: 8px !important;
 }
 
-.ngs-table_column-header-tooltip {
+.duffel-components .ngs-table_column-header-tooltip {
   visibility: hidden;
   position: absolute;
   z-index: 1;
@@ -185,15 +195,17 @@
   text-align: left;
 }
 
-.ngs-table_column-header-tooltip--left {
+.duffel-components .ngs-table_column-header-tooltip--left {
   left: -300px;
 }
 
-.ngs-table_column-header:hover .ngs-table_column-header-tooltip {
+.duffel-components
+  .ngs-table_column-header:hover
+  .ngs-table_column-header-tooltip {
   visibility: visible;
 }
 
-.ngs-table_slice-details-button {
+.duffel-components .ngs-table_slice-details-button {
   appearance: none;
   margin: 0;
   padding: 0;
@@ -209,12 +221,12 @@
   margin-top: 16px;
 }
 
-.ngs-table_th {
+.duffel-components .ngs-table_th {
   width: 300px;
   padding-block: 18px;
 }
 
-.ngs-table_th--sticky {
+.duffel-components .ngs-table_th--sticky {
   position: sticky;
   top: 0;
   background-color: var(--GREY-100);

--- a/src/styles/components/OfferSlice.css
+++ b/src/styles/components/OfferSlice.css
@@ -1,58 +1,58 @@
-.offer-slice {
+.duffel-components .offer-slice {
   display: flex;
   align-items: center;
 }
 
-.offer-slice__airline-logo-wrapper {
+.duffel-components .offer-slice__airline-logo-wrapper {
   margin-right: 32px;
 }
 
-.offer-slice__column:first-child {
+.duffel-components .offer-slice__column:first-child {
   flex-grow: 1;
   margin-right: 32px;
 }
 
-.offer-slice__column > div {
+.duffel-components .offer-slice__column > div {
   min-width: 120px;
 }
 
-.offer-slice__column > div:first-child {
+.duffel-components .offer-slice__column > div:first-child {
   font-weight: bold;
   margin-bottom: 4px;
   line-height: 16px;
   font-size: 16px;
 }
 
-.offer-slice__column > div:first-child > sup {
+.duffel-components .offer-slice__column > div:first-child > sup {
   vertical-align: baseline;
   position: relative;
   top: -4px;
   font-size: 12px;
 }
 
-.offer-slice__column > div:last-child {
+.duffel-components .offer-slice__column > div:last-child {
   color: var(--grey-700);
   font-size: 14px;
 }
 
-.offer-slice__date-label {
+.duffel-components .offer-slice__date-label {
   margin-right: 16px;
 }
 
-.offer-slice > div:last-child {
+.duffel-components .offer-slice > div:last-child {
   display: flex;
   align-items: flex-start;
   width: 100%;
 }
 
-.highlight {
+.duffel-components .highlight {
   position: relative;
   border-radius: 4px;
   color: var(--grey-900);
   z-index: 1;
 }
 
-.highlight::before {
+.duffel-components .highlight::before {
   position: absolute;
   content: "";
   top: -2px;
@@ -65,28 +65,28 @@
   border-radius: 4px;
 }
 
-.highlight--green::before {
+.duffel-components .highlight--green::before {
   background-color: var(--green-200);
 }
 
-.highlight--pink::before {
+.duffel-components .highlight--pink::before {
   background-color: var(--pink-200);
 }
 
-.highlight--yellow::before {
+.duffel-components .highlight--yellow::before {
   background-color: var(--yellow-200);
 }
 
-.offer-slice__sup--pad {
+.duffel-components .offer-slice__sup--pad {
   padding-left: 4px;
 }
 
-.layover-item {
+.duffel-components .layover-item {
   margin-left: var(--space-16);
 }
 
 /* new stuff below */
-.offer-slice__row {
+.duffel-components .offer-slice__row {
   display: grid;
   padding: 16px 24px;
   column-gap: 16px;
@@ -98,13 +98,13 @@
   line-height: 16px;
 }
 
-.offer-slice__row--grey-background {
+.duffel-components .offer-slice__row--grey-background {
   background-color: var(--GREY-100, #f6f5f9);
   color: var(--GREY-600, #696972);
   fill: var(--GREY-600, #696972);
 }
 
-.offer-slice__row--compact {
+.duffel-components .offer-slice__row--compact {
   color: var(--GREY-600, #696972);
   font-size: 12px;
   font-style: normal;
@@ -113,15 +113,15 @@
   padding-block: 0;
 }
 
-.offer-slice__row-time {
+.duffel-components .offer-slice__row-time {
   justify-self: end;
 }
 
-.offer-slice__row-icon-container {
+.duffel-components .offer-slice__row-icon-container {
   position: relative;
 }
 
-.offer-slice__row-icon-container:before {
+.duffel-components .offer-slice__row-icon-container:before {
   content: "";
   position: absolute;
   height: 12px;
@@ -130,7 +130,7 @@
   border-left: solid 1px var(--GREY-300);
 }
 
-.offer-slice__row-icon-container:after {
+.duffel-components .offer-slice__row-icon-container:after {
   content: "";
   position: absolute;
   width: 1px;
@@ -140,30 +140,36 @@
   border-left: solid 1px var(--GREY-300);
 }
 
-.offer-slice__row-icon-container--no-icon:before {
+.duffel-components .offer-slice__row-icon-container--no-icon:before {
   height: 40px;
 }
 
-.offer-slice__row:first-child .offer-slice__row-icon-container:before,
-.offer-slice__row:last-child .offer-slice__row-icon-container:after {
+.duffel-components
+  .offer-slice__row:first-child
+  .duffel-components
+  .offer-slice__row-icon-container:before,
+.duffel-components
+  .offer-slice__row:last-child
+  .duffel-components
+  .offer-slice__row-icon-container:after {
   display: none;
 }
 
-.offer-slice__row-icon-container--dotted-before:before {
+.duffel-components .offer-slice__row-icon-container--dotted-before:before {
   border-left: dotted 1px var(--GREY-300);
 }
 
-.offer-slice__row-icon-container--dotted-after:after {
+.duffel-components .offer-slice__row-icon-container--dotted-after:after {
   border-left: dotted 1px var(--GREY-300);
   bottom: -15px;
 }
 
-.offer-slice__row-icon-container--dotted-both:before,
-.offer-slice__row-icon-container--dotted-both:after {
+.duffel-components .offer-slice__row-icon-container--dotted-both:before,
+.duffel-components .offer-slice__row-icon-container--dotted-both:after {
   border-left: dotted 1px var(--GREY-300);
 }
 
-.offer-slice__row--compact-callout {
+.duffel-components .offer-slice__row--compact-callout {
   color: var(--GREY-600, #696972);
   font-size: 12px;
   font-style: normal;
@@ -173,14 +179,14 @@
   margin-top: 8px;
 }
 
-.offer-slice__row--compact-callout p {
+.duffel-components .offer-slice__row--compact-callout p {
   border-radius: 4px;
   padding: 4px 8px;
   background-color: var(--GREY-100);
   width: fit-content;
 }
 
-.offer-slice-conditions-callout {
+.duffel-components .offer-slice-conditions-callout {
   padding: 8px 16px;
   display: flex;
   column-gap: 8px;
@@ -191,13 +197,13 @@
   border-radius: 6px;
 }
 
-.offer-slice-conditions-callout--blue {
+.duffel-components .offer-slice-conditions-callout--blue {
   color: var(--BLUE-300);
   fill: var(--BLUE-300);
   background: var(--BLUE-100);
 }
 
-.offer-slice-conditions-callout--green {
+.duffel-components .offer-slice-conditions-callout--green {
   color: var(--GREEN-300);
   fill: var(--GREEN-300);
   background: var(--GREEN-100);

--- a/src/styles/components/OfferSliceDetailTravelItem.css
+++ b/src/styles/components/OfferSliceDetailTravelItem.css
@@ -1,12 +1,12 @@
-.itinerary-container {
+.duffel-components .itinerary-container {
   display: flex;
 }
 
-.itinerary-top {
+.duffel-components .itinerary-top {
   position: relative;
 }
 
-.itinerary-top:before {
+.duffel-components .itinerary-top:before {
   content: "";
   position: absolute;
   left: 22px;
@@ -26,20 +26,20 @@
   background: var(--GREY-400);
 }
 
-.itinerary-top--added:before {
+.duffel-components .itinerary-top--added:before {
   background: var(--GREEN-300);
 }
 
-.itinerary-top--removed:before {
+.duffel-components .itinerary-top--removed:before {
   background: var(--RED-200);
 }
 
-.itinerary-node-container {
+.duffel-components .itinerary-node-container {
   display: flex;
   flex-direction: row;
 }
 
-.itinerary-graph-container {
+.duffel-components .itinerary-graph-container {
   display: flex;
   color: var(--grey-400);
   justify-content: center;
@@ -47,27 +47,27 @@
   width: 48px;
 }
 
-.itinerary-duration {
+.duffel-components .itinerary-duration {
   display: flex;
   flex-direction: row;
   align-items: center;
   margin-left: 64px;
 }
 
-.itinerary-node-text {
+.duffel-components .itinerary-node-text {
   display: flex;
   font-size: 16px;
   line-height: 150%;
   flex-direction: row;
 }
 
-.itinerary-node-text > span:first-child {
+.duffel-components .itinerary-node-text > span:first-child {
   font-weight: bold;
   margin-right: 16px;
   white-space: nowrap;
 }
 
-.travel-item-detail {
+.duffel-components .travel-item-detail {
   display: flex;
   margin-left: 64px;
   margin-top: 16px;
@@ -76,11 +76,11 @@
   color: var(--GREY-700);
 }
 
-.travel-item-detail > div {
+.duffel-components .travel-item-detail > div {
   margin-right: 16px;
 }
 
-.circle {
+.duffel-components .circle {
   box-sizing: content-box;
   position: relative;
   top: 4px;
@@ -93,22 +93,22 @@
   border: 1px solid var(--GREY-400);
 }
 
-.circle--added {
+.duffel-components .circle--added {
   border: 1px solid var(--GREEN-600);
 }
 
-.circle--removed {
+.duffel-components .circle--removed {
   border: 1px solid var(--RED-200);
 }
 
-.highlight {
+.duffel-components .highlight {
   position: relative;
   border-radius: 4px;
   color: var(--GREY-900);
   z-index: 1;
 }
 
-.highlight::before {
+.duffel-components .highlight::before {
   position: absolute;
   content: "";
   top: -2px;
@@ -121,14 +121,14 @@
   border-radius: 4px;
 }
 
-.highlight--green::before {
+.duffel-components .highlight--green::before {
   background-color: var(--GREEN-200);
 }
 
-.highlight--pink::before {
+.duffel-components .highlight--pink::before {
   background-color: var(--RED-200);
 }
 
-.highlight--yellow::before {
+.duffel-components .highlight--yellow::before {
   background-color: var(--YELLOW-200);
 }

--- a/src/styles/components/OfferSliceModal.css
+++ b/src/styles/components/OfferSliceModal.css
@@ -1,21 +1,21 @@
-.offer-slice-modal-title {
+.duffel-components .offer-slice-modal-title {
   color: var(--GREY-900, #161618);
   font-size: 20px;
   font-style: normal;
   font-weight: 600;
 }
 
-.offer-slice-modal-divider {
+.duffel-components .offer-slice-modal-divider {
   height: 1px;
   background: var(--GREY-200, #e2e2e8);
   border: none;
   margin: 0;
 }
 
-.offer-slice-modal-padding {
+.duffel-components .offer-slice-modal-padding {
   padding: 20px 24px;
 }
 
-.offer-slice-modal-footer {
+.duffel-components .offer-slice-modal-footer {
   padding: 8px;
 }

--- a/src/styles/components/PassengerSelect.css
+++ b/src/styles/components/PassengerSelect.css
@@ -1,11 +1,11 @@
-.passenger-selection {
+.duffel-components .passenger-selection {
   display: flex;
   flex-direction: column;
   font-family: var(--FONT-FAMILY);
   flex-grow: 1;
 }
 
-.passenger-selection__title {
+.duffel-components .passenger-selection__title {
   margin: 0;
   padding: 0 0 var(--SPACING-MD-3);
   font-size: var(--FONT-SIZES-H2);
@@ -13,7 +13,7 @@
   min-width: 360px;
 }
 
-.passenger-selection__segments {
+.duffel-components .passenger-selection__segments {
   list-style: none;
   overflow-y: auto;
   font-size: var(--FONT-SIZES-C1);
@@ -21,7 +21,7 @@
   margin: calc(var(--SPACING-XS-2) * -1);
 }
 
-.passenger-selection-passenger {
+.duffel-components .passenger-selection-passenger {
   appearance: none;
   border: none;
   background: none;
@@ -36,49 +36,49 @@
   width: 100%;
 }
 
-.passenger-selection-passenger:first-child {
+.duffel-components .passenger-selection-passenger:first-child {
   margin-top: 0;
 }
 
-.passenger-selection-passenger:hover,
-.passenger-selection-passenger:focus,
-.passenger-selection-passenger:active {
+.duffel-components .passenger-selection-passenger:hover,
+.duffel-components .passenger-selection-passenger:focus,
+.duffel-components .passenger-selection-passenger:active {
   background-color: var(
     --SECONDARY,
     rgba(var(--ACCENT), var(--ACCENT-LIGHT-100))
   );
 }
 
-.passenger-selection-passenger__identifier,
-.passenger-selection-passenger__action {
+.duffel-components .passenger-selection-passenger__identifier,
+.duffel-components .passenger-selection-passenger__action {
   line-height: 1;
 }
 
-.passenger-selection-passenger__identifier {
+.duffel-components .passenger-selection-passenger__identifier {
   flex-grow: 1;
   margin-right: var(--SPACING-LG-1);
   text-align: left;
   color: var(--GREY-900);
 }
 
-.passenger-selection-passenger__action {
+.duffel-components .passenger-selection-passenger__action {
   color: var(--GREY-600);
   margin-right: var(--SPACING-XS-2);
 }
 
-.passenger-selection-passenger__seat-designator {
+.duffel-components .passenger-selection-passenger__seat-designator {
   color: var(--GREY-900);
   font-weight: 600;
   margin-right: var(--SPACING-SM-3);
 }
 
-.passenger-selection-passenger__seat-price {
+.duffel-components .passenger-selection-passenger__seat-price {
   text-align: right;
   display: inline-block;
   width: 70px;
 }
 
-.passenger-selection-passenger--selected {
+.duffel-components .passenger-selection-passenger--selected {
   box-shadow: 4px 0px 0px 0px rgba(var(--ACCENT), var(--ACCENT-LIGHT-1000))
     inset;
   background-color: var(
@@ -87,13 +87,13 @@
   );
 }
 
-.passenger-selection-segment {
+.duffel-components .passenger-selection-segment {
   margin: var(--SPACING-LG-1) 0 0;
   padding: 0 0 var(--SPACING-LG-1);
   border-bottom: 1px solid var(--GREY-200);
   font-family: var(--FONT-FAMILY);
 }
 
-.passenger-selection-segment:first-child {
+.duffel-components .passenger-selection-segment:first-child {
   margin-top: 0;
 }

--- a/src/styles/components/PassengersLayout.css
+++ b/src/styles/components/PassengersLayout.css
@@ -1,4 +1,4 @@
-.layout {
+.duffel-components .layout {
   --LAYOUT-BOX-SHADOW: 0px 0px 0px 1px rgba(var(--BLACK), 0.05),
     0px 4px 24px rgba(var(--BLACK), 0.08);
   display: flex;
@@ -9,7 +9,7 @@
   position: relative;
 }
 
-.layout__container {
+.duffel-components .layout__container {
   display: flex;
   flex-direction: column;
   align-items: center;
@@ -19,12 +19,12 @@
   overflow: auto;
 }
 
-.layout__aside {
+.duffel-components .layout__aside {
   display: none;
   padding-top: var(--SPACING-LG-1);
 }
 
-.layout__main-content {
+.duffel-components .layout__main-content {
   width: 100%;
   height: 100%;
   display: flex;
@@ -32,7 +32,7 @@
   flex-direction: column;
 }
 
-.layout__mobile-info {
+.duffel-components .layout__mobile-info {
   align-self: center;
   position: absolute;
   bottom: 187px;
@@ -45,7 +45,7 @@
   box-shadow: var(--LAYOUT-BOX-SHADOW);
 }
 
-.layout__confirmation {
+.duffel-components .layout__confirmation {
   padding: var(--SPACING-MD-3);
   box-shadow: var(--LAYOUT-BOX-SHADOW);
   position: sticky;
@@ -54,11 +54,11 @@
 }
 
 @media screen and (min-width: 768px) {
-  .layout {
+  .duffel-components .layout {
     overflow: hidden;
   }
 
-  .layout__container {
+  .duffel-components .layout__container {
     height: auto;
     padding: 0;
     flex-direction: row;
@@ -66,12 +66,12 @@
     max-height: calc(100vh - 115px);
   }
 
-  .layout__confirmation {
+  .duffel-components .layout__confirmation {
     padding: var(--SPACING-LG-1);
     box-shadow: none;
   }
 
-  .layout__aside {
+  .duffel-components .layout__aside {
     overflow: auto;
     border-right: 1px solid var(--GREY-200);
     display: flex;
@@ -82,7 +82,7 @@
     min-width: 415px;
   }
 
-  .layout__main-content {
+  .duffel-components .layout__main-content {
     height: auto;
     align-items: center;
     overflow: auto;

--- a/src/styles/components/PlacesLookup.css
+++ b/src/styles/components/PlacesLookup.css
@@ -1,4 +1,4 @@
-.places-lookup-input {
+.duffel-components .places-lookup-input {
   width: calc(100% - 34px);
   padding: 12px 16px;
   border-radius: 4px;
@@ -6,7 +6,7 @@
   font-size: 16px;
 }
 
-.places-lookup-popover {
+.duffel-components .places-lookup-popover {
   background-color: white;
   box-shadow: 0 1px 4px rgb(59 64 86 / 100%);
   border-radius: 4px;
@@ -16,7 +16,7 @@
   flex-direction: column;
 }
 
-.places-lookup-popover__item {
+.duffel-components .places-lookup-popover__item {
   display: flex;
   align-items: center;
   justify-content: space-between;
@@ -28,13 +28,13 @@
   border-radius: 4px;
 }
 
-.places-lookup-popover-item--highlighted,
-.places-lookup-popover__item:hover,
-.places-lookup-popover__item:focus {
+.duffel-components .places-lookup-popover-item--highlighted,
+.duffel-components .places-lookup-popover__item:hover,
+.duffel-components .places-lookup-popover__item:focus {
   background-color: lightgrey;
 }
 
-.places-lookup-popover__icon-and-name-container {
+.duffel-components .places-lookup-popover__icon-and-name-container {
   column-gap: 2px;
   display: flex;
   align-items: flex-start;

--- a/src/styles/components/RadioButton.css
+++ b/src/styles/components/RadioButton.css
@@ -1,12 +1,12 @@
-.radio__input {
+.duffel-components .radio__input {
   display: none;
 }
 
-.radio__container {
+.duffel-components .radio__container {
   cursor: pointer;
 }
 
-.radio {
+.duffel-components .radio {
   display: flex;
   flex-shrink: 0;
   align-items: center;
@@ -22,10 +22,10 @@
   transition: all 0.3s var(--TRANSITIONs-CUBIC-BEZIER);
 }
 
-.radio:hover {
+.duffel-components .radio:hover {
   border-color: var(--GREY-600);
 }
 
-.radio.radio--is-checked {
+.duffel-components .radio.radio--is-checked {
   border-color: var(--GREY-900);
 }

--- a/src/styles/components/Row.css
+++ b/src/styles/components/Row.css
@@ -1,4 +1,4 @@
-.map-element--exit {
+.duffel-components .map-element--exit {
   color: var(--GREY-400);
   width: 100%;
   height: var(--SPACING-LG-3);
@@ -7,23 +7,23 @@
   align-items: center;
 }
 
-.map-element--exit--right {
+.duffel-components .map-element--exit--right {
   justify-content: flex-end;
 }
 
-.map-element--empty {
+.duffel-components .map-element--empty {
   min-width: var(--SPACING-LG-2);
   height: var(--SPACING-LG-2);
 }
 
 @media only screen and (min-width: 768px) {
-  .map-element--empty {
+  .duffel-components .map-element--empty {
     min-width: var(--SPACING-LG-3);
     height: var(--SPACING-LG-3);
   }
 }
 
-.map-section {
+.duffel-components .map-section {
   display: flex;
   justify-content: center;
   padding: var(--SPACING-XS-1) 0;
@@ -31,30 +31,30 @@
 }
 
 @media only screen and (min-width: 768px) {
-  .map-section {
+  .duffel-components .map-section {
     padding: var(--SPACING-XS-2) 0;
   }
 }
 
-.map-section--left {
+.duffel-components .map-section--left {
   border-left: 2px solid var(--GREY-200);
   padding-left: var(--SPACING-SM-3);
 }
 
-.map-section--left.map-section--wing {
+.duffel-components .map-section--left.map-section--wing {
   box-shadow: -19px 0px 0px 0px var(--GREY-200);
 }
 
-.map-section--right {
+.duffel-components .map-section--right {
   border-right: 2px solid var(--GREY-200);
   padding-right: var(--SPACING-SM-3);
 }
 
-.map-section--right.map-section--wing {
+.duffel-components .map-section--right.map-section--wing {
   box-shadow: 19px 0px 0px 0px var(--GREY-200);
 }
 
-.map-section__aisle {
+.duffel-components .map-section__aisle {
   display: flex;
   justify-content: center;
   color: var(--GREY-600);
@@ -63,7 +63,7 @@
 }
 
 @media only screen and (min-width: 768px) {
-  .map-section__aisle {
+  .duffel-components .map-section__aisle {
     font-size: var(--FONT-SIZES-C2);
     line-height: var(--SPACING-MD-3);
   }

--- a/src/styles/components/Seat.css
+++ b/src/styles/components/Seat.css
@@ -1,4 +1,4 @@
-.map-element__seat {
+.duffel-components .map-element__seat {
   appearance: none;
   outline: none;
   cursor: default;
@@ -20,14 +20,14 @@
   position: relative;
 }
 
-.map-element--available {
+.duffel-components .map-element--available {
   border: 2px solid
     var(--TERTIARY, rgba(var(--ACCENT), var(--ACCENT-LIGHT-200)));
   background-color: rgba(var(--ACCENT), var(--ACCENT-LIGHT-100));
   color: var(--TERTIARY, rgba(var(--ACCENT), var(--ACCENT-LIGHT-300)));
 }
 
-.map-element--fee-payable {
+.duffel-components .map-element--fee-payable {
   position: absolute;
   bottom: -2px;
   right: -2px;
@@ -35,23 +35,24 @@
 }
 
 @media (hover: hover) and (pointer: fine) {
-  .map-element--actionable:hover {
+  .duffel-components .map-element--actionable:hover {
     cursor: pointer;
   }
 
-  .map-element--actionable:not(.map-element--selected):hover {
+  .duffel-components
+    .map-element--actionable:not(.map-element--selected):hover {
     background-color: rgba(var(--ACCENT), var(--ACCENT-LIGHT-200));
     color: var(--SECONDARY, rgba(var(--ACCENT), var(--ACCENT-LIGHT-1000)));
     transition: var(--TRANSITIONS-CUBIC-BEZIER);
   }
 
-  .map-element--fee-payable {
+  .duffel-components .map-element--fee-payable {
     color: var(--TERTIARY, rgba(var(--ACCENT), var(--ACCENT-LIGHT-1000)));
     transition: var(--TRANSITIONS-CUBIC-BEZIER);
   }
 }
 
-.map-element--selected {
+.duffel-components .map-element--selected {
   background-color: rgba(var(--ACCENT), var(--ACCENT-LIGHT-1000));
   border: 2px solid
     var(--SECONDARY, rgba(var(--ACCENT), var(--ACCENT-LIGHT-1000)));

--- a/src/styles/components/SeatInfo.css
+++ b/src/styles/components/SeatInfo.css
@@ -1,4 +1,4 @@
-.seat-info {
+.duffel-components .seat-info {
   --INFO-CARD-MARGIN: 20px;
   background-color: rgb(var(--WHITE));
   padding: 24px;
@@ -20,7 +20,7 @@
 
 /* tablet or greater  */
 @media (min-width: 768px) {
-  .seat-info {
+  .duffel-components .seat-info {
     left: 0;
     right: 0;
     margin-left: auto;
@@ -31,7 +31,7 @@
   }
 }
 
-.seat-info__details {
+.duffel-components .seat-info__details {
   font-size: var(--FONT-SIZES-C1);
   color: var(--GREY-900);
   font-weight: normal;
@@ -40,12 +40,12 @@
   justify-content: space-between;
 }
 
-.seat-info__details > span {
+.duffel-components .seat-info__details > .duffel-components span {
   flex-grow: 1;
   margin: 0 var(--SPACING-SM-1);
 }
 
-.seat-info__disclosure {
+.duffel-components .seat-info__disclosure {
   font-size: var(--FONT-SIZES-C3);
   color: var(--GREY-600);
   line-height: 150%;
@@ -54,7 +54,10 @@
   margin-top: var(--SPACING-SM-1);
 }
 
-.seat-info__details + .seat-info__disclosure {
+.duffel-components
+  .seat-info__details
+  + .duffel-components
+  .seat-info__disclosure {
   padding-top: var(--SPACING-SM-3);
   border-top: 1px solid var(--GREY-200);
   margin-top: var(--SPACING-SM-3);

--- a/src/styles/components/SeatMap.css
+++ b/src/styles/components/SeatMap.css
@@ -1,4 +1,4 @@
-.seat-map {
+.duffel-components .seat-map {
   background-color: rgba(var(--WHITE), 1);
   padding: var(--SPACING-SM-3);
   padding-bottom: 80px; /* To account for the fixed footer */
@@ -10,12 +10,12 @@
   margin-inline: auto;
 }
 
-.seat-map__legend-container {
+.duffel-components .seat-map__legend-container {
   margin-bottom: var(--SPACING-MD-3);
   width: fit-content;
 }
 
-.seat-map__map-container {
+.duffel-components .seat-map__map-container {
   display: grid;
   grid-template-columns: repeat(var(--CABIN-AISLES), auto var(--SPACING-LG-1)) auto;
   grid-column-gap: var(--SPACING-XS-2);

--- a/src/styles/components/SeatSelect.css
+++ b/src/styles/components/SeatSelect.css
@@ -1,4 +1,4 @@
-.seat-selection {
+.duffel-components .seat-selection {
   --SEAT-SELECTION-BOX-SHADOW: 0px 0px 0px 1px rgba(var(--BLACK), 0.05),
     0px 4px 24px rgba(var(--BLACK), 0.08);
   background-color: rgb(var(--WHITE));
@@ -10,7 +10,7 @@
   position: relative;
 }
 
-.seat-selection__content {
+.duffel-components .seat-selection__content {
   display: flex;
   flex-direction: column;
   align-items: center;
@@ -20,12 +20,12 @@
   overflow: auto;
 }
 
-.seat-selection__content-child--passengers {
+.duffel-components .seat-selection__content-child--passengers {
   display: none;
   padding-top: var(--SPACING-LG-1);
 }
 
-.seat-selection__content-child--map {
+.duffel-components .seat-selection__content-child--map {
   width: 100%;
   height: 100%;
   display: flex;
@@ -33,7 +33,7 @@
   flex-direction: column;
 }
 
-.seat-selection__mobile-seat-info {
+.duffel-components .seat-selection__mobile-seat-info {
   align-self: center;
   position: absolute;
   bottom: 187px;
@@ -47,7 +47,7 @@
   box-shadow: var(--SEAT-SELECTION-BOX-SHADOW);
 }
 
-.seat-selection__confirmation {
+.duffel-components .seat-selection__confirmation {
   padding: var(--SPACING-MD-3);
   box-shadow: var(--SEAT-SELECTION-BOX-SHADOW);
   position: sticky;
@@ -56,7 +56,7 @@
 }
 
 @media screen and (min-width: 768px) {
-  .seat-selection__content {
+  .duffel-components .seat-selection__content {
     height: auto;
     padding: 0;
     flex-direction: row;
@@ -64,12 +64,12 @@
     max-height: calc(100vh - 115px);
   }
 
-  .seat-selection__confirmation {
+  .duffel-components .seat-selection__confirmation {
     padding: var(--SPACING-LG-1);
     box-shadow: none;
   }
 
-  .seat-selection__content-child--passengers {
+  .duffel-components .seat-selection__content-child--passengers {
     overflow: auto;
     border-right: 1px solid var(--GREY-200);
     display: flex;
@@ -80,11 +80,13 @@
     min-width: 415px;
   }
 
-  .seat-selection__content-child--passengers > div:not(.passenger-selection) {
+  .duffel-components
+    .seat-selection__content-child--passengers
+    > div:not(.passenger-selection) {
     margin-left: var(--SPACING-LG-1);
   }
 
-  .seat-selection__content-child--map {
+  .duffel-components .seat-selection__content-child--map {
     height: auto;
     align-items: center;
     overflow: auto;

--- a/src/styles/components/Segment.css
+++ b/src/styles/components/Segment.css
@@ -1,4 +1,4 @@
-.passenger-segment__title {
+.duffel-components .passenger-segment__title {
   color: var(--GREY-900);
   font-style: normal;
   font-size: var(--FONT-SIZES-C1);
@@ -10,7 +10,7 @@
   align-items: center;
 }
 
-.passenger-segment__chevron {
+.duffel-components .passenger-segment__chevron {
   /* We use important here because this margin can get overwritten by the icon one */
   margin: 0 var(--SPACING-SM-1) !important;
   color: var(--GREY-400);

--- a/src/styles/components/SelectionSegment.css
+++ b/src/styles/components/SelectionSegment.css
@@ -1,10 +1,10 @@
-.passenger-selection-segment {
+.duffel-components .passenger-selection-segment {
   margin: var(--SPACING-LG-1) 0 0;
   padding: 0 0 var(--SPACING-LG-1);
   border-bottom: 1px solid var(--GREY-200);
   font-family: var(--FONT-FAMILY);
 }
 
-.passenger-selection-segment:first-child {
+.duffel-components .passenger-selection-segment:first-child {
   margin-top: 0;
 }

--- a/src/styles/components/SliceCarriersTitle.css
+++ b/src/styles/components/SliceCarriersTitle.css
@@ -1,4 +1,4 @@
-.slice-carriers-title {
+.duffel-components .slice-carriers-title {
   color: var(--GREY-900, #09090a);
   font-size: 14px;
   font-style: normal;
@@ -7,7 +7,7 @@
   text-align: left;
 }
 
-.slice-carriers-title__operating-carrier {
+.duffel-components .slice-carriers-title__operating-carrier {
   color: var(--GREY-600, #71717a);
   font-size: 10px;
   font-style: normal;

--- a/src/styles/components/SliceSummary.css
+++ b/src/styles/components/SliceSummary.css
@@ -1,4 +1,4 @@
-.slice-summary {
+.duffel-components .slice-summary {
   display: grid;
   grid-template-columns: auto 1fr 20px auto;
   column-gap: 16px;
@@ -6,17 +6,17 @@
   width: 100%;
 }
 
-.slice-summary__time-and-place {
+.duffel-components .slice-summary__time-and-place {
   display: flex;
   flex-direction: column;
   align-items: start;
 }
 
-.slice-summary__time-and-place--align-end {
+.duffel-components .slice-summary__time-and-place--align-end {
   align-items: end;
 }
 
-.slice-summary__time {
+.duffel-components .slice-summary__time {
   color: var(--GREY-900, #161618);
   font-size: 14px;
   font-style: normal;
@@ -24,7 +24,7 @@
   line-height: 150%; /* 21px */
 }
 
-.slice-summary__place {
+.duffel-components .slice-summary__place {
   color: var(--GREY-500, #69696b);
   font-size: 10px;
   font-style: normal;
@@ -32,7 +32,7 @@
   line-height: 150%; /* 15px */
 }
 
-.slice-summary__duration {
+.duffel-components .slice-summary__duration {
   color: var(--GREY-500, #86868e);
   font-size: 12px;
   font-style: normal;
@@ -41,7 +41,7 @@
   text-align: center;
 }
 
-.slice-summary__stops {
+.duffel-components .slice-summary__stops {
   color: var(--GREY-900, #161618);
   font-size: 10px;
   font-style: normal;
@@ -51,33 +51,33 @@
   text-align: center;
 }
 
-.slice-summary__flight-line-container {
+.duffel-components .slice-summary__flight-line-container {
   display: grid;
   margin-block: 6px;
   column-gap: 4px;
   align-items: center;
 }
 
-.slice-summary__flight-line {
+.duffel-components .slice-summary__flight-line {
   position: relative;
 }
 
-.slice-summary__flight-line-color {
+.duffel-components .slice-summary__flight-line-color {
   height: 1px;
   background: var(--GREY-200, #ebebf0);
   /* width: calc(100% - 24px); */
 }
 
-.slice-summary__flight-line-color--full-width {
+.duffel-components .slice-summary__flight-line-color--full-width {
   width: 100%;
 }
 
-.slice-summary__plane {
+.duffel-components .slice-summary__plane {
   margin-left: -8px;
   fill: var(--GREY-400);
 }
 
-.slice-summary__flight-line-dot {
+.duffel-components .slice-summary__flight-line-dot {
   width: 6px;
   height: 6px;
   border-radius: 50%;

--- a/src/styles/components/StaysAmenities.css
+++ b/src/styles/components/StaysAmenities.css
@@ -1,4 +1,4 @@
-.amenities__text {
+.duffel-components .amenities__text {
   color: var(--GREY-700);
   font-size: 12px;
 }

--- a/src/styles/components/StaysRoomRateCard.css
+++ b/src/styles/components/StaysRoomRateCard.css
@@ -1,4 +1,4 @@
-.stays-room-rate-card__container {
+.duffel-components .stays-room-rate-card__container {
   display: flex;
   flex-direction: column;
   align-items: stretch;
@@ -11,41 +11,41 @@
   cursor: pointer;
 }
 
-.stays-room-rate-card__container:hover {
+.duffel-components .stays-room-rate-card__container:hover {
   border-color: var(--GREY-300);
   box-shadow: 0px 4px 20px rgba(0, 0, 0, 0.08);
 }
 
-.stays-room-rate-card__container--selected,
-.stays-room-rate-card__container--selected:hover {
+.duffel-components .stays-room-rate-card__container--selected,
+.duffel-components .stays-room-rate-card__container--selected:hover {
   border-color: var(--PURPLE-600);
 }
 
-.stays-room-rate-card__container--disabled,
-.stays-room-rate-card__container--disabled:hover {
+.duffel-components .stays-room-rate-card__container--disabled,
+.duffel-components .stays-room-rate-card__container--disabled:hover {
   background-color: var(--GREY-100);
   border-color: var(--GREY-100);
   box-shadow: none;
   cursor: auto;
 }
 
-.stays-room-rate-card__content {
+.duffel-components .stays-room-rate-card__content {
   padding: 20px;
   height: 100px;
 }
 
-.stays-room-rate-card__footer {
+.duffel-components .stays-room-rate-card__footer {
   display: flex;
   flex-direction: column;
   padding: 20px;
   border-radius: 0 0 8px 8px;
 }
 
-.stays-room-rate-card__icon:hover {
+.duffel-components .stays-room-rate-card__icon:hover {
   fill: var(--GREY-900);
 }
 
-.stays-room-rate-card__text--large {
+.duffel-components .stays-room-rate-card__text--large {
   color: var(--GREY-900);
   font-size: 16px;
   font-weight: 500;
@@ -53,20 +53,20 @@
   padding-top: 8px;
 }
 
-.stays-room-rate-card__text--medium {
+.duffel-components .stays-room-rate-card__text--medium {
   color: var(--GREY-900);
   font-size: 14px;
   font-weight: 500;
   text-align: left;
 }
 
-.stays-room-rate-card__text--small {
+.duffel-components .stays-room-rate-card__text--small {
   color: var(--GREY-600);
   font-size: 12px;
   text-align: left;
 }
 
-.stays-room-rate-card__item-label {
+.duffel-components .stays-room-rate-card__item-label {
   color: var(--GREY-700);
   font-size: 12px;
   text-align: left;

--- a/src/styles/components/StaysSummary.css
+++ b/src/styles/components/StaysSummary.css
@@ -1,10 +1,10 @@
-.stays-summary-container {
+.duffel-components .stays-summary-container {
   border: 1px solid var(--GREY-200);
   border-radius: 8px;
   padding: 24px;
 }
 
-.stays-summary-photo {
+.duffel-components .stays-summary-photo {
   width: 56px;
   height: 56px;
   background-color: var(--GREY-200);
@@ -17,29 +17,29 @@
   align-items: center;
 }
 
-.stays-summary-times {
+.duffel-components .stays-summary-times {
   display: grid;
   column-gap: 16px;
   grid-template-columns: 1fr 1px 1fr;
 }
 
-.stays-summary-divider {
+.duffel-components .stays-summary-divider {
   border-left: 1px solid var(--GREY-200);
   height: 100%;
 }
 
-.stays-summary-text--small {
+.duffel-components .stays-summary-text--small {
   font-size: 12px;
   color: var(--GREY-600);
 }
 
-.stays-summary-text--large {
+.duffel-components .stays-summary-text--large {
   font-size: 16px;
   font-weight: 600;
   line-height: 24px;
 }
 
-.stays-summary-stamp {
+.duffel-components .stays-summary-stamp {
   background-color: var(--GREY-100);
   color: var(--GREY-700);
   border-radius: 4px;

--- a/src/styles/components/Summary.css
+++ b/src/styles/components/Summary.css
@@ -1,4 +1,4 @@
-.summary__segment {
+.duffel-components .summary__segment {
   border-bottom: 1px solid var(--GREY-200);
   display: flex;
   align-items: center;
@@ -7,12 +7,12 @@
   padding-bottom: var(--SPACING-SM-3);
 }
 
-.summary > .passenger-segment__title {
+.duffel-components .summary > .passenger-segment__title {
   padding: 0;
   margin: 0;
 }
 
-.summary-passenger {
+.duffel-components .summary-passenger {
   color: var(--GREY-900);
   font-size: var(--FONT-SIZES-C1);
   font-weight: normal;
@@ -20,51 +20,51 @@
   padding: 0;
 }
 
-.summary__description-cost {
+.duffel-components .summary__description-cost {
   display: flex;
   justify-content: space-between;
   font-size: var(--FONT-SIZES-C1);
   margin-bottom: var(--SPACING-SM-3);
 }
 
-.summary:not(.summary--mobile) {
+.duffel-components .summary:not(.summary--mobile) {
   padding-top: 0;
   display: none;
 }
 
-.summary__actions {
+.duffel-components .summary__actions {
   display: flex;
 }
 
-.summary__actions--previous {
+.duffel-components .summary__actions--previous {
   transform: rotate(180deg);
 }
 
-.summary__actions > button:last-of-type {
+.duffel-components .summary__actions > button:last-of-type {
   flex: 1 auto;
   justify-content: center;
   margin-left: var(--SPACING-SM-3);
 }
 
 @media screen and (min-width: 768px) {
-  .summary:not(.summary--mobile) {
+  .duffel-components .summary:not(.summary--mobile) {
     display: flex;
     justify-content: space-between;
     align-items: center;
   }
 
-  .summary--mobile {
+  .duffel-components .summary--mobile {
     display: none;
   }
 
-  .summary__description-title {
+  .duffel-components .summary__description-title {
     color: var(--GREY-900);
     font-size: var(--FONT-SIZES-H5);
     line-height: 26px;
     margin-bottom: var(--SPACING-XS-2);
   }
 
-  .summary__confirmation-btn:last-child {
+  .duffel-components .summary__confirmation-btn:last-child {
     margin-left: var(--SPACING-SM-1);
   }
 }

--- a/src/styles/components/Tabs.css
+++ b/src/styles/components/Tabs.css
@@ -1,4 +1,4 @@
-.seat-map__tab-select {
+.duffel-components .seat-map__tab-select {
   width: 100%;
   max-width: 400px;
   display: flex;
@@ -10,7 +10,7 @@
   background-color: var(--GREY-200);
 }
 
-.seat-map__tab-select-option {
+.duffel-components .seat-map__tab-select-option {
   appearance: none;
   outline: none;
   margin: 0;
@@ -25,9 +25,9 @@
   border-radius: 3px;
 }
 
-.seat-map__tab-select-option:hover,
-.seat-map__tab-select-option:focus,
-.seat-map__tab-select-option:active {
+.duffel-components .seat-map__tab-select-option:hover,
+.duffel-components .seat-map__tab-select-option:focus,
+.duffel-components .seat-map__tab-select-option:active {
   color: var(--SECONDARY, rgba(var(--ACCENT), var(--ACCENT-LIGHT-1000)));
   background-color: var(
     --TERTIARY,
@@ -36,7 +36,7 @@
   transition: var(--TRANSITIONS-CUBIC-BEZIER);
 }
 
-.seat-map__tab-select-option--selected {
+.duffel-components .seat-map__tab-select-option--selected {
   color: var(--GREY-900);
   background-color: rgba(var(--WHITE), 1);
   box-shadow:
@@ -44,10 +44,10 @@
     0px 2px 12px rgba(var(--BLACK), 0.08);
 }
 
-.seat-map__tab-select-option:first-child {
+.duffel-components .seat-map__tab-select-option:first-child {
   margin-right: 1px;
 }
 
-.seat-map__tab-select-option:last-child {
+.duffel-components .seat-map__tab-select-option:last-child {
   margin-left: 1px;
 }

--- a/src/styles/components/TimeRangeSelector.css
+++ b/src/styles/components/TimeRangeSelector.css
@@ -1,19 +1,19 @@
 @import "rc-slider/assets/index.css";
 
-.rc-slider-handle {
+.duffel-components .rc-slider-handle {
   border-color: black !important;
   opacity: 1 !important;
 }
 
-.rc-slider-handle:focus,
-.rc-slider-handle-dragging {
+.duffel-components .rc-slider-handle:focus,
+.duffel-components .rc-slider-handle-dragging {
   box-shadow: 0 0 0 3px lightgrey !important;
 }
 
-.rc-slider-track {
+.duffel-components .rc-slider-track {
   background-color: black !important;
 }
 
-.rc-slider-dot-active {
+.duffel-components .rc-slider-dot-active {
   border-color: black !important;
 }

--- a/src/styles/flex.css
+++ b/src/styles/flex.css
@@ -1,4 +1,4 @@
-.flex--space-between {
+.duffel-components .flex--space-between {
   display: flex;
   justify-content: space-between;
   align-items: center;

--- a/src/styles/font-families.css
+++ b/src/styles/font-families.css
@@ -1,4 +1,4 @@
-.p1--semibold {
+.duffel-components .p1--semibold {
   font-family: var(--FONT-FAMILY);
   font-size: 16px;
   font-weight: 600;
@@ -6,7 +6,7 @@
   letter-spacing: 0em;
 }
 
-.p1--regular {
+.duffel-components .p1--regular {
   font-family: var(--FONT-FAMILY);
   font-size: 16px;
   font-weight: 400;
@@ -14,7 +14,7 @@
   letter-spacing: 0em;
 }
 
-.p2--regular {
+.duffel-components .p2--regular {
   font-family: var(--FONT-FAMILY);
   font-size: 14px;
   font-weight: 400;
@@ -22,7 +22,7 @@
   letter-spacing: 0em;
 }
 
-.p2--semibold {
+.duffel-components .p2--semibold {
   font-family: var(--FONT-FAMILY);
   font-size: 14px;
   font-weight: 600;
@@ -30,7 +30,7 @@
   letter-spacing: 0em;
 }
 
-.p3--regular {
+.duffel-components .p3--regular {
   font-family: var(--FONT-FAMILY);
   font-size: 12px;
   font-weight: 400;
@@ -38,7 +38,7 @@
   letter-spacing: 0em;
 }
 
-.h3--semibold {
+.duffel-components .h3--semibold {
   font-family: var(--FONT-FAMILY);
   font-size: 20px;
   font-weight: 600;

--- a/src/styles/margin.css
+++ b/src/styles/margin.css
@@ -1,3 +1,3 @@
-.margin-0 {
+.duffel-components .margin-0 {
   margin: 0;
 }

--- a/src/styles/utilities.css
+++ b/src/styles/utilities.css
@@ -1,108 +1,108 @@
 /* VSPACE */
-.v-space {
+.duffel-components .v-space {
   display: flex;
   flex-direction: column;
 }
 
-.v-space--0 {
+.duffel-components .v-space--0 {
   row-gap: 0;
 }
 
-.v-space--4 {
+.duffel-components .v-space--4 {
   row-gap: 4px;
 }
 
-.v-space--8 {
+.duffel-components .v-space--8 {
   row-gap: 8px;
 }
 
-.v-space--12 {
+.duffel-components .v-space--12 {
   row-gap: 12px;
 }
 
-.v-space--16 {
+.duffel-components .v-space--16 {
   row-gap: 16px;
 }
 
-.v-space--24 {
+.duffel-components .v-space--24 {
   row-gap: 24px;
 }
 
 /* HSPACE */
-.h-space {
+.duffel-components .h-space {
   display: flex;
   flex-direction: row;
   align-items: center;
 }
 
-.h-space--0 {
+.duffel-components .h-space--0 {
   column-gap: 0;
 }
 
-.h-space--4 {
+.duffel-components .h-space--4 {
   column-gap: 4px;
 }
 
-.h-space--8 {
+.duffel-components .h-space--8 {
   column-gap: 8px;
 }
 
-.h-space--12 {
+.duffel-components .h-space--12 {
   column-gap: 12px;
 }
 
-.h-space--16 {
+.duffel-components .h-space--16 {
   column-gap: 16px;
 }
 
-.hspace--align-center {
+.duffel-components .hspace--align-center {
   align-items: center;
 }
 
-.hspace--space-between {
+.duffel-components .hspace--space-between {
   justify-content: space-between;
 }
 
-.hspace--justify-end {
+.duffel-components .hspace--justify-end {
   justify-content: end;
 }
 
-.hspace--justify-center {
+.duffel-components .hspace--justify-center {
   justify-content: center !important;
 }
 
 /* PADDING */
-.padding-8 {
+.duffel-components .padding-8 {
   padding: 8px;
 }
 
-.padding-12 {
+.duffel-components .padding-12 {
   padding: 12px;
 }
 
-.padding-inline-8 {
+.duffel-components .padding-inline-8 {
   padding-inline: 8px !important;
 }
 
 /* MARGIN */
-.margin-t-8 {
+.duffel-components .margin-t-8 {
   margin-top: 8px;
 }
 
-.margin-b-12 {
+.duffel-components .margin-b-12 {
   margin-bottom: 12px;
 }
 
-.margin-x-12 {
+.duffel-components .margin-x-12 {
   margin-inline: 12px;
 }
 
 /* TEXT */
-.font-size-14 {
+.duffel-components .font-size-14 {
   font-size: 14px;
 }
 
 /* WIDTH */
-.width-100 {
+.duffel-components .width-100 {
   width: 100%;
 }


### PR DESCRIPTION
We use global styles, so they conflict with integrator styles sometimes. This PR prevents that from happening again, it scopes every css selector we have to be a child of the class `duffel-components`.  


https://github.com/user-attachments/assets/2dcb45d4-84fe-4c2b-8306-95e95b381cf4


https://github.com/user-attachments/assets/f8be72ec-9b80-472c-b505-99e9439f265b

