### PR TITLE
Add years to dashboard stay summary dates

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -23,10 +23,10 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Check out repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5
 
       - name: Set up Node.js
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020
         with:
           node-version-file: .nvmrc
           cache: yarn
@@ -52,10 +52,10 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Check out repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5
 
       - name: Set up Node.js
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020
         with:
           node-version-file: .nvmrc
           cache: yarn
@@ -75,10 +75,10 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Check out repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5
 
       - name: Set up Node.js
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020
         with:
           node-version-file: .nvmrc
           cache: yarn

--- a/src/components/Stays/StaysSummary.tsx
+++ b/src/components/Stays/StaysSummary.tsx
@@ -89,7 +89,7 @@ export const StaysSummary: React.FC<
           <div>
             <p className="stays-summary-text--small">Check in</p>
             <p className="stays-summary-text--large">
-              {getDateString(checkInDate, "longNoYear").replace(",", "")}
+              {getDateString(checkInDate, "long").replace(",", "")}
             </p>
             {accommodation.check_in_information && (
               <p className="stays-summary-text--small">
@@ -101,7 +101,7 @@ export const StaysSummary: React.FC<
           <div>
             <p className="stays-summary-text--small">Check out</p>
             <p className="stays-summary-text--large">
-              {getDateString(checkOutDate, "longNoYear").replace(",", "")}
+              {getDateString(checkOutDate, "long").replace(",", "")}
             </p>
             {accommodation.check_in_information && (
               <p className="stays-summary-text--small">

--- a/src/tests/components/StaysSummary.test.tsx
+++ b/src/tests/components/StaysSummary.test.tsx
@@ -1,0 +1,22 @@
+import { render, screen } from "@testing-library/react";
+import { StaysAccommodation } from "@duffel/api/types";
+import { StaysSummary } from "../../components/Stays/StaysSummary";
+
+/* eslint-disable @typescript-eslint/no-var-requires */
+const accommodation: StaysAccommodation = require("../../fixtures/accommodation/acc_0000AWr2VsUNIF1Vl91xg0.json");
+/* eslint-enable @typescript-eslint/no-var-requires */
+
+describe("StaysSummary", () => {
+  test("shows years for check-in and check-out dates", () => {
+    render(
+      <StaysSummary
+        accommodation={accommodation}
+        checkInDate={new Date("2023-04-28")}
+        checkOutDate={new Date("2023-05-04")}
+      />,
+    );
+
+    expect(screen.getByText("Fri 28 Apr 2023")).toBeTruthy();
+    expect(screen.getByText("Thu 4 May 2023")).toBeTruthy();
+  });
+});


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary
- update the stays summary check-in and check-out labels to use the long date format with the year included
- add a focused component test covering the rendered check-in and check-out strings
- pin GitHub Actions used by the CI workflow to full commit SHAs so checks can start under the repository policy

## Testing
- `yarn test src/tests/components/StaysSummary.test.tsx --runInBand`
- `yarn check-types`
- `yarn prettier-check .github/workflows/ci.yml`
- `yarn eslint src/components/Stays/StaysSummary.tsx src/tests/components/StaysSummary.test.tsx`

## Post-merge rollout
1. Manually publish a new `@duffel/components` release.
   - `3.13.1` is already the live npm version, so the release flow needs a version bump first (for example, the next patch version) before publishing.
   - The publish script in this repo is `yarn build-and-publish`.
2. Once that new version is live, upgrade `@duffel/components` in both dashboards.
   - Update the dependency to the released version.
   - Refresh the lockfile.
   - Verify the stays summary check-in / check-out dates show the year.
3. Suggested Cursor prompt for each dashboard repo after publish:
   - `Upgrade @duffel/components to <released-version>, update the lockfile, verify the stay summary check-in and check-out dates now include the year, run the relevant tests/build, and open a PR.`
<!-- CURSOR_AGENT_PR_BODY_END -->

[Slack Thread](https://duffel.slack.com/archives/C06E7PV0UMV/p1776677857196659?thread_ts=1776677857.196659&cid=C06E7PV0UMV)

<div><a href="https://cursor.com/agents/bc-73dbb412-e938-5068-be64-25e84f0c7c91"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-73dbb412-e938-5068-be64-25e84f0c7c91"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

