### PR TITLE
Update React and React-DOM to be peer dependencies supporting versions 18 and 19

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@duffel/components",
-  "version": "3.15.0",
+  "version": "3.16.0",
   "description": "Component library to build your travel product with Duffel.",
   "keywords": [
     "Duffel",

--- a/package.json
+++ b/package.json
@@ -62,9 +62,11 @@
     "form-data": "4.0.5",
     "fuse.js": "6.6.2",
     "lodash": "4.18.1",
-    "rc-slider": "10.6.2",
-    "react": "18.3.1",
-    "react-dom": "18.3.1"
+    "rc-slider": "10.6.2"
+  },
+  "peerDependencies": {
+    "react": "^18.0.0 || ^19.0.0",
+    "react-dom": "^18.0.0 || ^19.0.0"
   },
   "devDependencies": {
     "@aashutoshrathi/word-wrap": "1.2.6",
@@ -113,6 +115,8 @@
     "prompts": "2.4.2",
     "prop-types": "15.8.1",
     "puppeteer": "22.15.0",
+    "react": "19.2.5",
+    "react-dom": "19.2.5",
     "storybook": "8.3.5",
     "ts-node": "10.9.2",
     "tsconfig-paths-webpack-plugin": "4.0.1",

--- a/yarn.lock
+++ b/yarn.lock
@@ -1908,12 +1908,15 @@ __metadata:
     prop-types: "npm:15.8.1"
     puppeteer: "npm:22.15.0"
     rc-slider: "npm:10.6.2"
-    react: "npm:18.3.1"
-    react-dom: "npm:18.3.1"
+    react: "npm:19.2.5"
+    react-dom: "npm:19.2.5"
     storybook: "npm:8.3.5"
     ts-node: "npm:10.9.2"
     tsconfig-paths-webpack-plugin: "npm:4.0.1"
     typescript: "npm:5.2.2"
+  peerDependencies:
+    react: ^18.0.0 || ^19.0.0
+    react-dom: ^18.0.0 || ^19.0.0
   languageName: unknown
   linkType: soft
 
@@ -11447,7 +11450,18 @@ __metadata:
   languageName: node
   linkType: hard
 
-"react-dom@npm:18.3.1, react-dom@npm:^16.8.0 || ^17.0.0 || ^18.0.0":
+"react-dom@npm:19.2.5":
+  version: 19.2.5
+  resolution: "react-dom@npm:19.2.5"
+  dependencies:
+    scheduler: "npm:^0.27.0"
+  peerDependencies:
+    react: ^19.2.5
+  checksum: 10c0/8067606e9f58e4c2e8cb5f09570217dbc71c4843ebcaa20ae2085912d3e3a351f17d8f7c1713313cdda7f272840c8c34ff6c860fcb840862071bceea218e0c63
+  languageName: node
+  linkType: hard
+
+"react-dom@npm:^16.8.0 || ^17.0.0 || ^18.0.0":
   version: 18.3.1
   resolution: "react-dom@npm:18.3.1"
   dependencies:
@@ -11508,7 +11522,14 @@ __metadata:
   languageName: node
   linkType: hard
 
-"react@npm:18.3.1, react@npm:^16.8.0 || ^17.0.0 || ^18.0.0":
+"react@npm:19.2.5":
+  version: 19.2.5
+  resolution: "react@npm:19.2.5"
+  checksum: 10c0/4b5f231dbef92886f602533c9ce3bde04d99f0e71dfb5d794c43e02726efaad0421c08688f75fc98a6d6e1dc017372e1af7abbfecdc86a79968f461675931a7a
+  languageName: node
+  linkType: hard
+
+"react@npm:^16.8.0 || ^17.0.0 || ^18.0.0":
   version: 18.3.1
   resolution: "react@npm:18.3.1"
   dependencies:
@@ -11949,6 +11970,13 @@ __metadata:
   dependencies:
     loose-envify: "npm:^1.1.0"
   checksum: 10c0/26383305e249651d4c58e6705d5f8425f153211aef95f15161c151f7b8de885f24751b377e4a0b3dd42cce09aad3f87a61dab7636859c0d89b7daf1a1e2a5c78
+  languageName: node
+  linkType: hard
+
+"scheduler@npm:^0.27.0":
+  version: 0.27.0
+  resolution: "scheduler@npm:0.27.0"
+  checksum: 10c0/4f03048cb05a3c8fddc45813052251eca00688f413a3cee236d984a161da28db28ba71bd11e7a3dd02f7af84ab28d39fb311431d3b3772fed557945beb00c452
   languageName: node
   linkType: hard
 


### PR DESCRIPTION

- Updated peer dependencies for React and React-DOM in package.json and yarn.lock to allow compatibility with both version 18 and 19.
- Removed specific version entries for React and React-DOM from dependencies to streamline version management.

both build are still working as expected:


https://github.com/user-attachments/assets/46cd6c6f-b122-478b-999d-dc5a03c619b5


https://github.com/user-attachments/assets/eb38b684-7969-48b6-8e37-8917814ceb9a

