### PR TITLE
TSP-1776 Document component CSP requirements

### DIFF
--- a/README.md
+++ b/README.md
@@ -146,6 +146,11 @@ More guides are coming soon.
 If your application uses a Content Security Policy (CSP), merge the following
 sources into your existing directives.
 
+In production, applications that load any Duffel Components bundle using the
+CDN `<script>` tag documented above must also include
+`https://assets.duffel.com` in `script-src`. This requirement is independent of
+the Evervault sandbox requirements below.
+
 #### `createThreeDSecureSession`
 
 | Directive     | Sources                                                                              | Purpose                                                 |

--- a/README.md
+++ b/README.md
@@ -162,6 +162,20 @@ sources into your existing directives.
 | `img-src`   | `'self' https://assets.duffel.com` |
 | `style-src` | `'self' 'unsafe-inline'`           |
 
+#### Evervault sandbox
+
+When testing 3DS flows with Evervault's sandbox, also merge these sources into
+your existing directives.
+
+| Directive     | Sources                                                                                                                                  |
+| ------------- | ---------------------------------------------------------------------------------------------------------------------------------------- |
+| `img-src`     | `https://sandbox-acs.evervault.com`                                                                                                      |
+| `script-src`  | `https://sandbox-acs.evervault.com https://js.evervault.com https://ui-components.evervault.com https://assets.duffel.com`               |
+| `style-src`   | `https://sandbox-acs.evervault.com https://ui-components.evervault.com https://assets.duffel.com`                                        |
+| `font-src`    | `https://sandbox-acs.evervault.com`                                                                                                      |
+| `frame-src`   | `https://sandbox-acs.evervault.com https://ui-components.evervault.com https://3ds-trampoline.evervault.app`                             |
+| `connect-src` | `https://sandbox-acs.evervault.com https://api.evervault.com https://keys.evervault.com https://api.duffel.com https://api.duffel.cards` |
+
 ### Is there a runnable example?
 
 Yes. The `example` folder contains the repository's single runnable example. It

--- a/README.md
+++ b/README.md
@@ -148,19 +148,19 @@ sources into your existing directives.
 
 #### `createThreeDSecureSession`
 
-| Directive     | Sources                                                                                     |
-| ------------- | ------------------------------------------------------------------------------------------- |
-| `script-src`  | `'self' https://js.evervault.com`                                                           |
-| `connect-src` | `'self' https://api.duffel.com https://keys.evervault.com https://api.evervault.com`        |
-| `frame-src`   | `https://ui-components.evervault.com`                                                       |
+| Directive     | Sources                                                                              |
+| ------------- | ------------------------------------------------------------------------------------ |
+| `script-src`  | `'self' https://js.evervault.com`                                                    |
+| `connect-src` | `'self' https://api.duffel.com https://keys.evervault.com https://api.evervault.com` |
+| `frame-src`   | `https://ui-components.evervault.com`                                                |
 
 #### `DuffelCardForm`
 
-| Directive   | Sources                                        |
-| ----------- | ---------------------------------------------- |
-| `frame-src` | `https://api.duffel.cards`                     |
-| `img-src`   | `'self' https://assets.duffel.com`             |
-| `style-src` | `'self' 'unsafe-inline'`                       |
+| Directive   | Sources                            |
+| ----------- | ---------------------------------- |
+| `frame-src` | `https://api.duffel.cards`         |
+| `img-src`   | `'self' https://assets.duffel.com` |
+| `style-src` | `'self' 'unsafe-inline'`           |
 
 ### Is there a runnable example?
 

--- a/README.md
+++ b/README.md
@@ -148,33 +148,33 @@ sources into your existing directives.
 
 #### `createThreeDSecureSession`
 
-| Directive     | Sources                                                                              |
-| ------------- | ------------------------------------------------------------------------------------ |
-| `script-src`  | `'self' https://js.evervault.com`                                                    |
-| `connect-src` | `'self' https://api.duffel.com https://keys.evervault.com https://api.evervault.com` |
-| `frame-src`   | `https://ui-components.evervault.com`                                                |
+| Directive     | Sources                                                                              | Purpose                                                 |
+| ------------- | ------------------------------------------------------------------------------------ | ------------------------------------------------------- |
+| `script-src`  | `'self' https://js.evervault.com`                                                    | Loads Evervault's browser SDK for the 3DS challenge.    |
+| `connect-src` | `'self' https://api.duffel.com https://keys.evervault.com https://api.evervault.com` | Allows Duffel 3DS API calls and Evervault SDK requests. |
+| `frame-src`   | `https://ui-components.evervault.com`                                                | Embeds Evervault's 3DS challenge UI.                    |
 
 #### `DuffelCardForm`
 
-| Directive   | Sources                            |
-| ----------- | ---------------------------------- |
-| `frame-src` | `https://api.duffel.cards`         |
-| `img-src`   | `'self' https://assets.duffel.com` |
-| `style-src` | `'self' 'unsafe-inline'`           |
+| Directive   | Sources                            | Purpose                                               |
+| ----------- | ---------------------------------- | ----------------------------------------------------- |
+| `frame-src` | `https://api.duffel.cards`         | Embeds the Duffel card form.                          |
+| `img-src`   | `'self' https://assets.duffel.com` | Loads the card form's hosted loading spinner.         |
+| `style-src` | `'self' 'unsafe-inline'`           | Allows the component's React inline style attributes. |
 
 #### Evervault sandbox
 
 When testing 3DS flows with Evervault's sandbox, also merge these sources into
 your existing directives.
 
-| Directive     | Sources                                                                                                                                  |
-| ------------- | ---------------------------------------------------------------------------------------------------------------------------------------- |
-| `img-src`     | `https://sandbox-acs.evervault.com`                                                                                                      |
-| `script-src`  | `https://sandbox-acs.evervault.com https://js.evervault.com https://ui-components.evervault.com https://assets.duffel.com`               |
-| `style-src`   | `https://sandbox-acs.evervault.com https://ui-components.evervault.com https://assets.duffel.com`                                        |
-| `font-src`    | `https://sandbox-acs.evervault.com`                                                                                                      |
-| `frame-src`   | `https://sandbox-acs.evervault.com https://ui-components.evervault.com https://3ds-trampoline.evervault.app`                             |
-| `connect-src` | `https://sandbox-acs.evervault.com https://api.evervault.com https://keys.evervault.com https://api.duffel.com https://api.duffel.cards` |
+| Directive     | Sources                                                                                                                                  | Purpose                                                |
+| ------------- | ---------------------------------------------------------------------------------------------------------------------------------------- | ------------------------------------------------------ |
+| `img-src`     | `https://sandbox-acs.evervault.com`                                                                                                      | Loads sandbox ACS challenge images.                    |
+| `script-src`  | `https://sandbox-acs.evervault.com https://js.evervault.com https://ui-components.evervault.com https://assets.duffel.com`               | Runs scripts required by sandbox 3DS flows.            |
+| `style-src`   | `https://sandbox-acs.evervault.com https://ui-components.evervault.com https://assets.duffel.com`                                        | Loads styles required by sandbox 3DS flows.            |
+| `font-src`    | `https://sandbox-acs.evervault.com`                                                                                                      | Loads sandbox ACS challenge fonts.                     |
+| `frame-src`   | `https://sandbox-acs.evervault.com https://ui-components.evervault.com https://3ds-trampoline.evervault.app`                             | Embeds sandbox ACS and Evervault 3DS challenge frames. |
+| `connect-src` | `https://sandbox-acs.evervault.com https://api.evervault.com https://keys.evervault.com https://api.duffel.com https://api.duffel.cards` | Allows sandbox 3DS and API requests.                   |
 
 ### Is there a runnable example?
 

--- a/README.md
+++ b/README.md
@@ -156,11 +156,11 @@ sources into your existing directives.
 
 #### `DuffelCardForm`
 
-| Directive   | Sources                            | Purpose                                               |
-| ----------- | ---------------------------------- | ----------------------------------------------------- |
-| `frame-src` | `https://api.duffel.cards`         | Embeds the Duffel card form.                          |
-| `img-src`   | `'self' https://assets.duffel.com` | Loads the card form's hosted loading spinner.         |
-| `style-src` | `'self' 'unsafe-inline'`           | Allows the component's React inline style attributes. |
+| Directive        | Sources                            | Purpose                                               |
+| ---------------- | ---------------------------------- | ----------------------------------------------------- |
+| `frame-src`      | `https://api.duffel.cards`         | Embeds the Duffel card form.                          |
+| `img-src`        | `'self' https://assets.duffel.com` | Loads the card form's hosted loading spinner.         |
+| `style-src-attr` | `'unsafe-inline'`                  | Allows the component's React inline style attributes. |
 
 #### Evervault sandbox
 

--- a/README.md
+++ b/README.md
@@ -141,6 +141,27 @@ If you are not in a node environment and can't rely on npm to install the packag
 
 More guides are coming soon.
 
+### Which Content Security Policy directives are required?
+
+If your application uses a Content Security Policy (CSP), merge the following
+sources into your existing directives.
+
+#### `createThreeDSecureSession`
+
+| Directive     | Sources                                                                                     |
+| ------------- | ------------------------------------------------------------------------------------------- |
+| `script-src`  | `'self' https://js.evervault.com`                                                           |
+| `connect-src` | `'self' https://api.duffel.com https://keys.evervault.com https://api.evervault.com`        |
+| `frame-src`   | `https://ui-components.evervault.com`                                                       |
+
+#### `DuffelCardForm`
+
+| Directive   | Sources                                        |
+| ----------- | ---------------------------------------------- |
+| `frame-src` | `https://api.duffel.cards`                     |
+| `img-src`   | `'self' https://assets.duffel.com`             |
+| `style-src` | `'self' 'unsafe-inline'`                       |
+
 ### Is there a runnable example?
 
 Yes. The `example` folder contains the repository's single runnable example. It


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

- document the CSP directives required by `createThreeDSecureSession`
- document the CSP directives required by `DuffelCardForm`
- use `style-src-attr` to scope the card form's inline-style permission to style attributes
- document the production `script-src` requirement for CDN-hosted component bundles
- document the additional CSP sources used by Evervault sandbox 3DS flows
- explain why each CSP directive is required
- clarify that the listed sources should be merged into an application's existing policy

## Testing

- `npx --yes prettier@3.2.5 --check README.md`
- `git diff --check origin/main...HEAD`
<!-- CURSOR_AGENT_PR_BODY_END -->

[Slack Thread](https://duffel.slack.com/archives/C05MFDJ4KH9/p1785742803564869?thread_ts=1785742803.564869&cid=C05MFDJ4KH9)

<div><a href="https://cursor.com/agents/bc-b7012bdb-bb62-534a-b3d0-b341162df8bc?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-b7012bdb-bb62-534a-b3d0-b341162df8bc&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

